### PR TITLE
refactor: move system prompts to core/src/ai/constants.rs

### DIFF
--- a/core/src/ai/constants.rs
+++ b/core/src/ai/constants.rs
@@ -1,2 +1,38 @@
 pub const PROVIDER_OPENAI: &str = "openai";
 pub const PROVIDER_ANTHROPIC: &str = "anthropic";
+
+pub const PATCH_SYSTEM_PROMPT: &str = r#"You are the Re-prod assistant. When suggesting code changes,
+always emit them in the structured patch format shown below, and include three lines of
+context before and after each chunk:
+
+*** Begin Patch
+*** Update File: analysis.R
+@@
+  # context line
+- old_line
++ new_line
+  # more context
+*** End Patch
+
+Rules:
+1. Wrap every suggestion in a patch block (`*** Begin Patch` / `*** End Patch`).
+2. Use `Update File`, `Add File`, or `Delete File` to describe the target path.
+3. Include `@@` markers to show the function/section context.
+4. Prefix removed lines with `-` and added lines with `+`.
+5. Keep the patch as narrow as possible—do not resend the entire file unless it truly must be replaced.
+6. When context matching may fail, include the original snippet under `-` lines so the client can locate it.
+"#;
+
+pub const RANGE_SYSTEM_PROMPT: &str = r#"In addition to structured patches, provide a concise diff-style block for each change
+using '-' for removed lines and '+' for added lines. Include at least two unprefixed
+context lines both before and after the +/- lines so the editor can locate the change.
+Example:
+
+context_before_line
+context_before_line
+- old_line
++ new_line
+context_after_line
+context_after_line
+
+Each diff block should match the actual code exactly and avoid re-sending entire files."#;

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -10,42 +10,6 @@ use reprod_core::{
     ToolManifest,
 };
 
-const PATCH_SYSTEM_PROMPT: &str = r#"You are the Re-prod assistant. When suggesting code changes,
-always emit them in the structured patch format shown below, and include three lines of
-context before and after each chunk:
-
-*** Begin Patch
-*** Update File: analysis.R
-@@
-  # context line
-- old_line
-+ new_line
-  # more context
-*** End Patch
-
-Rules:
-1. Wrap every suggestion in a patch block (`*** Begin Patch` / `*** End Patch`).
-2. Use `Update File`, `Add File`, or `Delete File` to describe the target path.
-3. Include `@@` markers to show the function/section context.
-4. Prefix removed lines with `-` and added lines with `+`.
-5. Keep the patch as narrow as possible—do not resend the entire file unless it truly must be replaced.
-6. When context matching may fail, include the original snippet under `-` lines so the client can locate it.
-"#;
-
-const RANGE_SYSTEM_PROMPT: &str = r#"In addition to structured patches, provide a concise diff-style block for each change
-using '-' for removed lines and '+' for added lines. Include at least two unprefixed
-context lines both before and after the +/- lines so the editor can locate the change.
-Example:
-
-context_before_line
-context_before_line
-- old_line
-+ new_line
-context_after_line
-context_after_line
-
-Each diff block should match the actual code exactly and avoid re-sending entire files."#;
-
 pub async fn health() -> &'static str {
     "OK"
 }
@@ -70,11 +34,11 @@ pub async fn send_ai_message(
     let mut messages = Vec::with_capacity(payload.messages.len() + 2);
     messages.push(ChatMessage {
         role: "system".to_string(),
-        content: PATCH_SYSTEM_PROMPT.to_string(),
+        content: ai::PATCH_SYSTEM_PROMPT.to_string(),
     });
     messages.push(ChatMessage {
         role: "system".to_string(),
-        content: RANGE_SYSTEM_PROMPT.to_string(),
+        content: ai::RANGE_SYSTEM_PROMPT.to_string(),
     });
     messages.extend(payload.messages.into_iter());
 


### PR DESCRIPTION
## Description

Refactors the AI system prompts (`PATCH_SYSTEM_PROMPT` and `RANGE_SYSTEM_PROMPT`) by moving them from `server/src/routes.rs` (formerly handlers) to `core/src/ai/constants.rs`. This centralizes AI-related constants and improves maintainability.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (non-breaking change)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`cargo check` passes)
- [ ] Documentation updated (not needed)

## Related Issues

Closes #98
