### PR TITLE
feat: enable ai assistant to read console output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 ## Commit & Pull Request Guidelines
 - Adopt conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:` followed by a short description and optional `(#issue)` when applicable.
 - Every PR should explain what changed, why it matters, how it was implemented, and what tests were run; link to the tracked issue or discussion and include screenshots when UI behavior changes.
+- Fill out `.github/pull_request_template.md` for every PR (check the right boxes and list the tests you actually ran).
 - Husky’s pre-push hook enforces formatting/linting; fix the reported issues locally rather than bypassing with `git push --no-verify`.
 - Branch naming/checkout: always create/switch feature branches as `git switch -c feature/issue-<number>-<slug>` (issue number + name), e.g., `git switch -c feature/issue-126-enable-ai-assistant-to-read-console-output`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 - Adopt conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:` followed by a short description and optional `(#issue)` when applicable.
 - Every PR should explain what changed, why it matters, how it was implemented, and what tests were run; link to the tracked issue or discussion and include screenshots when UI behavior changes.
 - Husky’s pre-push hook enforces formatting/linting; fix the reported issues locally rather than bypassing with `git push --no-verify`.
+- Branch naming/checkout: always create/switch feature branches as `git switch -c feature/issue-<number>-<slug>` (issue number + name), e.g., `git switch -c feature/issue-126-enable-ai-assistant-to-read-console-output`.
 
 ## Husky Hooks & Configuration Tips
 - Husky auto-installs once `pnpm install` completes; the pre-push hook runs `cargo fmt --check`, `cargo clippy`, and `pnpm run lint`.

--- a/client/src/core/ai/promptUtils.ts
+++ b/client/src/core/ai/promptUtils.ts
@@ -1,8 +1,48 @@
+import type { ExecutionLogEntry } from '@shared/types';
+
 /**
  * Set of code change actions that should be applied to remote files
  * rather than the current editor buffer
  */
 export const REMOTE_FILE_ACTIONS = new Set(['create-file', 'delete-range', 'replace-range']);
+
+const MAX_CONSOLE_ITEMS = 3;
+const MAX_CONSOLE_SNIPPET_LENGTH = 800;
+
+const truncateText = (value: string, maxLength: number): string =>
+  value.length > maxLength ? `${value.slice(0, maxLength)}... (truncated)` : value;
+
+const formatConsoleEntry = (entry: ExecutionLogEntry): string => {
+  const lines = [
+    `- [${new Date(entry.timestamp).toLocaleString()}] ${entry.success ? 'success' : 'error'} in ${entry.duration}ms`,
+  ];
+
+  if (entry.stdout?.trim()) {
+    lines.push(`stdout: ${truncateText(entry.stdout.trim(), MAX_CONSOLE_SNIPPET_LENGTH)}`);
+  }
+
+  if (entry.stderr?.trim()) {
+    lines.push(`stderr: ${truncateText(entry.stderr.trim(), MAX_CONSOLE_SNIPPET_LENGTH)}`);
+  }
+
+  if (entry.plots.length > 0) {
+    const plotPaths = entry.plots.map((plot) => plot.path).filter(Boolean);
+    const suffix = plotPaths.length ? ` (${plotPaths.slice(0, 3).join(', ')})` : '';
+    lines.push(`plots: ${entry.plots.length}${suffix}`);
+  }
+
+  return lines.join('\n');
+};
+
+const buildConsoleContext = (history: ExecutionLogEntry[] = []): string => {
+  if (history.length === 0) {
+    return '';
+  }
+
+  const recent = history.slice(-MAX_CONSOLE_ITEMS).reverse();
+  const formatted = recent.map(formatConsoleEntry).join('\n\n');
+  return `Recent console output (newest first, truncated):\n${formatted}\n\n`;
+};
 
 /**
  * Builds a prompt string that includes the current file context
@@ -12,9 +52,11 @@ export const buildPromptWithContext = (
   filepath: string,
   editorContent: string,
   userInput: string,
+  consoleHistory: ExecutionLogEntry[] = [],
 ): string => {
   const fileLabel = filepath || 'current editor buffer';
-  return `Current file (${fileLabel}):\n\n\`\`\`r\n${editorContent}\n\`\`\`\n\n${userInput}`;
+  const consoleContext = buildConsoleContext(consoleHistory);
+  return `${consoleContext}Current file (${fileLabel}):\n\n\`\`\`r\n${editorContent}\n\`\`\`\n\n${userInput}`;
 };
 
 /**

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -19,6 +19,7 @@ export function useAIConversation() {
   const completeStreamingMessage = useStore((state) => state.completeStreamingMessage);
   const editorContent = useStore((state) => state.editor.content);
   const editorFilepath = useStore((state) => state.editor.filepath);
+  const consoleHistory = useStore((state) => state.execution.results);
 
   const { clearTimeoutRef, startTimeout } = useAITimeout();
   const { registerStreamingHandlers } = useAIStreaming();
@@ -88,7 +89,10 @@ export function useAIConversation() {
 
       const requestMessages = [
         ...messages.map((message) => ({ role: message.role, content: message.content })),
-        { role: 'user' as const, content: buildPromptWithContext(editorFilepath, editorContent, input) },
+        {
+          role: 'user' as const,
+          content: buildPromptWithContext(editorFilepath, editorContent, input, consoleHistory),
+        },
       ];
 
       const requestId = createRequestId();
@@ -144,6 +148,7 @@ export function useAIConversation() {
       clearActiveRequest,
       clearTimeoutRef,
       completeStreamingMessage,
+      consoleHistory,
       editorContent,
       editorFilepath,
       input,

--- a/core/src/ai/tools/console.rs
+++ b/core/src/ai/tools/console.rs
@@ -153,6 +153,7 @@ mod tests {
         CodeBlockKind, CodeBlockMetadata, EnvironmentSnapshot, ExecutionActor, ExecutionContext,
         ExecutionResult, PlotInfo,
     };
+    use crate::timeline::TimelineSink;
 
     fn build_event(event_id: &str, created_at_ms: u64) -> ExecutionEvent {
         ExecutionEvent {

--- a/core/src/ai/tools/console.rs
+++ b/core/src/ai/tools/console.rs
@@ -32,18 +32,19 @@ pub struct ConsoleLogSummary {
 }
 
 impl ConsoleLogSummary {
-    fn from_event(event: ExecutionEvent, max_chars: usize) -> Self {
+    fn from_event(event: &ExecutionEvent, max_chars: usize) -> Self {
         Self {
             created_at_ms: event.created_at_ms,
             success: event.result.success,
-            source: source_to_string(event.context.source),
-            document_path: event.context.document_path,
+            source: source_to_string(&event.context.source),
+            document_path: event.context.document_path.clone(),
             duration_ms: event.result.execution_time_ms,
-            code: truncate(&collect_code(&event), max_chars),
+            code: truncate(&collect_code(event), max_chars),
             output: truncate(event.result.output.trim(), max_chars),
             error: event
                 .result
                 .error
+                .as_ref()
                 .map(|err| truncate(err.trim(), max_chars)),
             plot_count: event.result.plots.len(),
         }
@@ -68,7 +69,7 @@ fn truncate(text: &str, max_chars: usize) -> String {
     format!("{}... (truncated)", truncated)
 }
 
-fn source_to_string(source: ExecutionSource) -> String {
+fn source_to_string(source: &ExecutionSource) -> String {
     match source {
         ExecutionSource::Selection => "selection",
         ExecutionSource::Cell => "cell",
@@ -79,14 +80,13 @@ fn source_to_string(source: ExecutionSource) -> String {
 }
 
 fn clamp_limit(limit: Option<u32>) -> u32 {
-    limit.unwrap_or(DEFAULT_LIMIT).max(1).min(MAX_LIMIT)
+    limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT)
 }
 
 fn clamp_max_chars(max_chars: Option<usize>) -> usize {
     max_chars
         .unwrap_or(DEFAULT_MAX_CHARS)
-        .max(200)
-        .min(MAX_ALLOWED_CHARS)
+        .clamp(200, MAX_ALLOWED_CHARS)
 }
 
 pub fn fetch_console_logs(
@@ -110,7 +110,7 @@ pub fn fetch_console_logs(
     let summaries = response
         .events
         .into_iter()
-        .map(|event| ConsoleLogSummary::from_event(event, max_chars))
+        .map(|event| ConsoleLogSummary::from_event(&event, max_chars))
         .collect();
 
     Ok(summaries)

--- a/core/src/ai/tools/console.rs
+++ b/core/src/ai/tools/console.rs
@@ -1,0 +1,242 @@
+use crate::{
+    executor::timeline::{SortOrder, TimelineQuery},
+    protocol::{ExecutionEvent, ExecutionSource},
+    timeline::JsonTimeline,
+    ReprodError,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const DEFAULT_LIMIT: u32 = 5;
+const MAX_LIMIT: u32 = 20;
+const DEFAULT_MAX_CHARS: usize = 1200;
+const MAX_ALLOWED_CHARS: usize = 4000;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetConsoleLogsRequest {
+    pub limit: Option<u32>,
+    pub max_chars_per_entry: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ConsoleLogSummary {
+    pub created_at_ms: u64,
+    pub success: bool,
+    pub source: String,
+    pub document_path: Option<String>,
+    pub duration_ms: u64,
+    pub code: String,
+    pub output: String,
+    pub error: Option<String>,
+    pub plot_count: usize,
+}
+
+impl ConsoleLogSummary {
+    fn from_event(event: ExecutionEvent, max_chars: usize) -> Self {
+        Self {
+            created_at_ms: event.created_at_ms,
+            success: event.result.success,
+            source: source_to_string(event.context.source),
+            document_path: event.context.document_path,
+            duration_ms: event.result.execution_time_ms,
+            code: truncate(&collect_code(&event), max_chars),
+            output: truncate(event.result.output.trim(), max_chars),
+            error: event
+                .result
+                .error
+                .map(|err| truncate(err.trim(), max_chars)),
+            plot_count: event.result.plots.len(),
+        }
+    }
+}
+
+fn collect_code(event: &ExecutionEvent) -> String {
+    event
+        .blocks
+        .iter()
+        .map(|block| block.code.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn truncate(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+
+    let truncated: String = text.chars().take(max_chars).collect();
+    format!("{}... (truncated)", truncated)
+}
+
+fn source_to_string(source: ExecutionSource) -> String {
+    match source {
+        ExecutionSource::Selection => "selection",
+        ExecutionSource::Cell => "cell",
+        ExecutionSource::WholeDocument => "whole_document",
+        ExecutionSource::Unknown => "unknown",
+    }
+    .to_string()
+}
+
+fn clamp_limit(limit: Option<u32>) -> u32 {
+    limit.unwrap_or(DEFAULT_LIMIT).max(1).min(MAX_LIMIT)
+}
+
+fn clamp_max_chars(max_chars: Option<usize>) -> usize {
+    max_chars
+        .unwrap_or(DEFAULT_MAX_CHARS)
+        .max(200)
+        .min(MAX_ALLOWED_CHARS)
+}
+
+pub fn fetch_console_logs(
+    timeline: &JsonTimeline,
+    request: &GetConsoleLogsRequest,
+) -> Result<Vec<ConsoleLogSummary>, ReprodError> {
+    let limit = clamp_limit(request.limit);
+    let max_chars = clamp_max_chars(request.max_chars_per_entry);
+
+    let query = TimelineQuery {
+        filters: None,
+        sort: Some(SortOrder::Desc),
+        limit: Some(limit),
+        offset: None,
+    };
+
+    let response = timeline
+        .query(query)
+        .map_err(|e| ReprodError::IOError(format!("Timeline query failed: {}", e)))?;
+
+    let summaries = response
+        .events
+        .into_iter()
+        .map(|event| ConsoleLogSummary::from_event(event, max_chars))
+        .collect();
+
+    Ok(summaries)
+}
+
+/// Tool definitions for AI provider to access console output.
+pub fn get_console_tools() -> Vec<Value> {
+    serde_json::json!([
+        {
+            "name": "get_recent_console_logs",
+            "description": "Fetch recent R console outputs (stdout, stderr, plots count) from the execution timeline. Newest first and truncated for brevity.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 20,
+                        "description": "Number of recent execution entries to return. Defaults to 5."
+                    },
+                    "max_chars_per_entry": {
+                        "type": "integer",
+                        "minimum": 200,
+                        "maximum": 4000,
+                        "description": "Maximum characters to include for code and output fields per entry. Defaults to 1200."
+                    }
+                }
+            }
+        }
+    ])
+    .as_array()
+    .expect("get_console_tools: json! array literal should always be an array")
+    .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{
+        CodeBlockKind, CodeBlockMetadata, EnvironmentSnapshot, ExecutionActor, ExecutionContext,
+        ExecutionResult, PlotInfo,
+    };
+
+    fn build_event(event_id: &str, created_at_ms: u64) -> ExecutionEvent {
+        ExecutionEvent {
+            event_id: event_id.to_string(),
+            context: ExecutionContext {
+                source: ExecutionSource::Cell,
+                document_path: Some("analysis.R".to_string()),
+                cell_index: Some(0),
+                triggered_at_ms: created_at_ms,
+                actor: ExecutionActor::User,
+            },
+            blocks: vec![CodeBlockMetadata {
+                id: "block-1".to_string(),
+                index: 0,
+                kind: CodeBlockKind::Section,
+                label: Some("Test".to_string()),
+                start_line: 1,
+                end_line: 2,
+                code: "print('ok')".to_string(),
+            }],
+            result: ExecutionResult {
+                success: true,
+                output: "line one\nline two".to_string(),
+                error: None,
+                plots: vec![PlotInfo {
+                    filename: "plot.png".to_string(),
+                    base64_data: "data".to_string(),
+                    index: 0,
+                }],
+                execution_time_ms: 123,
+            },
+            environment: EnvironmentSnapshot {
+                r_path: "Rscript".to_string(),
+                working_dir: "/tmp".to_string(),
+                temp_dir: "/tmp/reprod".to_string(),
+            },
+            created_at_ms,
+        }
+    }
+
+    #[tokio::test]
+    async fn fetches_recent_logs_with_defaults() {
+        let timeline = JsonTimeline::new_in_memory().expect("create timeline");
+        timeline
+            .record(build_event("evt-1", 10))
+            .await
+            .expect("record");
+        timeline
+            .record(build_event("evt-2", 20))
+            .await
+            .expect("record");
+
+        let logs = fetch_console_logs(
+            &timeline,
+            &GetConsoleLogsRequest {
+                limit: None,
+                max_chars_per_entry: None,
+            },
+        )
+        .expect("fetch logs");
+
+        assert_eq!(logs.len(), 2);
+        assert_eq!(logs[0].created_at_ms, 20);
+        assert_eq!(logs[0].plot_count, 1);
+    }
+
+    #[tokio::test]
+    async fn applies_truncation() {
+        let timeline = JsonTimeline::new_in_memory().expect("create timeline");
+        let mut event = build_event("evt-1", 30);
+        event.result.output = "abcdefg".repeat(300);
+        timeline.record(event).await.expect("record");
+
+        let logs = fetch_console_logs(
+            &timeline,
+            &GetConsoleLogsRequest {
+                limit: Some(1),
+                max_chars_per_entry: Some(50),
+            },
+        )
+        .expect("fetch logs");
+
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].output.ends_with("(truncated)"));
+        assert!(logs[0].output.len() <= 64); // 50 chars + suffix
+    }
+}

--- a/core/src/ai/tools/console.rs
+++ b/core/src/ai/tools/console.rs
@@ -66,7 +66,7 @@ fn truncate(text: &str, max_chars: usize) -> String {
     }
 
     let truncated: String = text.chars().take(max_chars).collect();
-    format!("{}... (truncated)", truncated)
+    format!("{}...(truncated)", truncated)
 }
 
 fn source_to_string(source: &ExecutionSource) -> String {
@@ -86,7 +86,7 @@ fn clamp_limit(limit: Option<u32>) -> u32 {
 fn clamp_max_chars(max_chars: Option<usize>) -> usize {
     max_chars
         .unwrap_or(DEFAULT_MAX_CHARS)
-        .clamp(200, MAX_ALLOWED_CHARS)
+        .clamp(1, MAX_ALLOWED_CHARS)
 }
 
 pub fn fetch_console_logs(
@@ -133,7 +133,7 @@ pub fn get_console_tools() -> Vec<Value> {
                     },
                     "max_chars_per_entry": {
                         "type": "integer",
-                        "minimum": 200,
+                        "minimum": 1,
                         "maximum": 4000,
                         "description": "Maximum characters to include for code and output fields per entry. Defaults to 1200."
                     }

--- a/core/src/ai/tools/mod.rs
+++ b/core/src/ai/tools/mod.rs
@@ -1,6 +1,10 @@
+mod console;
 mod filesystem;
 mod r_context;
 
+pub use console::{
+    fetch_console_logs, get_console_tools, ConsoleLogSummary, GetConsoleLogsRequest,
+};
 pub use filesystem::{
     get_filesystem_tools, FileInfo, FileSystemTool, ListFilesRequest, ReadFileRequest,
     WriteFileRequest,

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -4,7 +4,7 @@ use crate::projects::ProjectRuntime;
 use reprod_core::{
     ai::{
         self,
-        tools::{get_filesystem_tools, get_r_context_tools},
+        tools::{get_console_tools, get_filesystem_tools, get_r_context_tools},
     },
     ChatMessage,
 };
@@ -38,6 +38,7 @@ pub(super) async fn handle_ai_message(
     if enable_tools {
         let mut tools = get_filesystem_tools();
         tools.extend(get_r_context_tools());
+        tools.extend(get_console_tools());
         let mut outbound = Vec::new();
 
         match provider

--- a/server/src/handlers/tool_handler.rs
+++ b/server/src/handlers/tool_handler.rs
@@ -119,6 +119,15 @@ pub(super) async fn execute_ai_tool_call(
                 })
                 .map_err(|e| e.to_string())
         }
+        "get_recent_console_logs" => {
+            let request: GetConsoleLogsRequest = serde_json::from_value(tool_call.input.clone())
+                .map_err(|e| format!("Invalid request: {}", e))?;
+
+            let logs = fetch_console_logs(runtime.timeline.as_ref(), &request)
+                .map_err(|e| e.to_string())?;
+
+            serde_json::to_string(&logs).map_err(|e| e.to_string())
+        }
         _ => Err(format!("Unknown tool: {}", tool_call.name)),
     }
 }


### PR DESCRIPTION
## Summary
- add console log AI tool wired into tool list/handler
- include recent console output in AI prompts and pass execution history
- document branch naming convention for feature branches

## Testing
- cargo fmt --manifest-path core/Cargo.toml
- cargo clippy --manifest-path core/Cargo.toml --lib --all-features
- pnpm run lint (pre-push TS lint)

## Issue

Close #126