### PR TITLE
style(modal): add phylo theme and remove unused options in project manager

### DIFF
--- a/client/src/components/modals/ProjectManagerModal.tsx
+++ b/client/src/components/modals/ProjectManagerModal.tsx
@@ -1,5 +1,4 @@
-import { useMemo, useState } from 'react';
-import type { ProjectRecord } from 'shared';
+import { useState } from 'react';
 
 import { useStore } from '@/core';
 import { persistCurrentProjectState } from '@/hooks/useProjectSession';
@@ -13,22 +12,12 @@ interface ProjectManagerModalProps {
 
 export function ProjectManagerModal({ open, onClose }: ProjectManagerModalProps): JSX.Element | null {
   const currentProject = useStore((state) => state.project);
-  const projects = useStore((state) => state.projects);
   const [newProjectName, setNewProjectName] = useState('New Project');
   const [newProjectPath, setNewProjectPath] = useState('');
-  const [existingPath, setExistingPath] = useState('');
   const [cloneRemote, setCloneRemote] = useState('');
   const [clonePath, setClonePath] = useState('');
   const [cloneName, setCloneName] = useState('');
   const [error, setError] = useState<string | null>(null);
-
-  const sortedProjects = useMemo<ProjectRecord[]>(() => {
-    return [...projects].sort((a, b) => {
-      const aTime = a.last_opened_at ?? 0;
-      const bTime = b.last_opened_at ?? 0;
-      return bTime - aTime;
-    });
-  }, [projects]);
 
   if (!open) {
     return null;
@@ -51,16 +40,6 @@ export function ProjectManagerModal({ open, onClose }: ProjectManagerModalProps)
     projectService.create({ name: newProjectName.trim(), path: newProjectPath.trim() });
   };
 
-  const handleAddExisting = () => {
-    if (!existingPath.trim()) {
-      setError('Provide a directory path.');
-      return;
-    }
-    setError(null);
-    persistCurrentProjectState();
-    projectService.addExisting(existingPath.trim());
-  };
-
   const handleClone = () => {
     if (!cloneRemote.trim() || !clonePath.trim()) {
       setError('Remote URL and destination path are required.');
@@ -80,7 +59,7 @@ export function ProjectManagerModal({ open, onClose }: ProjectManagerModalProps)
       open={open}
       onClose={onClose}
       title="Projects"
-      subtitle="Switch between recent projects or create new isolated workspaces."
+      subtitle="Create new isolated workspaces or clone from version control."
       maxWidth={800}
     >
       <div className="project-manager">
@@ -99,32 +78,6 @@ export function ProjectManagerModal({ open, onClose }: ProjectManagerModalProps)
             </div>
           ) : (
             <p>No project selected.</p>
-          )}
-        </section>
-
-        <section className="project-manager-section">
-          <div className="section-header">
-            <h3>Recent Projects</h3>
-            <button type="button" className="btn btn-link" onClick={() => projectService.requestList()}>
-              Refresh List
-            </button>
-          </div>
-          {sortedProjects.length === 0 ? (
-            <p>No recent projects yet.</p>
-          ) : (
-            <ul className="project-list">
-              {sortedProjects.map((project) => (
-                <li key={project.id} className="project-card">
-                  <div>
-                    <strong>{project.name}</strong>
-                    <p className="muted">{project.path}</p>
-                  </div>
-                  <button type="button" className="btn" onClick={() => handleProjectOpen(project.id)}>
-                    Open
-                  </button>
-                </li>
-              ))}
-            </ul>
           )}
         </section>
 
@@ -151,22 +104,6 @@ export function ProjectManagerModal({ open, onClose }: ProjectManagerModalProps)
           </div>
           <button type="button" className="btn btn-primary" onClick={handleCreate}>
             Create Project
-          </button>
-        </section>
-
-        <section className="project-manager-section">
-          <h3>Add Existing Directory</h3>
-          <label>
-            Directory Path
-            <input
-              type="text"
-              placeholder="/path/to/existing/project"
-              value={existingPath}
-              onChange={(event) => setExistingPath(event.target.value)}
-            />
-          </label>
-          <button type="button" className="btn" onClick={handleAddExisting}>
-            Add Project
           </button>
         </section>
 

--- a/client/src/css/components/modal-dialog.css
+++ b/client/src/css/components/modal-dialog.css
@@ -815,3 +815,65 @@
 [data-theme="phylo"] .settings-number-input input[type="range"] {
   accent-color: #3b82f6;
 }
+
+/* Project Manager Modal */
+[data-theme="phylo"] .project-manager-section {
+  background: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  border-radius: 3px;
+  padding: 12px;
+}
+
+[data-theme="phylo"] .project-manager-section h3 {
+  color: #333333;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+[data-theme="phylo"] .project-card {
+  border-bottom: 1px solid #e0e0e0;
+  padding: 8px 0;
+}
+
+[data-theme="phylo"] .project-card strong {
+  font-size: 12px;
+  color: #333333;
+}
+
+[data-theme="phylo"] .project-card .muted {
+  color: #666666;
+  font-size: 11px;
+}
+
+[data-theme="phylo"] .project-manager input {
+  background: #ffffff;
+  border: 1px solid #cccccc;
+  border-radius: 3px;
+  color: #333333;
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+[data-theme="phylo"] .project-manager input:focus {
+  outline: 1px solid #3b82f6;
+  outline-offset: -1px;
+}
+
+[data-theme="phylo"] .alert-error {
+  background: #fee2e2;
+  border: 1px solid #ef4444;
+  color: #991b1b;
+  border-radius: 3px;
+  font-size: 12px;
+  padding: 8px 12px;
+}
+
+[data-theme="phylo"] .project-manager .btn-link {
+  color: #3b82f6;
+  font-size: 11px;
+  text-decoration: none;
+}
+
+[data-theme="phylo"] .project-manager .btn-link:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Description

This PR updates the `ProjectManagerModal` to support the `phylo` theme, ensuring it matches the application's RStudio-inspired flat design (light background, sharp corners). It also removes the "Recent Projects" and "Add Existing Directory" sections to simplify the interface as requested.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

Verified that the modal opens correctly with the new styles in `phylo` theme.
Verified that "Create New Project" and "Clone" options still function.
Verified that removed sections are no longer visible.
