### PR TITLE
chore: remove debug console logs/info from menuActions

### DIFF
--- a/client/src/services/menuActions.ts
+++ b/client/src/services/menuActions.ts
@@ -40,7 +40,6 @@ export const menuActions = {
       store.setEditorContent('# New R Script\n\n');
       store.setEditorFilepath('');
       store.setEditorIsDirty(false);
-      console.log('New file created');
     },
 
     /**
@@ -61,7 +60,6 @@ export const menuActions = {
           store.setEditorContent(content);
           store.setEditorFilepath(file.name);
           store.setEditorIsDirty(false);
-          console.log(`Opened: ${file.name}`);
         } catch (error) {
           console.error(`Failed to open file: ${error}`);
         }
@@ -96,7 +94,6 @@ export const menuActions = {
       URL.revokeObjectURL(url);
 
       store.setEditorIsDirty(false);
-      console.log('File saved');
     },
 
     /**
@@ -119,8 +116,6 @@ export const menuActions = {
       a.download = 'untitled.R';
       a.click();
       URL.revokeObjectURL(url);
-
-      console.log('File downloaded');
     },
 
     /**
@@ -249,7 +244,6 @@ export const menuActions = {
      * Interrupt running R execution
      */
     interrupt: () => {
-      console.info('Interrupt not yet implemented');
       // TODO: Implement execution interrupt
     },
 
@@ -262,7 +256,6 @@ export const menuActions = {
         return;
       }
 
-      console.info('Restart session not yet implemented');
       // TODO: Implement session restart
     },
 
@@ -314,7 +307,6 @@ export const menuActions = {
      * TODO: Implement session persistence
      */
     save: () => {
-      console.info('Session save not yet implemented');
     },
 
     /**
@@ -322,14 +314,12 @@ export const menuActions = {
      * TODO: Implement session loading
      */
     load: () => {
-      console.info('Session load not yet implemented');
     },
 
     /**
      * Show session info
      */
     info: () => {
-      console.info('Session info not yet implemented');
       // TODO: Implement session info modal
     },
 
@@ -338,7 +328,6 @@ export const menuActions = {
      * TODO: Implement settings modal
      */
     settings: () => {
-      console.info('Settings not yet implemented');
     },
   },
 
@@ -351,8 +340,6 @@ export const menuActions = {
       const pane = paneId as ViewPane;
       const { togglePaneVisibility } = useStore.getState();
       togglePaneVisibility(pane);
-      const next = useStore.getState().view.panes[pane];
-      console.log(`${paneId} ${next ? 'shown' : 'hidden'}`);
     },
 
     /**
@@ -361,8 +348,6 @@ export const menuActions = {
     zoomIn: () => {
       const { adjustZoom } = useStore.getState();
       adjustZoom(0.1);
-      const { view } = useStore.getState();
-      console.log(`Zoom: ${Math.round(view.zoom * 100)}%`);
     },
 
     /**
@@ -371,8 +356,6 @@ export const menuActions = {
     zoomOut: () => {
       const { adjustZoom } = useStore.getState();
       adjustZoom(-0.1);
-      const { view } = useStore.getState();
-      console.log(`Zoom: ${Math.round(view.zoom * 100)}%`);
     },
 
     /**
@@ -381,9 +364,6 @@ export const menuActions = {
     zoomReset: () => {
       const { resetZoom } = useStore.getState();
       resetZoom();
-      const next = useStore.getState().view.zoom;
-      const rounded = Math.round(next * 100);
-      console.log(rounded === 100 ? 'Zoom reset to 100%' : `Zoom: ${rounded}%`);
     },
   },
 
@@ -401,7 +381,6 @@ export const menuActions = {
      * TODO: Implement shortcuts modal
      */
     shortcuts: () => {
-      console.info('Shortcuts modal not yet implemented');
     },
 
     /**
@@ -416,7 +395,6 @@ export const menuActions = {
      * TODO: Implement about modal
      */
     about: () => {
-      console.info('About modal not yet implemented');
     },
   },
 };


### PR DESCRIPTION
## Description

Removed development-only `console.log()` and `console.info()` statements from `menuActions.ts` as part of production cleanup. No functional changes.
No debug logs were found in `TimelinePanel.tsx`, so no changes were required in that file.


## Related Issue

Closes #68 

## Changes

- Removed all `console.log()` calls from `menuActions.ts`
- Removed all `console.info()` “not yet implemented” logs
- Kept all `console.error()` calls as required


## Testing
Manually verified that menu actions still work (file operations, zoom, toggling panes).
All checks pass.

<!-- Describe how you tested these changes -->

## Test results:
- [ ] Frontend tests pass (`pnpm --filter client test`)
- [ ] Backend tests pass (`cargo test`)
- [ ] Frontend lint passes (`pnpm --filter client run lint`)
- [ ] Backend clippy passes (`cargo clippy`)
- [ ] Backend formatting passes (`cargo fmt --check`)
- [x] Manual testing completed

## Checklist
- [x] This PR addresses an existing issue
- [x] Code follows project conventions
- [ ] Tests added or updated (not needed for this change)
- [ ] Documentation updated (not needed)

