### PR TITLE
fix(issue-031): verify and fix export dialog options

### DIFF
--- a/client/src/components/export/__tests__/ExportDialog.test.tsx
+++ b/client/src/components/export/__tests__/ExportDialog.test.tsx
@@ -77,4 +77,270 @@ describe('ExportDialog', () => {
     const [sentRequest] = sendMock.mock.calls[0];
     expect(sentRequest.request.documentPath).toBe('/tmp/report.R');
   });
+
+  it('toggles includeTimestamps option correctly', async () => {
+    const sendMock = vi.fn((request, handler) => {
+      handler({
+        type: 'export_rmarkdown_response',
+        response: { success: true, outputPath: 'test.Rmd' },
+      });
+      return true;
+    });
+
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    const timestampsCheckbox = screen.getByLabelText('Include timestamps');
+    expect(timestampsCheckbox).toBeChecked();
+
+    fireEvent.click(timestampsCheckbox);
+    expect(timestampsCheckbox).not.toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+
+    const [sentRequest] = sendMock.mock.calls[0];
+    expect(sentRequest.request.includeTimestamps).toBe(false);
+  });
+
+  it('toggles showActor option correctly', async () => {
+    const sendMock = vi.fn((request, handler) => {
+      handler({
+        type: 'export_rmarkdown_response',
+        response: { success: true, outputPath: 'test.Rmd' },
+      });
+      return true;
+    });
+
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    const actorCheckbox = screen.getByLabelText('Show actor (User/AI) for each chunk');
+    expect(actorCheckbox).toBeChecked();
+
+    fireEvent.click(actorCheckbox);
+    expect(actorCheckbox).not.toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+
+    const [sentRequest] = sendMock.mock.calls[0];
+    expect(sentRequest.request.showActor).toBe(false);
+  });
+
+  it('toggles embedPlots option correctly', async () => {
+    const sendMock = vi.fn((request, handler) => {
+      handler({
+        type: 'export_rmarkdown_response',
+        response: { success: true, outputPath: 'test.Rmd' },
+      });
+      return true;
+    });
+
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    const plotsCheckbox = screen.getByLabelText('Embed plot images inline');
+    expect(plotsCheckbox).toBeChecked();
+
+    fireEvent.click(plotsCheckbox);
+    expect(plotsCheckbox).not.toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+
+    const [sentRequest] = sendMock.mock.calls[0];
+    expect(sentRequest.request.embedPlots).toBe(false);
+  });
+
+  it('toggles includeOutputs option correctly', async () => {
+    const sendMock = vi.fn((request, handler) => {
+      handler({
+        type: 'export_rmarkdown_response',
+        response: { success: true, outputPath: 'test.Rmd' },
+      });
+      return true;
+    });
+
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    const outputsCheckbox = screen.getByLabelText('Include execution outputs');
+    expect(outputsCheckbox).toBeChecked();
+
+    fireEvent.click(outputsCheckbox);
+    expect(outputsCheckbox).not.toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+
+    const [sentRequest] = sendMock.mock.calls[0];
+    expect(sentRequest.request.includeOutputs).toBe(false);
+  });
+
+  it('toggles includeErrors option correctly', async () => {
+    const sendMock = vi.fn((request, handler) => {
+      handler({
+        type: 'export_rmarkdown_response',
+        response: { success: true, outputPath: 'test.Rmd' },
+      });
+      return true;
+    });
+
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    const errorsCheckbox = screen.getByLabelText('Include error messages');
+    expect(errorsCheckbox).not.toBeChecked();
+
+    fireEvent.click(errorsCheckbox);
+    expect(errorsCheckbox).toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+
+    const [sentRequest] = sendMock.mock.calls[0];
+    expect(sentRequest.request.includeErrors).toBe(true);
+  });
+
+  it('toggles includeSummary option correctly', async () => {
+    const sendMock = vi.fn((request, handler) => {
+      handler({
+        type: 'export_rmarkdown_response',
+        response: { success: true, outputPath: 'test.Rmd' },
+      });
+      return true;
+    });
+
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    const summaryCheckbox = screen.getByLabelText('Add session statistics summary');
+    expect(summaryCheckbox).toBeChecked();
+
+    fireEvent.click(summaryCheckbox);
+    expect(summaryCheckbox).not.toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+
+    const [sentRequest] = sendMock.mock.calls[0];
+    expect(sentRequest.request.includeSummary).toBe(false);
+  });
+
+  it('sends all options disabled when all checkboxes are unchecked', async () => {
+    const sendMock = vi.fn((request, handler) => {
+      handler({
+        type: 'export_rmarkdown_response',
+        response: { success: true, outputPath: 'test.Rmd' },
+      });
+      return true;
+    });
+
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    // Uncheck all options that are checked by default
+    fireEvent.click(screen.getByLabelText('Include timestamps'));
+    fireEvent.click(screen.getByLabelText('Show actor (User/AI) for each chunk'));
+    fireEvent.click(screen.getByLabelText('Embed plot images inline'));
+    fireEvent.click(screen.getByLabelText('Include execution outputs'));
+    fireEvent.click(screen.getByLabelText('Add session statistics summary'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+
+    const [sentRequest] = sendMock.mock.calls[0];
+    expect(sentRequest.request).toMatchObject({
+      includeTimestamps: false,
+      showActor: false,
+      embedPlots: false,
+      includeOutputs: false,
+      includeErrors: false,
+      includeSummary: false,
+    });
+  });
+
+  it('requires document path for document mode', async () => {
+    const sendMock = vi.fn();
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    // Switch to document mode
+    fireEvent.click(screen.getByRole('radio', { name: /Document-Based/i }));
+
+    // Try to export without document path
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Error: Document path is required for document-based export')).toBeInTheDocument();
+    });
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('handles WebSocket connection failure', async () => {
+    const sendMock = vi.fn(() => false);
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Error: WebSocket not connected')).toBeInTheDocument();
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('changes output path correctly', async () => {
+    const sendMock = vi.fn((request, handler) => {
+      handler({
+        type: 'export_rmarkdown_response',
+        response: { success: true, outputPath: 'custom_report.Rmd' },
+      });
+      return true;
+    });
+
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    const outputPathInput = screen.getByLabelText('Output Path');
+    fireEvent.change(outputPathInput, { target: { value: 'custom_report.Rmd' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+
+    const [sentRequest] = sendMock.mock.calls[0];
+    expect(sentRequest.request.outputPath).toBe('custom_report.Rmd');
+  });
 });


### PR DESCRIPTION
## Corresponding issue

Issue #34


## Summary

- Verified all export dialog features and WebSocket integration
- Added comprehensive test coverage for all export options:
  * Test toggles for includeTimestamps, showActor, embedPlots
  * Test toggles for includeOutputs, includeErrors, includeSummary
  * Test document path validation
  * Test WebSocket connection failure handling
  * Test output path customization
  * Test all options disabled scenario
- Created EXPORT_VERIFICATION_REPORT.md with detailed findings
- All 12 tests passing successfully
- No critical or major issues found in implementation

Generated with [Claude Code](https://claude.com/claude-code)