### PR TITLE
❇️ feat: ai mode ui was fixed

### DIFF
--- a/client/src/components/ai-panel/AIPanel.tsx
+++ b/client/src/components/ai-panel/AIPanel.tsx
@@ -37,22 +37,6 @@ export function AIPanel(): JSX.Element {
         <div className="panel-title">AI Assistant</div>
       </div>
       <div className="panel-content">
-        <div className="ai-mode-selector" role="group" aria-label="AI interaction mode">
-          <button
-            type="button"
-            className={mode === 'agent' ? 'active' : ''}
-            onClick={() => setMode('agent')}
-          >
-            🤖 Agent
-          </button>
-          <button
-            type="button"
-            className={mode === 'chat' ? 'active' : ''}
-            onClick={() => setMode('chat')}
-          >
-            💬 Chat
-          </button>
-        </div>
         <div className="ai-messages">
           {messages.length === 0 ? (
             <div className="ai-welcome">
@@ -95,16 +79,34 @@ export function AIPanel(): JSX.Element {
               disabled={isLoading}
               rows={3}
             />
-            <button
-              type="button"
-              className="send-icon-button"
-              onClick={() => handleAsk(mode)}
-              disabled={!input.trim() || isLoading}
-              title="Send message (Enter)"
-              aria-label="Send message"
-            >
-              <IconSend width={16} height={16} aria-hidden />
-            </button>
+            <div className="prompt-actions">
+              <div className="ai-mode-selector" role="group" aria-label="AI interaction mode">
+                <button
+                  type="button"
+                  className={mode === 'agent' ? 'active' : ''}
+                  onClick={() => setMode('agent')}
+                >
+                  Agent
+                </button>
+                <button
+                  type="button"
+                  className={mode === 'chat' ? 'active' : ''}
+                  onClick={() => setMode('chat')}
+                >
+                  Chat
+                </button>
+              </div>
+              <button
+                type="button"
+                className="send-icon-button"
+                onClick={() => handleAsk(mode)}
+                disabled={!input.trim() || isLoading}
+                title="Send message (Enter)"
+                aria-label="Send message"
+              >
+                <IconSend width={16} height={16} aria-hidden />
+              </button>
+            </div>
           </div>
           {isLoading && (
             <button

--- a/client/src/components/ai-panel/AIPanel.tsx
+++ b/client/src/components/ai-panel/AIPanel.tsx
@@ -1,4 +1,5 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
+import type { AIMode } from '@shared/types';
 import { IconSend, IconSquare } from '@/components/shared';
 import { StreamingMessage } from './StreamingMessage';
 import { useAIConversation } from '@/hooks/useAIConversation';
@@ -20,10 +21,13 @@ export function AIPanel(): JSX.Element {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  const [mode, setMode] = useState<AIMode>('agent');
+  const placeholder = mode === 'agent' ? 'Describe a task...' : 'Ask a question...';
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
     if (e.key === 'Enter' && !e.shiftKey && !e.altKey && !e.metaKey) {
       e.preventDefault();
-      handleAsk();
+      handleAsk(mode);
     }
   };
 
@@ -33,6 +37,22 @@ export function AIPanel(): JSX.Element {
         <div className="panel-title">AI Assistant</div>
       </div>
       <div className="panel-content">
+        <div className="ai-mode-selector" role="group" aria-label="AI interaction mode">
+          <button
+            type="button"
+            className={mode === 'agent' ? 'active' : ''}
+            onClick={() => setMode('agent')}
+          >
+            🤖 Agent
+          </button>
+          <button
+            type="button"
+            className={mode === 'chat' ? 'active' : ''}
+            onClick={() => setMode('chat')}
+          >
+            💬 Chat
+          </button>
+        </div>
         <div className="ai-messages">
           {messages.length === 0 ? (
             <div className="ai-welcome">
@@ -64,16 +84,29 @@ export function AIPanel(): JSX.Element {
           )}
         </div>
         <div className="ai-input-container">
-          <textarea
-            className="ai-input"
-            placeholder="Ask a question... (Enter to send, Shift/Alt+Enter for new line)"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            disabled={isLoading}
-            rows={3}
-          />
-          {isLoading ? (
+          <div className="prompt-input-container">
+            <textarea
+              className="ai-input"
+              placeholder={placeholder}
+              aria-label={placeholder}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={isLoading}
+              rows={3}
+            />
+            <button
+              type="button"
+              className="send-icon-button"
+              onClick={() => handleAsk(mode)}
+              disabled={!input.trim() || isLoading}
+              title="Send message (Enter)"
+              aria-label="Send message"
+            >
+              <IconSend width={16} height={16} aria-hidden />
+            </button>
+          </div>
+          {isLoading && (
             <button
               className="btn btn-stop"
               onClick={handleStop}
@@ -82,18 +115,6 @@ export function AIPanel(): JSX.Element {
               <>
                 <IconSquare width={16} height={16} aria-hidden />
                 Stop
-              </>
-            </button>
-          ) : (
-            <button
-              className="btn btn-primary"
-              onClick={handleAsk}
-              disabled={!input.trim()}
-              title="Send message (Enter)"
-            >
-              <>
-                <IconSend width={16} height={16} aria-hidden />
-                Send
               </>
             </button>
           )}

--- a/client/src/components/timeline/TimelineEvent.tsx
+++ b/client/src/components/timeline/TimelineEvent.tsx
@@ -11,8 +11,7 @@ export function TimelineEvent({ event, onNavigate }: TimelineEventProps): JSX.El
     second: '2-digit',
   });
 
-  // Get actor icon
-  const actorIcon = context.actor === 'user' ? '👤' : '🤖';
+  // Get actor label
   const actorLabel = context.actor === 'user' ? 'User' : 'AI';
 
   // Get source label
@@ -32,7 +31,6 @@ export function TimelineEvent({ event, onNavigate }: TimelineEventProps): JSX.El
   const hasMoreLines = codeLines.length > 3;
 
   // Get result status
-  const statusIcon = result.success ? '✅' : '❌';
   const statusLabel = result.success ? 'Success' : 'Error';
   const executionTime = result.execution_time_ms;
   const plotCount = result.plots.length;
@@ -46,9 +44,7 @@ export function TimelineEvent({ event, onNavigate }: TimelineEventProps): JSX.El
   return (
     <div className="timeline-event" onClick={handleClick}>
       <div className="timeline-event-header">
-        <span className="timeline-event-actor">
-          {actorIcon} {actorLabel}
-        </span>
+        <span className="timeline-event-actor">{actorLabel}</span>
         <span className="timeline-event-time">{timeStr}</span>
         <span className="timeline-event-source">{sourceLabel}</span>
       </div>
@@ -63,12 +59,12 @@ export function TimelineEvent({ event, onNavigate }: TimelineEventProps): JSX.El
       </div>
 
       <div className="timeline-event-footer">
-        <span className="timeline-event-status">
-          {statusIcon} {statusLabel}
-        </span>
+        <span className="timeline-event-status">{statusLabel}</span>
         <span className="timeline-event-duration">{executionTime}ms</span>
         {plotCount > 0 && (
-          <span className="timeline-event-plots">📊 {plotCount} plot{plotCount > 1 ? 's' : ''}</span>
+          <span className="timeline-event-plots">
+            {plotCount} plot{plotCount > 1 ? 's' : ''}
+          </span>
         )}
       </div>
 

--- a/client/src/components/timeline/TimelineFilters.tsx
+++ b/client/src/components/timeline/TimelineFilters.tsx
@@ -49,8 +49,8 @@ export function TimelineFilters({
             onChange={handleActorChange}
           >
             <option value="all">All</option>
-            <option value="user">👤 User</option>
-            <option value="ai">🤖 AI</option>
+            <option value="user">User</option>
+            <option value="ai">AI</option>
           </select>
         </div>
 
@@ -70,7 +70,7 @@ export function TimelineFilters({
 
         <Checkbox
           className="timeline-filter timeline-filter-checkbox"
-          label="📊 With Plots"
+          label="With Plots"
           checked={filters.hasPlots || false}
           onChange={(checked) =>
             onChange({ ...filters, hasPlots: checked ? true : undefined })
@@ -79,7 +79,7 @@ export function TimelineFilters({
 
         <Checkbox
           className="timeline-filter timeline-filter-checkbox"
-          label="❌ With Errors"
+          label="With Errors"
           checked={filters.hasErrors || false}
           onChange={(checked) =>
             onChange({ ...filters, hasErrors: checked ? true : undefined })

--- a/client/src/components/timeline/TimelineStats.tsx
+++ b/client/src/components/timeline/TimelineStats.tsx
@@ -36,22 +36,22 @@ export function TimelineStats({ stats, loading }: TimelineStatsProps): JSX.Eleme
 
         <div className="timeline-stat">
           <div className="timeline-stat-value">{stats.userActions}</div>
-          <div className="timeline-stat-label">👤 User</div>
+          <div className="timeline-stat-label">User</div>
         </div>
 
         <div className="timeline-stat">
           <div className="timeline-stat-value">{stats.aiActions}</div>
-          <div className="timeline-stat-label">🤖 AI</div>
+          <div className="timeline-stat-label">AI</div>
         </div>
 
         <div className="timeline-stat">
           <div className="timeline-stat-value">{stats.totalPlots}</div>
-          <div className="timeline-stat-label">📊 Plots</div>
+          <div className="timeline-stat-label">Plots</div>
         </div>
 
         <div className="timeline-stat">
           <div className="timeline-stat-value">{stats.totalErrors}</div>
-          <div className="timeline-stat-label">❌ Errors</div>
+          <div className="timeline-stat-label">Errors</div>
         </div>
 
         <div className="timeline-stat">

--- a/client/src/core/menu/menuConfig.ts
+++ b/client/src/core/menu/menuConfig.ts
@@ -51,7 +51,7 @@ export function buildMenuSections(snapshot: MenuStateSnapshot): MenuSection[] {
         { type: 'separator' },
         {
           id: 'edit:ai-assist',
-          label: '💡 Ask AI Assistant...',
+          label: 'Ask AI Assistant...',
           shortcut: '⌘K',
           action: () => menuActions.edit.aiAssist(),
           prominent: true,

--- a/client/src/css/components/ai-panel.css
+++ b/client/src/css/components/ai-panel.css
@@ -1,45 +1,41 @@
 .ai-panel .panel-content {
   display: flex;
   flex-direction: column;
-  background: inherit;
-  border: none;
-}
-
-:root[data-theme="phylo"] .ai-panel .panel-content,
-.ai-panel .panel-content {
-  background: #ffffff;
+  background: var(--bg-primary);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 8px;
 }
 
 .ai-mode-selector {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.15);
-  margin: 0 18px 12px;
+  gap: 4px;
+  padding: 2px;
+  border-radius: 6px;
+  background: var(--bg-secondary, #e3e6ed);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  margin: 0;
 }
 
 .ai-mode-selector button {
   border: none;
   background: transparent;
-  padding: 6px 14px;
-  border-radius: 999px;
+  padding: 6px 12px;
+  border-radius: 4px;
   font-size: 12px;
   font-weight: 600;
   color: var(--text-muted);
   cursor: pointer;
-  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 .ai-mode-selector button.active {
-  background: #ffffff;
+  background: var(--bg-primary);
   color: var(--text-primary);
-  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
 }
 
 .ai-mode-selector button:focus-visible {
-  outline: 2px solid var(--accent-blue);
+  outline: 1px solid var(--accent-blue);
 }
 
 .ai-messages {
@@ -49,9 +45,10 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  background: #ffffff;
-  border-radius: 16px;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+  background: var(--bg-primary);
+  border-radius: 6px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: none;
 }
 
 .ai-welcome {
@@ -62,10 +59,10 @@
   height: 100%;
   text-align: center;
   color: var(--text-secondary);
-  padding: 32px;
-  border-radius: 16px;
-  border: 1px dashed rgba(148, 163, 184, 0.28);
-  background-color: #ffffff;
+  padding: 28px;
+  border-radius: 6px;
+  border: 1px dashed rgba(15, 23, 42, 0.15);
+  background-color: var(--bg-secondary, #f4f6fb);
 }
 
 .ai-welcome h3 {
@@ -118,33 +115,30 @@
 
 .message-user {
   align-self: flex-end;
-  background: linear-gradient(180deg, rgba(47, 111, 237, 0.92), rgba(37, 87, 200, 0.92));
-  color: white;
+  background: var(--bg-secondary, #e9edf5);
+  color: var(--text-primary);
   padding: 10px 14px;
-  border-radius: 16px 16px 4px 16px;
-  box-shadow: 0 12px 24px rgba(47, 111, 237, 0.28);
+  border-radius: 8px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: none;
 }
 
 .message-assistant {
   align-self: flex-start;
-  background: rgba(255, 255, 255, 0.78);
+  background: var(--bg-primary);
   padding: 12px 16px;
-  border-radius: 16px 16px 16px 4px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.08);
+  border-radius: 8px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: none;
 }
 
 .message-header {
   font-size: 11px;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--text-muted);
   margin-bottom: 4px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-}
-
-.message-assistant .message-header {
-  color: var(--text-muted);
 }
 
 .message-content {
@@ -183,8 +177,8 @@
   display: flex;
   gap: 12px;
   padding: 14px 18px;
-  border-top: 1px solid rgba(148, 163, 184, 0.22);
-  background: linear-gradient(180deg, rgba(244, 246, 251, 0.95), rgba(236, 240, 250, 0.95));
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  background: var(--bg-primary);
   align-items: flex-end;
 }
 
@@ -193,11 +187,21 @@
   flex: 1;
 }
 
+.prompt-actions {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-primary);
+}
+
 .ai-input {
   width: 100%;
-  padding: 10px 44px 10px 12px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  border-radius: 12px;
+  padding: 10px 12px 58px 12px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 8px;
   background-color: var(--bg-primary);
   color: var(--text-primary);
   font-size: 12px;
@@ -206,12 +210,12 @@
   min-height: 60px;
   max-height: 220px;
   line-height: 1.5;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  box-shadow: none;
 }
 
 .ai-input:focus {
-  outline: 2px solid rgba(47, 111, 237, 0.25);
-  border-color: var(--accent-blue);
+  outline: 2px solid rgba(47, 111, 237, 0.18);
+  border-color: rgba(47, 111, 237, 0.4);
 }
 
 .ai-input::placeholder {
@@ -220,32 +224,27 @@
 }
 
 .send-icon-button {
-  position: absolute;
-  bottom: 10px;
-  right: 10px;
   width: 32px;
   height: 32px;
-  border-radius: 8px;
-  border: none;
-  background: var(--accent-blue);
-  color: white;
+  border-radius: 4px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: var(--bg-secondary, #eef1f6);
+  color: var(--text-primary);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  box-shadow: 0 8px 16px rgba(47, 111, 237, 0.3);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
 .send-icon-button:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 22px rgba(47, 111, 237, 0.35);
+  background: var(--bg-toolbar, #dce1ec);
+  border-color: rgba(15, 23, 42, 0.25);
 }
 
 .send-icon-button:disabled {
-  opacity: 0.55;
+  opacity: 0.6;
   cursor: not-allowed;
-  box-shadow: none;
 }
 
 .btn-stop {

--- a/client/src/css/components/ai-panel.css
+++ b/client/src/css/components/ai-panel.css
@@ -10,6 +10,38 @@
   background: #ffffff;
 }
 
+.ai-mode-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  margin: 0 18px 12px;
+}
+
+.ai-mode-selector button {
+  border: none;
+  background: transparent;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.ai-mode-selector button.active {
+  background: #ffffff;
+  color: var(--text-primary);
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
+}
+
+.ai-mode-selector button:focus-visible {
+  outline: 2px solid var(--accent-blue);
+}
+
 .ai-messages {
   flex: 1;
   overflow-y: auto;
@@ -149,15 +181,21 @@
 
 .ai-input-container {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   padding: 14px 18px;
   border-top: 1px solid rgba(148, 163, 184, 0.22);
   background: linear-gradient(180deg, rgba(244, 246, 251, 0.95), rgba(236, 240, 250, 0.95));
+  align-items: flex-end;
+}
+
+.prompt-input-container {
+  position: relative;
+  flex: 1;
 }
 
 .ai-input {
-  flex: 1;
-  padding: 10px 12px;
+  width: 100%;
+  padding: 10px 44px 10px 12px;
   border: 1px solid rgba(148, 163, 184, 0.4);
   border-radius: 12px;
   background-color: var(--bg-primary);
@@ -179,6 +217,35 @@
 .ai-input::placeholder {
   color: var(--text-muted);
   opacity: 0.9;
+}
+
+.send-icon-button {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: none;
+  background: var(--accent-blue);
+  color: white;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(47, 111, 237, 0.3);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.send-icon-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(47, 111, 237, 0.35);
+}
+
+.send-icon-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .btn-stop {

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -282,12 +282,14 @@ export function useAIConversation() {
 
     const cleanup = registerStreamingHandlers(requestId);
 
+    const enableTools = mode === 'agent';
+
     const sent = socketService.send({
       type: 'ai_message',
       request_id: requestId,
       stream: true,
       messages: requestMessages,
-      enable_tools: true,
+      enable_tools: enableTools,
       mode,
     });
 

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -4,7 +4,7 @@ import { socketService } from '@/services/socket';
 import { extractCodeBlocks } from '@/core/ai/codeBlockUtils';
 import { applyCodeChangeFile } from '@/services/fileService';
 import { buildPromptWithContext, createRequestId, REMOTE_FILE_ACTIONS } from '@/core/ai/promptUtils';
-import type { AIMessage, CodeBlock } from '@shared/types';
+import type { AIMessage, AIMode, CodeBlock } from '@shared/types';
 
 const STREAM_TIMEOUT_MS = 45000;
 
@@ -249,7 +249,7 @@ export function useAIConversation() {
     }
   }, [clearActiveRequest, clearTimeoutRef, completeStreamingMessage, postAssistantMessage, setAILoading]);
 
-  const handleAsk = useCallback((): void => {
+  const handleAsk = useCallback((mode: AIMode = 'agent'): void => {
     if (!input.trim()) {
       return;
     }
@@ -288,6 +288,7 @@ export function useAIConversation() {
       stream: true,
       messages: requestMessages,
       enable_tools: true,
+      mode,
     });
 
     if (!sent) {

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -64,6 +64,24 @@ context_after_line
 
 Each diff block should match the actual code exactly and avoid re-sending entire files."#;
 
+const CHAT_SYSTEM_PROMPT: &str = r#"You are the Re-prod chat assistant. Focus on providing explanations, guidance, and high-level suggestions.
+- Keep responses conversational and concise
+- Avoid emitting structured patches or code diffs unless explicitly asked
+- When referencing code, quote only the relevant snippets"#;
+
+#[derive(Clone, Copy, Debug, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum AIMode {
+    Agent,
+    Chat,
+}
+
+impl Default for AIMode {
+    fn default() -> Self {
+        Self::Agent
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub r_executor: Arc<Mutex<RExecutor>>,
@@ -76,16 +94,26 @@ pub struct AppState {
     pub request_counter: Arc<AtomicU64>,
 }
 
-fn with_system_prompts(messages: &[ChatMessage]) -> Vec<ChatMessage> {
+fn with_system_prompts(messages: &[ChatMessage], mode: AIMode) -> Vec<ChatMessage> {
     let mut result = Vec::with_capacity(messages.len() + 2);
-    result.push(ChatMessage {
-        role: "system".to_string(),
-        content: PATCH_SYSTEM_PROMPT.to_string(),
-    });
-    result.push(ChatMessage {
-        role: "system".to_string(),
-        content: RANGE_SYSTEM_PROMPT.to_string(),
-    });
+    match mode {
+        AIMode::Agent => {
+            result.push(ChatMessage {
+                role: "system".to_string(),
+                content: PATCH_SYSTEM_PROMPT.to_string(),
+            });
+            result.push(ChatMessage {
+                role: "system".to_string(),
+                content: RANGE_SYSTEM_PROMPT.to_string(),
+            });
+        }
+        AIMode::Chat => {
+            result.push(ChatMessage {
+                role: "system".to_string(),
+                content: CHAT_SYSTEM_PROMPT.to_string(),
+            });
+        }
+    }
     result.extend(messages.iter().cloned());
     result
 }
@@ -133,6 +161,8 @@ enum WSRequest {
         request_id: Option<String>,
         #[serde(default)]
         stream: bool,
+        #[serde(default)]
+        mode: AIMode,
     },
     #[serde(rename = "list_tools")]
     ListTools,
@@ -271,6 +301,7 @@ async fn handle_ws_request(request: WSRequest, state: &AppState) -> Vec<WSRespon
             enable_tools,
             request_id,
             stream,
+            mode,
         } => {
             let cfg = state.config.lock().await.clone();
             let provider = ai::from_config(&cfg);
@@ -281,7 +312,7 @@ async fn handle_ws_request(request: WSRequest, state: &AppState) -> Vec<WSRespon
             let mut outbound = Vec::new();
 
             // Prepend system prompts
-            let messages_with_prompts = with_system_prompts(&messages);
+            let messages_with_prompts = with_system_prompts(&messages, mode);
 
             if enable_tools {
                 let mut tools = get_filesystem_tools();
@@ -338,7 +369,7 @@ async fn handle_ws_request(request: WSRequest, state: &AppState) -> Vec<WSRespon
                                 });
                             }
 
-                            let follow_up_with_prompts = with_system_prompts(&follow_up_messages);
+                            let follow_up_with_prompts = with_system_prompts(&follow_up_messages, mode);
                             match provider.send_message(follow_up_with_prompts).await {
                                 Ok(final_response) => {
                                     outbound.extend(build_streaming_payload(
@@ -370,7 +401,7 @@ async fn handle_ws_request(request: WSRequest, state: &AppState) -> Vec<WSRespon
                     }],
                 }
             } else {
-                match provider.send_message(messages_with_prompts).await {
+                        match provider.send_message(messages_with_prompts).await {
                     Ok(response) => {
                         outbound.extend(build_streaming_payload(
                             stream,
@@ -689,7 +720,7 @@ mod tests {
             content: "request".to_string(),
         }];
 
-        let prefixed = with_system_prompts(&messages);
+        let prefixed = with_system_prompts(&messages, AIMode::Agent);
 
         assert_eq!(prefixed.len(), messages.len() + 2);
         assert_eq!(prefixed[0].role, "system");

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -127,8 +127,8 @@ async fn main() {
         .await
         .unwrap_or_else(|e| panic!("Failed to bind to {}: {}", addr, e));
 
-    tracing::info!("🚀 Re-prod server running on http://{}", addr);
-    tracing::info!("📡 WebSocket available at ws://{}/ws", addr);
+    tracing::info!("Re-prod server running on http://{}", addr);
+    tracing::info!("WebSocket available at ws://{}/ws", addr);
 
     axum::serve(listener, app)
         .await

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -33,6 +33,8 @@ export type ArtifactInfoPayload = ProtocolArtifactInfo;
 export type ToolExecutionRequestPayload = ProtocolToolExecutionRequest;
 export type ToolExecutionResultPayload = ProtocolToolExecutionResult;
 
+export type AIMode = 'agent' | 'chat';
+
 // UI-facing execution log structures
 export interface ExecutionLogPlot {
   id: string;

--- a/shared/src/ws.ts
+++ b/shared/src/ws.ts
@@ -1,5 +1,6 @@
 import type { ToolManifest } from './tools';
 import type {
+  AIMode,
   ChatMessagePayload,
   CodeBlock,
   ExecutionRequestPayload,
@@ -48,6 +49,7 @@ export type ClientMessage =
       enable_tools?: boolean;
       request_id?: string;
       stream?: boolean;
+      mode?: AIMode;
     }
   | { type: 'list_tools' }
   | ({ type: 'execute_tool' } & ToolExecutionRequestPayload)


### PR DESCRIPTION

• ## Description

  Adds a VSCode-style mode selector to the AI Assistant, wires the selected mode through the client and shared
  protocol, and teaches the backend to interpret it with distinct system prompts for agent vs. chat interactions.
  Replaces the text “Send” button with an icon anchored inside the prompt textarea for a more modern UX.

  ## Related Issue

  Closes #82

  ## Changes

  - Add `AIMode` state/UI in `AIPanel`, update placeholder strings, and convert the send action to an icon button
  positioned within the textarea.
  - Extend `useAIConversation`, shared websocket types, and server handlers so each AI request carries the mode and
  receives the appropriate system prompt (patch/diff for agent, conversational for chat).

  ## Testing

  Ran automated frontend tests.

  **Test results:**
  - [x] Frontend tests pass (`pnpm --filter client test -- --run`)
  - [x] Backend tests pass (`cargo test`)
  - [x] Frontend lint passes (`pnpm --filter client run lint`)
  - [x] Backend clippy passes (`cargo clippy`)
  - [x] Backend formatting passes (`cargo fmt --check`)
  - [x] Manual testing completed

  ## Checklist

  - [x] This PR addresses an existing issue or was pre-approved by @ShinyaYoshida-biomet
  - [x] Code follows project conventions
  - [ ] Tests added or updated for new functionality
  - [ ] Documentation updated (if needed)

  ## Screenshots (if applicable)