### PR TITLE
refactor: cleanup TypeScript configuration files

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,12 +1,6 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    "moduleResolution": "bundler",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
@@ -19,17 +13,7 @@
       "@shared/*": ["../shared/src/*"],
       "shared": ["../shared/src/index.ts"],
       "shared/*": ["../shared/src/*"]
-    },
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    }
   },
   "include": ["src"],
   "exclude": ["src/**/__tests__", "src/**/*.test.ts", "src/**/*.test.tsx"],

--- a/package.json
+++ b/package.json
@@ -22,20 +22,5 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@shared/*": [
-        "shared/src/*"
-      ],
-      "@server/*": [
-        "server/src/*"
-      ]
-    },
-    "rootDirs": [
-      "server/src",
-      "shared/src"
-    ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,24 +14,6 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["client/src/*"],
-      "@/components/*": ["client/src/components/*"],
-      "@/core/*": ["client/src/core/*"],
-      "@/hooks/*": ["client/src/hooks/*"],
-      "@/utils/*": ["client/src/utils/*"],
-      "@/css/*": ["client/src/css/*"],
-      "@server/*": ["server/src/*"],
-      "@shared/*": ["shared/src/*"]
-    },
-    "rootDirs": [
-      "client/src",
-      "server/src",
-      "shared/src"
-    ]
-  },
-  "include": ["client/src", "server/src", "shared/src"],
-  "references": [{ "path": "client/tsconfig.node.json" }]
+    "noFallthroughCasesInSwitch": true
+  }
 }


### PR DESCRIPTION
## Summary

Cleaned up TypeScript configuration files to follow monorepo best practices and remove redundant settings.

## Changes

- **package.json**: Removed invalid `compilerOptions` section (TypeScript config should only be in tsconfig.json)
- **tsconfig.json** (root): Simplified to contain only base compiler settings shared across all workspaces
- **client/tsconfig.json**: Added `extends` to inherit from root config, removed duplicate settings

## Benefits

- Reduces code duplication (removed 53 lines)
- Follows TypeScript monorepo best practices
- Easier to maintain - base settings defined in one place
- `shared/tsconfig.json` already follows this pattern correctly

## Verification

- ✅ Type checking passes (`pnpm exec tsc --noEmit`)
- ✅ Build succeeds (`pnpm build`)
- ✅ All pre-push hooks pass

## Notes

The `logs/` directory is already properly ignored in `.gitignore`.