### PR TITLE
feat: add tool-spec registry and openai provider support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ base64 = "0.22"
 # Directory utilities
 dirs = "5"
 
+# Config parsing
+toml = "0.8"
+
 # Web framework (server only)
 axum = { version = "0.7", features = ["ws"] }
 tower = "0.4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,5 +26,6 @@ reqwest = { workspace = true }
 dirs = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+toml = { workspace = true }
 
 # NO Tauri dependencies - platform-agnostic!

--- a/core/src/ai/mod.rs
+++ b/core/src/ai/mod.rs
@@ -1,5 +1,7 @@
 mod provider;
 mod anthropic;
+mod openai;
 
 pub use provider::AIProvider;
 pub use anthropic::AnthropicProvider;
+pub use openai::OpenAIProvider;

--- a/core/src/ai/openai.rs
+++ b/core/src/ai/openai.rs
@@ -1,0 +1,84 @@
+use super::AIProvider;
+use async_trait::async_trait;
+use reprod_protocol::ChatMessage;
+use reprod_common::ReprodError;
+use reqwest::Client;
+use serde_json::json;
+
+pub struct OpenAIProvider {
+    api_key: Option<String>,
+    base_url: String,
+    model: String,
+    client: Client,
+}
+
+impl OpenAIProvider {
+    pub fn new(api_key: Option<String>) -> Self {
+        Self {
+            api_key,
+            base_url: "https://api.openai.com/v1/chat/completions".to_string(),
+            model: "gpt-4o".to_string(),
+            client: Client::new(),
+        }
+    }
+
+    pub fn from_env() -> Self {
+        let api_key = std::env::var("OPENAI_API_KEY").ok();
+        Self::new(api_key)
+    }
+
+    pub fn with_model(mut self, model: String) -> Self {
+        self.model = model;
+        self
+    }
+}
+
+#[async_trait]
+impl AIProvider for OpenAIProvider {
+    async fn send_message(&self, messages: Vec<ChatMessage>) -> Result<String, ReprodError> {
+        let api_key = self.api_key.as_ref()
+            .ok_or_else(|| ReprodError::AIError("OpenAI API key not configured".to_string()))?;
+
+        let response = self.client
+            .post(&self.base_url)
+            .header("Authorization", format!("Bearer {}", api_key))
+            .header("Content-Type", "application/json")
+            .json(&json!({
+                "model": self.model,
+                "messages": messages,
+                "max_tokens": 4096,
+                "temperature": 0.7,
+            }))
+            .timeout(std::time::Duration::from_secs(120))
+            .send()
+            .await
+            .map_err(|e| ReprodError::AIError(format!("Request failed: {}", e)))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response.text().await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(ReprodError::AIError(format!(
+                "OpenAI API error ({}): {}",
+                status,
+                error_text
+            )));
+        }
+
+        let data: serde_json::Value = response.json().await
+            .map_err(|e| ReprodError::AIError(format!("Invalid response: {}", e)))?;
+
+        data["choices"][0]["message"]["content"]
+            .as_str()
+            .ok_or_else(|| ReprodError::AIError("Missing content in response".to_string()))
+            .map(|s| s.to_string())
+    }
+
+    fn name(&self) -> &str {
+        "OpenAI"
+    }
+
+    fn is_configured(&self) -> bool {
+        self.api_key.is_some()
+    }
+}

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -6,6 +6,13 @@ use std::path::PathBuf;
 pub struct Config {
     pub r_path: String,
     pub anthropic_api_key: Option<String>,
+    pub openai_api_key: Option<String>,
+    #[serde(default = "default_ai_provider")]
+    pub default_ai_provider: String,
+}
+
+fn default_ai_provider() -> String {
+    "openai".to_string()
 }
 
 impl Config {
@@ -49,6 +56,8 @@ impl Default for Config {
         Self {
             r_path: "/usr/local/bin/R".to_string(),
             anthropic_api_key: std::env::var("ANTHROPIC_API_KEY").ok(),
+            openai_api_key: std::env::var("OPENAI_API_KEY").ok(),
+            default_ai_provider: default_ai_provider(),
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod executor;
 pub mod ai;
 pub mod config;
+pub mod tools;
 
 pub use executor::RExecutor;
 pub use ai::{AIProvider, AnthropicProvider};
 pub use config::Config;
+pub use tools::*;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,6 @@ pub mod config;
 pub mod tools;
 
 pub use executor::RExecutor;
-pub use ai::{AIProvider, AnthropicProvider};
+pub use ai::{AIProvider, AnthropicProvider, OpenAIProvider};
 pub use config::Config;
 pub use tools::*;

--- a/core/src/tools/executor.rs
+++ b/core/src/tools/executor.rs
@@ -1,0 +1,206 @@
+use anyhow::{anyhow, Context, Result};
+use std::collections::HashMap;
+use std::time::Instant;
+use serde_json::Value;
+
+use super::{CapabilityDescriptor, CapabilityKind, ToolManifest, ToolRegistry};
+use crate::RExecutor;
+
+/// Artifact generated during tool execution
+#[derive(Debug, Clone)]
+pub struct Artifact {
+    pub path: String,
+    pub artifact_type: String,
+    pub label: Option<String>,
+    pub record_as: String,
+}
+
+/// Result of tool execution
+#[derive(Debug)]
+pub struct ToolExecutionResult {
+    pub tool_id: String,
+    pub capability_id: String,
+    pub success: bool,
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+    pub artifacts: Vec<Artifact>,
+    pub execution_time_ms: u64,
+    pub error: Option<String>,
+}
+
+/// Executes tool capabilities using the appropriate runtime
+pub struct ToolExecutor {
+    registry: std::sync::Arc<ToolRegistry>,
+}
+
+impl ToolExecutor {
+    pub fn new(registry: std::sync::Arc<ToolRegistry>) -> Self {
+        Self { registry }
+    }
+
+    /// Execute a tool capability with the given parameters
+    pub async fn execute(
+        &self,
+        tool_id: &str,
+        capability_id: &str,
+        parameters: HashMap<String, Value>,
+        r_executor: &mut RExecutor,
+    ) -> Result<ToolExecutionResult> {
+        let start_time = Instant::now();
+
+        // Look up the capability
+        let (manifest, capability) = self
+            .registry
+            .capability(capability_id)
+            .ok_or_else(|| anyhow!("Capability {} not found", capability_id))?;
+
+        // Verify tool_id matches
+        if manifest.id != tool_id {
+            return Err(anyhow!(
+                "Tool ID mismatch: expected {}, got {}",
+                manifest.id,
+                tool_id
+            ));
+        }
+
+        // Execute based on capability kind
+        let result = match capability.kind {
+            CapabilityKind::RFunction | CapabilityKind::RSnippet => {
+                self.execute_r_capability(manifest, capability, parameters, r_executor)
+                    .await?
+            }
+            CapabilityKind::CliCommand => {
+                self.execute_cli_capability(manifest, capability, parameters)
+                    .await?
+            }
+        };
+
+        let execution_time_ms = start_time.elapsed().as_millis() as u64;
+
+        Ok(ToolExecutionResult {
+            tool_id: tool_id.to_string(),
+            capability_id: capability_id.to_string(),
+            execution_time_ms,
+            ..result
+        })
+    }
+
+    async fn execute_r_capability(
+        &self,
+        _manifest: &ToolManifest,
+        capability: &CapabilityDescriptor,
+        parameters: HashMap<String, Value>,
+        r_executor: &mut RExecutor,
+    ) -> Result<ToolExecutionResult> {
+        // Generate R code from template
+        let code = self.render_template(&capability.template, &parameters)?;
+
+        // Execute via RExecutor
+        let exec_result = r_executor
+            .execute(code)
+            .await
+            .context("R execution failed")?;
+
+        // TODO: Extract artifacts from R execution result
+        let artifacts = vec![];
+
+        Ok(ToolExecutionResult {
+            tool_id: String::new(),
+            capability_id: String::new(),
+            success: exec_result.success,
+            stdout: Some(exec_result.output),
+            stderr: exec_result.error.clone(),
+            artifacts,
+            execution_time_ms: exec_result.execution_time_ms,
+            error: exec_result.error,
+        })
+    }
+
+    async fn execute_cli_capability(
+        &self,
+        _manifest: &ToolManifest,
+        capability: &CapabilityDescriptor,
+        parameters: HashMap<String, Value>,
+    ) -> Result<ToolExecutionResult> {
+        // Generate command from template
+        let command = self.render_template(&capability.template, &parameters)?;
+
+        if command.is_empty() {
+            return Err(anyhow!("Empty command"));
+        }
+
+        // Execute CLI command via shell to support redirects and pipes
+        // Use sh on Unix, cmd on Windows
+        #[cfg(unix)]
+        let output = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(&command)
+            .output()
+            .await
+            .context("Failed to execute CLI command")?;
+
+        #[cfg(windows)]
+        let output = tokio::process::Command::new("cmd")
+            .args(&["/C", &command])
+            .output()
+            .await
+            .context("Failed to execute CLI command")?;
+
+        let success = output.status.success();
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        // TODO: Extract artifacts based on output_spec
+        let artifacts = vec![];
+
+        Ok(ToolExecutionResult {
+            tool_id: String::new(),
+            capability_id: String::new(),
+            success,
+            stdout: Some(stdout),
+            stderr: if stderr.is_empty() {
+                None
+            } else {
+                Some(stderr.clone())
+            },
+            artifacts,
+            execution_time_ms: 0,
+            error: if !success {
+                Some(format!("Command failed with exit code {:?}", output.status.code()))
+            } else {
+                None
+            },
+        })
+    }
+
+    fn render_template(
+        &self,
+        template: &Option<String>,
+        parameters: &HashMap<String, Value>,
+    ) -> Result<String> {
+        let template_str = template
+            .as_ref()
+            .ok_or_else(|| anyhow!("No template provided"))?;
+
+        let mut result = template_str.clone();
+
+        // Simple template substitution: {{param_name}} -> value
+        for (key, value) in parameters {
+            let placeholder = format!("{{{{{}}}}}", key);
+            let value_str = match value {
+                Value::String(s) => s.clone(),
+                Value::Number(n) => n.to_string(),
+                Value::Bool(b) => b.to_string(),
+                _ => value.to_string(),
+            };
+            result = result.replace(&placeholder, &value_str);
+        }
+
+        // Check for unresolved placeholders
+        if result.contains("{{") {
+            return Err(anyhow!("Unresolved template parameters in: {}", result));
+        }
+
+        Ok(result)
+    }
+}

--- a/core/src/tools/manifest.rs
+++ b/core/src/tools/manifest.rs
@@ -1,0 +1,146 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Distinguishes between R-backed and CLI-backed tooling.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ToolKind {
+    RPackage,
+    Cli,
+}
+
+/// Describes the execution strategy for a capability.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CapabilityKind {
+    RFunction,
+    RSnippet,
+    CliCommand,
+}
+
+/// Valid parameter types a capability can expose.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ParameterType {
+    String,
+    Integer,
+    Float,
+    Enum,
+    File,
+}
+
+/// Output channel taxonomy for tool execution.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OutputType {
+    Stdout,
+    Stderr,
+    File,
+    RObject,
+}
+
+/// Controls how generated artefacts should surface in the UI.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ArtifactRecord {
+    Artifact,
+    Preview,
+    Internal,
+}
+
+/// Runtime-specific configuration required to execute a tool.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RuntimeConfig {
+    #[serde(default)]
+    pub r_library: Option<String>,
+    #[serde(default)]
+    pub imports: Vec<String>,
+    #[serde(default)]
+    pub cli_binary: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+/// Validation hooks executed before tool capabilities become available.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ValidationConfig {
+    #[serde(default)]
+    pub requires_packages: Vec<String>,
+    #[serde(default)]
+    pub requires_cli: Vec<String>,
+    #[serde(default)]
+    pub preflight_r: Option<String>,
+    #[serde(default)]
+    pub preflight_cli: Option<String>,
+}
+
+/// Describes a single input accepted by a capability.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParameterSpec {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub kind: ParameterType,
+    #[serde(default)]
+    pub format: Option<String>,
+    #[serde(default)]
+    pub options: Vec<String>,
+    #[serde(default)]
+    pub default: Option<Value>,
+    #[serde(default)]
+    pub min: Option<f64>,
+    #[serde(default)]
+    pub max: Option<f64>,
+    #[serde(default)]
+    pub role: Option<String>,
+}
+
+/// Describes the artefacts or channels emitted during execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputSpec {
+    #[serde(rename = "type")]
+    pub kind: OutputType,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub class: Option<String>,
+    #[serde(default)]
+    pub record_as: Option<ArtifactRecord>,
+}
+
+/// A single callable capability exposed by a tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilityDescriptor {
+    pub id: String,
+    pub display_name: String,
+    pub kind: CapabilityKind,
+    pub description: String,
+    pub entrypoint: String,
+    #[serde(default)]
+    pub template: Option<String>,
+    #[serde(default)]
+    pub input_spec: Vec<ParameterSpec>,
+    #[serde(default)]
+    pub output_spec: Vec<OutputSpec>,
+    #[serde(default)]
+    pub post_validation: Option<String>,
+}
+
+/// Top-level manifest loaded from `core/tools/*.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolManifest {
+    pub id: String,
+    pub display_name: String,
+    pub kind: ToolKind,
+    pub description: String,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub homepage: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    pub runtime: RuntimeConfig,
+    #[serde(default)]
+    pub validation: ValidationConfig,
+    #[serde(default)]
+    pub capabilities: Vec<CapabilityDescriptor>,
+}

--- a/core/src/tools/mod.rs
+++ b/core/src/tools/mod.rs
@@ -1,0 +1,11 @@
+//! Tool registry primitives shared between the desktop and server runtimes.
+
+pub mod executor;
+pub mod manifest;
+pub mod registry;
+pub mod validator;
+
+pub use executor::{Artifact, ToolExecutionResult, ToolExecutor};
+pub use manifest::*;
+pub use registry::ToolRegistry;
+pub use validator::{ToolValidator, ValidationResult};

--- a/core/src/tools/registry.rs
+++ b/core/src/tools/registry.rs
@@ -1,0 +1,137 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use super::{CapabilityDescriptor, ToolManifest};
+
+/// In-memory registry for tool manifests and capabilities.
+#[derive(Debug, Default)]
+pub struct ToolRegistry {
+    manifests: HashMap<String, ToolManifest>,
+    source_dir: Option<PathBuf>,
+}
+
+impl ToolRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self {
+            manifests: HashMap::new(),
+            source_dir: None,
+        }
+    }
+
+    /// Loads all manifests from the given directory. Non-existent directories are treated as empty.
+    pub fn load_from_dir<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let directory = path.as_ref();
+        let mut registry = Self {
+            manifests: HashMap::new(),
+            source_dir: Some(directory.to_path_buf()),
+        };
+
+        if !directory.exists() {
+            tracing::debug!(
+                "tool manifest directory {} missing; starting with empty registry",
+                directory.display()
+            );
+            return Ok(registry);
+        }
+
+        for entry in fs::read_dir(directory).with_context(|| {
+            format!(
+                "failed to enumerate tool manifests under {}",
+                directory.display()
+            )
+        })? {
+            let entry = entry.with_context(|| {
+                format!(
+                    "failed to access entry under tool manifest directory {}",
+                    directory.display()
+                )
+            })?;
+
+            let file_path = entry.path();
+            if !entry
+                .file_type()
+                .with_context(|| format!("failed to inspect {}", file_path.display()))?
+                .is_file()
+            {
+                continue;
+            }
+
+            if !is_toml_file(&file_path) {
+                continue;
+            }
+
+            let contents = fs::read_to_string(&file_path).with_context(|| {
+                format!(
+                    "failed to read tool manifest {}",
+                    file_path.display()
+                )
+            })?;
+
+            let manifest: ToolManifest = toml::from_str(&contents).with_context(|| {
+                format!(
+                    "failed to parse tool manifest {}",
+                    file_path.display()
+                )
+            })?;
+
+            registry.register(manifest);
+        }
+
+        Ok(registry)
+    }
+
+    /// Returns the directory the registry was loaded from, if any.
+    pub fn source_dir(&self) -> Option<&Path> {
+        self.source_dir.as_deref()
+    }
+
+    /// Registers or replaces a manifest.
+    pub fn register(&mut self, manifest: ToolManifest) -> Option<ToolManifest> {
+        self.manifests.insert(manifest.id.clone(), manifest)
+    }
+
+    /// Returns the manifest for a given tool id.
+    pub fn get(&self, tool_id: &str) -> Option<&ToolManifest> {
+        self.manifests.get(tool_id)
+    }
+
+    /// Returns an iterator over all manifests.
+    pub fn iter(&self) -> impl Iterator<Item = &ToolManifest> {
+        self.manifests.values()
+    }
+
+    /// Resolves a capability descriptor by id and returns both the descriptor and its parent manifest.
+    pub fn capability(
+        &self,
+        capability_id: &str,
+    ) -> Option<(&ToolManifest, &CapabilityDescriptor)> {
+        self.manifests.values().find_map(|manifest| {
+            manifest
+                .capabilities
+                .iter()
+                .find(|capability| capability.id == capability_id)
+                .map(|capability| (manifest, capability))
+        })
+    }
+
+    /// Number of registered manifests.
+    pub fn len(&self) -> usize {
+        self.manifests.len()
+    }
+
+    /// Returns true if no manifests are registered.
+    pub fn is_empty(&self) -> bool {
+        self.manifests.is_empty()
+    }
+}
+
+fn is_toml_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("toml"))
+        .unwrap_or(false)
+}

--- a/core/src/tools/validator.rs
+++ b/core/src/tools/validator.rs
@@ -1,0 +1,158 @@
+use anyhow::{anyhow, Result};
+use std::collections::HashMap;
+
+use super::{ToolKind, ToolManifest};
+use crate::RExecutor;
+
+/// Validation result for a tool
+#[derive(Debug)]
+pub struct ValidationResult {
+    pub tool_id: String,
+    pub is_valid: bool,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+/// Validates tool availability and prerequisites
+pub struct ToolValidator;
+
+impl ToolValidator {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Validate all manifests in a registry
+    /// Note: R executor validation is not supported in batch mode due to ownership constraints
+    pub async fn validate_all(manifests: &[&ToolManifest]) -> HashMap<String, ValidationResult> {
+        let mut results = HashMap::new();
+
+        for manifest in manifests {
+            let result = Self::validate_manifest(manifest, None).await;
+            results.insert(manifest.id.clone(), result);
+        }
+
+        results
+    }
+
+    /// Validate a single manifest
+    pub async fn validate_manifest(
+        manifest: &ToolManifest,
+        r_executor: Option<&mut RExecutor>,
+    ) -> ValidationResult {
+        let mut errors = Vec::new();
+        let mut warnings = Vec::new();
+
+        match manifest.kind {
+            ToolKind::RPackage => {
+                // Validate R package availability
+                if let Some(executor) = r_executor {
+                    if let Err(e) = Self::validate_r_package(manifest, executor).await {
+                        errors.push(e.to_string());
+                    }
+                } else {
+                    warnings.push("No R executor available for validation".to_string());
+                }
+            }
+            ToolKind::Cli => {
+                // Validate CLI tool availability
+                if let Err(e) = Self::validate_cli_tool(manifest).await {
+                    errors.push(e.to_string());
+                }
+            }
+        }
+
+        ValidationResult {
+            tool_id: manifest.id.clone(),
+            is_valid: errors.is_empty(),
+            errors,
+            warnings,
+        }
+    }
+
+    async fn validate_r_package(
+        manifest: &ToolManifest,
+        r_executor: &mut RExecutor,
+    ) -> Result<()> {
+        let validation = &manifest.validation;
+
+        // Check required packages
+        for package in &validation.requires_packages {
+            let check_code = format!(
+                "if (!requireNamespace('{}', quietly = TRUE)) stop('Package {} not found')",
+                package, package
+            );
+
+            let result = r_executor.execute(check_code).await?;
+            if !result.success {
+                return Err(anyhow!("R package '{}' not available", package));
+            }
+        }
+
+        // Run preflight check if provided
+        if let Some(preflight) = &validation.preflight_r {
+            let result = r_executor.execute(preflight.to_string()).await?;
+            if !result.success {
+                return Err(anyhow!(
+                    "Preflight check failed: {}",
+                    result.error.unwrap_or_default()
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn validate_cli_tool(manifest: &ToolManifest) -> Result<()> {
+        let validation = &manifest.validation;
+
+        // Check required CLI tools
+        for cli_tool in &validation.requires_cli {
+            if !Self::check_cli_available(cli_tool).await? {
+                return Err(anyhow!("CLI tool '{}' not found in PATH", cli_tool));
+            }
+        }
+
+        // Run preflight check if provided
+        if let Some(preflight) = &validation.preflight_cli {
+            let parts: Vec<&str> = preflight.split_whitespace().collect();
+            if parts.is_empty() {
+                return Ok(());
+            }
+
+            let output = tokio::process::Command::new(parts[0])
+                .args(&parts[1..])
+                .output()
+                .await?;
+
+            if !output.status.success() {
+                return Err(anyhow!(
+                    "CLI preflight check failed: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn check_cli_available(tool_name: &str) -> Result<bool> {
+        // Use 'which' on Unix-like systems, 'where' on Windows
+        #[cfg(unix)]
+        let check_command = "which";
+        #[cfg(windows)]
+        let check_command = "where";
+
+        let output = tokio::process::Command::new(check_command)
+            .arg(tool_name)
+            .output()
+            .await?;
+
+        Ok(output.status.success())
+    }
+}
+
+impl Default for ToolValidator {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/core/tools/ape.toml
+++ b/core/tools/ape.toml
@@ -1,0 +1,50 @@
+id = "ape"
+display_name = "Analyses of Phylogenetics and Evolution"
+kind = "r-package"
+description = "Tree manipulation, distance matrices, and phylogenetic analysis helpers."
+version = "5.7-1"
+homepage = "https://cran.r-project.org/package=ape"
+tags = ["phylogenetics", "tree"]
+
+[runtime]
+r_library = "ape"
+imports = ["ape"]
+cli_binary = ""
+args = []
+
+[validation]
+requires_packages = ["ape"]
+requires_cli = []
+preflight_r = "if (!requireNamespace('ape', quietly = TRUE)) stop('ape package is not installed')"
+preflight_cli = ""
+
+[[capabilities]]
+id = "ape::read_alignment"
+display_name = "Load DNA alignment"
+kind = "r-function"
+entrypoint = "ape::read.dna"
+description = "Load aligned DNA sequences from FASTA."
+input_spec = [
+  { name = "path", type = "file", format = "fasta" },
+  { name = "as.character", type = "enum", options = ["TRUE", "FALSE"], default = "FALSE" }
+]
+output_spec = [
+  { type = "r-object", class = "DNAbin", record_as = "artifact" }
+]
+template = """ape::read.dna(file = "{{path}}", format = "fasta", as.character = {{as.character}})"""
+post_validation = "stopifnot(inherits(.last_value, 'DNAbin'))"
+
+[[capabilities]]
+id = "ape::nj_tree"
+display_name = "Build neighbour-joining tree"
+kind = "r-snippet"
+entrypoint = "ape::nj"
+description = "Compute neighbour-joining tree from a distance matrix."
+input_spec = [
+  { name = "distance_matrix", type = "string", format = "r-object" }
+]
+output_spec = [
+  { type = "r-object", class = "phylo", record_as = "artifact" }
+]
+template = """ape::nj({{distance_matrix}})"""
+post_validation = "stopifnot(inherits(.last_value, 'phylo'))"

--- a/core/tools/mafft.toml
+++ b/core/tools/mafft.toml
@@ -1,0 +1,38 @@
+id = "mafft"
+display_name = "MAFFT Multiple Sequence Alignment"
+kind = "cli"
+description = "High-throughput multiple sequence alignment for nucleotide and protein sequences."
+version = "7"
+homepage = "https://mafft.cbrc.jp/alignment/software/"
+tags = ["alignment", "phylogenetics"]
+
+[runtime]
+r_library = ""
+imports = []
+cli_binary = "mafft"
+args = []
+
+[validation]
+requires_packages = []
+requires_cli = ["mafft"]
+preflight_r = ""
+preflight_cli = "mafft --version"
+
+[[capabilities]]
+id = "mafft::align"
+display_name = "Multiple sequence alignment"
+kind = "cli-command"
+entrypoint = "mafft --thread {{threads}} {{input}}"
+description = "Align FASTA sequences with configurable threading."
+input_spec = [
+  { name = "input", type = "file", format = "fasta" },
+  { name = "threads", type = "integer", min = 1, max = 16, default = 4 },
+  { name = "output", type = "file", format = "fasta", role = "generated" }
+]
+output_spec = [
+  { type = "file", path = "{{output}}", record_as = "artifact" },
+  { type = "stdout" },
+  { type = "stderr" }
+]
+template = """mafft --thread {{threads}} {{input}} > {{output}}"""
+post_validation = "if (!file.exists('{{output}}')) stop('mafft output not generated')"

--- a/protocol/src/messages.rs
+++ b/protocol/src/messages.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Result of code execution
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -30,4 +31,34 @@ pub struct ChatMessage {
 pub struct FileChangeEvent {
     pub event_type: String,
     pub path: String,
+}
+
+/// Request to execute a tool capability
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolExecutionRequest {
+    pub tool_id: String,
+    pub capability_id: String,
+    pub parameters: HashMap<String, serde_json::Value>,
+}
+
+/// Result of tool execution with provenance metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolExecutionResult {
+    pub tool_id: String,
+    pub capability_id: String,
+    pub success: bool,
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+    pub artifacts: Vec<ArtifactInfo>,
+    pub execution_time_ms: u64,
+    pub error: Option<String>,
+}
+
+/// Artifact generated during tool execution
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactInfo {
+    pub path: String,
+    pub artifact_type: String,
+    pub label: Option<String>,
+    pub record_as: String,
 }

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -8,14 +8,16 @@ use axum::{
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use reprod_core::{
-    AIProvider, AnthropicProvider, Config, RExecutor, ToolExecutor, ToolManifest, ToolRegistry,
+    AIProvider, AnthropicProvider, Config, OpenAIProvider, RExecutor, ToolExecutor, ToolManifest,
+    ToolRegistry,
 };
 use reprod_protocol::{ChatMessage, ExecutionResult};
 
 #[derive(Clone)]
 pub struct AppState {
     pub r_executor: Arc<Mutex<RExecutor>>,
-    pub ai_provider: Arc<Mutex<AnthropicProvider>>,
+    pub anthropic_provider: Arc<Mutex<AnthropicProvider>>,
+    pub openai_provider: Arc<Mutex<OpenAIProvider>>,
     pub config: Arc<Mutex<Config>>,
     pub tool_registry: Arc<ToolRegistry>,
     pub tool_executor: Arc<ToolExecutor>,
@@ -112,8 +114,27 @@ async fn handle_ws_request(request: WSRequest, state: &AppState) -> WSResponse {
             }
         }
         WSRequest::AIMessage { messages } => {
-            let ai_provider = state.ai_provider.lock().await;
-            match ai_provider.send_message(messages).await {
+            let config = state.config.lock().await;
+            let provider_name = config.default_ai_provider.clone();
+            drop(config);
+
+            let result = match provider_name.as_str() {
+                "openai" => {
+                    let provider = state.openai_provider.lock().await;
+                    provider.send_message(messages).await
+                }
+                "anthropic" => {
+                    let provider = state.anthropic_provider.lock().await;
+                    provider.send_message(messages).await
+                }
+                _ => {
+                    return WSResponse::Error {
+                        message: format!("Unknown AI provider: {}", provider_name),
+                    }
+                }
+            };
+
+            match result {
                 Ok(response) => WSResponse::AIResponse { response },
                 Err(e) => WSResponse::Error {
                     message: e.to_string(),

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -7,14 +7,18 @@ use axum::{
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use reprod_core::{RExecutor, AnthropicProvider, Config, AIProvider};
-use reprod_protocol::{ExecutionResult, ChatMessage};
+use reprod_core::{
+    AIProvider, AnthropicProvider, Config, RExecutor, ToolExecutor, ToolManifest, ToolRegistry,
+};
+use reprod_protocol::{ChatMessage, ExecutionResult};
 
 #[derive(Clone)]
 pub struct AppState {
     pub r_executor: Arc<Mutex<RExecutor>>,
     pub ai_provider: Arc<Mutex<AnthropicProvider>>,
     pub config: Arc<Mutex<Config>>,
+    pub tool_registry: Arc<ToolRegistry>,
+    pub tool_executor: Arc<ToolExecutor>,
 }
 
 pub async fn ws_handler(
@@ -63,6 +67,14 @@ enum WSRequest {
     Execute { code: String },
     #[serde(rename = "ai_message")]
     AIMessage { messages: Vec<ChatMessage> },
+    #[serde(rename = "list_tools")]
+    ListTools,
+    #[serde(rename = "execute_tool")]
+    ExecuteTool {
+        tool_id: String,
+        capability_id: String,
+        parameters: std::collections::HashMap<String, serde_json::Value>,
+    },
 }
 
 #[derive(serde::Serialize)]
@@ -74,6 +86,18 @@ enum WSResponse {
     AIResponse { response: String },
     #[serde(rename = "error")]
     Error { message: String },
+    #[serde(rename = "tools")]
+    Tools { tools: Vec<ToolManifest> },
+    #[serde(rename = "tool_execution_result")]
+    ToolExecutionResult {
+        tool_id: String,
+        capability_id: String,
+        success: bool,
+        stdout: Option<String>,
+        stderr: Option<String>,
+        execution_time_ms: u64,
+        error: Option<String>,
+    },
 }
 
 async fn handle_ws_request(request: WSRequest, state: &AppState) -> WSResponse {
@@ -82,14 +106,47 @@ async fn handle_ws_request(request: WSRequest, state: &AppState) -> WSResponse {
             let executor = state.r_executor.lock().await;
             match executor.execute(code).await {
                 Ok(result) => WSResponse::ExecutionResult { result },
-                Err(e) => WSResponse::Error { message: e.to_string() },
+                Err(e) => WSResponse::Error {
+                    message: e.to_string(),
+                },
             }
         }
         WSRequest::AIMessage { messages } => {
             let ai_provider = state.ai_provider.lock().await;
             match ai_provider.send_message(messages).await {
                 Ok(response) => WSResponse::AIResponse { response },
-                Err(e) => WSResponse::Error { message: e.to_string() },
+                Err(e) => WSResponse::Error {
+                    message: e.to_string(),
+                },
+            }
+        }
+        WSRequest::ListTools => {
+            let tools = state.tool_registry.iter().cloned().collect();
+            WSResponse::Tools { tools }
+        }
+        WSRequest::ExecuteTool {
+            tool_id,
+            capability_id,
+            parameters,
+        } => {
+            let mut r_executor = state.r_executor.lock().await;
+            match state
+                .tool_executor
+                .execute(&tool_id, &capability_id, parameters, &mut r_executor)
+                .await
+            {
+                Ok(result) => WSResponse::ToolExecutionResult {
+                    tool_id: result.tool_id,
+                    capability_id: result.capability_id,
+                    success: result.success,
+                    stdout: result.stdout,
+                    stderr: result.stderr,
+                    execution_time_ms: result.execution_time_ms,
+                    error: result.error,
+                },
+                Err(e) => WSResponse::Error {
+                    message: e.to_string(),
+                },
             }
         }
     }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,15 +1,13 @@
 mod routes;
 mod handlers;
 
-use axum::{
-    Router,
-    routing::get,
-};
+use axum::{routing::get, Router};
 use std::sync::Arc;
+use std::path::PathBuf;
 use tokio::sync::Mutex;
 use tower_http::cors::{CorsLayer, Any};
 use tower_http::trace::TraceLayer;
-use reprod_core::{RExecutor, AnthropicProvider, Config};
+use reprod_core::{AnthropicProvider, Config, RExecutor, ToolExecutor, ToolRegistry};
 
 #[tokio::main]
 async fn main() {
@@ -35,6 +33,22 @@ async fn main() {
 
     let config_state = Arc::new(Mutex::new(config));
 
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../core/tools");
+    tracing::info!("Attempting to load tool manifests from: {}", manifest_dir.display());
+    let tool_registry = ToolRegistry::load_from_dir(&manifest_dir)
+        .unwrap_or_else(|error| {
+            tracing::warn!(
+                "Failed to load tool manifests from {}: {}. Continuing with empty registry.",
+                manifest_dir.display(),
+                error
+            );
+            ToolRegistry::new()
+        });
+    tracing::info!("Loaded {} tool manifests", tool_registry.len());
+    let tool_registry = Arc::new(tool_registry);
+
+    let tool_executor = Arc::new(ToolExecutor::new(tool_registry.clone()));
+
     // Build application
     let app = Router::new()
         .route("/health", get(routes::health))
@@ -42,6 +56,8 @@ async fn main() {
         .route("/api/ai/message", axum::routing::post(routes::send_ai_message))
         .route("/api/config/key/:provider", get(routes::get_api_key))
         .route("/api/config/key/:provider", axum::routing::put(routes::set_api_key))
+        .route("/api/tools", get(routes::list_tools))
+        .route("/api/tools/execute", axum::routing::post(routes::execute_tool))
         .route("/ws", get(handlers::ws_handler))
         .layer(
             CorsLayer::new()
@@ -54,6 +70,8 @@ async fn main() {
             r_executor,
             ai_provider,
             config: config_state,
+            tool_registry: tool_registry.clone(),
+            tool_executor: tool_executor.clone(),
         });
 
     let addr = "127.0.0.1:3001";

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use tokio::sync::Mutex;
 use tower_http::cors::{CorsLayer, Any};
 use tower_http::trace::TraceLayer;
-use reprod_core::{AnthropicProvider, Config, RExecutor, ToolExecutor, ToolRegistry};
+use reprod_core::{AnthropicProvider, Config, OpenAIProvider, RExecutor, ToolExecutor, ToolRegistry};
 
 #[tokio::main]
 async fn main() {
@@ -27,8 +27,12 @@ async fn main() {
         RExecutor::new(temp_dir, config.r_path.clone())
     ));
 
-    let ai_provider = Arc::new(Mutex::new(
+    let anthropic_provider = Arc::new(Mutex::new(
         AnthropicProvider::new(config.anthropic_api_key.clone())
+    ));
+
+    let openai_provider = Arc::new(Mutex::new(
+        OpenAIProvider::new(config.openai_api_key.clone())
     ));
 
     let config_state = Arc::new(Mutex::new(config));
@@ -56,6 +60,8 @@ async fn main() {
         .route("/api/ai/message", axum::routing::post(routes::send_ai_message))
         .route("/api/config/key/:provider", get(routes::get_api_key))
         .route("/api/config/key/:provider", axum::routing::put(routes::set_api_key))
+        .route("/api/config/provider", get(routes::get_provider))
+        .route("/api/config/provider", axum::routing::put(routes::set_provider))
         .route("/api/tools", get(routes::list_tools))
         .route("/api/tools/execute", axum::routing::post(routes::execute_tool))
         .route("/ws", get(handlers::ws_handler))
@@ -68,7 +74,8 @@ async fn main() {
         .layer(TraceLayer::new_for_http())
         .with_state(handlers::AppState {
             r_executor,
-            ai_provider,
+            anthropic_provider,
+            openai_provider,
             config: config_state,
             tool_registry: tool_registry.clone(),
             tool_executor: tool_executor.clone(),

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -3,8 +3,8 @@ use axum::{
     http::StatusCode,
     Json,
 };
-use reprod_protocol::{ExecutionResult, ChatMessage};
-use reprod_core::AIProvider;
+use reprod_core::{AIProvider, ToolManifest};
+use reprod_protocol::{ChatMessage, ExecutionResult, ToolExecutionRequest, ToolExecutionResult};
 use crate::handlers::AppState;
 
 pub async fn health() -> &'static str {
@@ -68,6 +68,50 @@ pub async fn set_api_key(
     config
         .save()
         .map(|_| StatusCode::OK)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+}
+
+pub async fn list_tools(State(state): State<AppState>) -> Json<Vec<ToolManifest>> {
+    let manifests = state.tool_registry.iter().cloned().collect();
+    Json(manifests)
+}
+
+pub async fn execute_tool(
+    State(state): State<AppState>,
+    Json(request): Json<ToolExecutionRequest>,
+) -> Result<Json<ToolExecutionResult>, (StatusCode, String)> {
+    let mut r_executor = state.r_executor.lock().await;
+
+    state
+        .tool_executor
+        .execute(
+            &request.tool_id,
+            &request.capability_id,
+            request.parameters,
+            &mut r_executor,
+        )
+        .await
+        .map(|result| {
+            Json(ToolExecutionResult {
+                tool_id: result.tool_id,
+                capability_id: result.capability_id,
+                success: result.success,
+                stdout: result.stdout,
+                stderr: result.stderr,
+                artifacts: result
+                    .artifacts
+                    .into_iter()
+                    .map(|a| reprod_protocol::ArtifactInfo {
+                        path: a.path,
+                        artifact_type: a.artifact_type,
+                        label: a.label,
+                        record_as: a.record_as,
+                    })
+                    .collect(),
+                execution_time_ms: result.execution_time_ms,
+                error: result.error,
+            })
+        })
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
 }
 

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -28,11 +28,28 @@ pub async fn send_ai_message(
     State(state): State<AppState>,
     Json(payload): Json<AIMessageRequest>,
 ) -> Result<Json<AIMessageResponse>, (StatusCode, String)> {
-    let ai_provider = state.ai_provider.lock().await;
+    let config = state.config.lock().await;
+    let provider_name = config.default_ai_provider.clone();
+    drop(config);
 
-    ai_provider
-        .send_message(payload.messages)
-        .await
+    let result = match provider_name.as_str() {
+        "openai" => {
+            let provider = state.openai_provider.lock().await;
+            provider.send_message(payload.messages).await
+        }
+        "anthropic" => {
+            let provider = state.anthropic_provider.lock().await;
+            provider.send_message(payload.messages).await
+        }
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("Unknown AI provider: {}", provider_name),
+            ))
+        }
+    };
+
+    result
         .map(|response| Json(AIMessageResponse { response }))
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
 }
@@ -45,6 +62,7 @@ pub async fn get_api_key(
 
     let api_key = match provider.as_str() {
         "anthropic" => config.anthropic_api_key.clone(),
+        "openai" => config.openai_api_key.clone(),
         _ => return Err((StatusCode::BAD_REQUEST, format!("Unknown provider: {}", provider))),
     };
 
@@ -62,6 +80,7 @@ pub async fn set_api_key(
 
     match provider.as_str() {
         "anthropic" => config.anthropic_api_key = Some(payload.api_key),
+        "openai" => config.openai_api_key = Some(payload.api_key),
         _ => return Err((StatusCode::BAD_REQUEST, format!("Unknown provider: {}", provider))),
     }
 
@@ -74,6 +93,35 @@ pub async fn set_api_key(
 pub async fn list_tools(State(state): State<AppState>) -> Json<Vec<ToolManifest>> {
     let manifests = state.tool_registry.iter().cloned().collect();
     Json(manifests)
+}
+
+pub async fn get_provider(
+    State(state): State<AppState>,
+) -> Result<Json<GetProviderResponse>, (StatusCode, String)> {
+    let config = state.config.lock().await;
+    Ok(Json(GetProviderResponse {
+        provider: config.default_ai_provider.clone(),
+    }))
+}
+
+pub async fn set_provider(
+    State(state): State<AppState>,
+    Json(payload): Json<SetProviderRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    if payload.provider != "openai" && payload.provider != "anthropic" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("Invalid provider: {}. Must be 'openai' or 'anthropic'", payload.provider),
+        ));
+    }
+
+    let mut config = state.config.lock().await;
+    config.default_ai_provider = payload.provider;
+
+    config
+        .save()
+        .map(|_| StatusCode::OK)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
 }
 
 pub async fn execute_tool(
@@ -139,4 +187,14 @@ pub struct ApiKeyResponse {
 #[derive(serde::Deserialize)]
 pub struct SetApiKeyRequest {
     pub api_key: String,
+}
+
+#[derive(serde::Deserialize)]
+pub struct SetProviderRequest {
+    pub provider: String,
+}
+
+#[derive(serde::Serialize)]
+pub struct GetProviderResponse {
+    pub provider: String,
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './tools';

--- a/shared/src/tools.ts
+++ b/shared/src/tools.ts
@@ -1,0 +1,83 @@
+export type ToolKind = 'r-package' | 'cli';
+export type CapabilityKind = 'r-function' | 'r-snippet' | 'cli-command';
+
+export interface ToolManifest {
+  id: string;
+  displayName: string;
+  kind: ToolKind;
+  description: string;
+  version?: string;
+  homepage?: string;
+  tags: string[];
+  runtime: RuntimeConfig;
+  validation: ValidationConfig;
+  capabilities: CapabilityDescriptor[];
+}
+
+export interface RuntimeConfig {
+  rLibrary?: string;
+  imports: string[];
+  cliBinary?: string;
+  args: string[];
+}
+
+export interface ValidationConfig {
+  requiresPackages: string[];
+  requiresCli: string[];
+  preflightR?: string;
+  preflightCli?: string;
+}
+
+export interface CapabilityDescriptor {
+  id: string;
+  displayName: string;
+  kind: CapabilityKind;
+  description: string;
+  entrypoint: string;
+  template?: string;
+  inputSpec: ParameterSpec[];
+  outputSpec: OutputSpec[];
+  postValidation?: string;
+}
+
+export type ParameterType = 'string' | 'integer' | 'float' | 'enum' | 'file';
+export type OutputType = 'stdout' | 'stderr' | 'file' | 'r-object';
+export type ArtifactRecord = 'artifact' | 'preview' | 'internal';
+
+export interface ParameterSpec {
+  name: string;
+  type: ParameterType;
+  format?: string;
+  options?: string[];
+  default?: string | number | boolean | null;
+  min?: number;
+  max?: number;
+  role?: 'generated';
+}
+
+export interface OutputSpec {
+  type: OutputType;
+  path?: string;
+  class?: string;
+  recordAs?: ArtifactRecord;
+}
+
+export interface ToolExecutionRequest {
+  toolId: string;
+  capabilityId: string;
+  parameters: Record<string, string>;
+}
+
+export interface ArtifactSummary {
+  path: string;
+  type: 'file' | 'plot';
+  label?: string;
+}
+
+export interface ToolExecutionResult {
+  toolId: string;
+  capabilityId: string;
+  stdout?: string;
+  stderr?: string;
+  artifacts?: ArtifactSummary[];
+}


### PR DESCRIPTION

  

# Summary

  - introduce OpenAI chat provider wiring with configurable default AI selection
    and shared config fields.
  - add tool manifest schema, registry, validator, and executor plus sample ape/
    mafft manifests.
  - expose new tool execution protocol types and HTTP/WebSocket routes to list and
    run tool capabilities.
  - include TOML parsing dependency updates to load manifests from core/tools.



# Note

“tools” here are structured R/CLI capabilities defined by TOML manifests (e.g., ape, mafft) that the desktop/server can enumerate and execute; they’re not UX widgets.