### PR TITLE
fix: Persist loaded R packages between executions

### DIFF
--- a/core/src/ai/tools/console.rs
+++ b/core/src/ai/tools/console.rs
@@ -32,18 +32,19 @@ pub struct ConsoleLogSummary {
 }
 
 impl ConsoleLogSummary {
-    fn from_event(event: ExecutionEvent, max_chars: usize) -> Self {
+    fn from_event(event: &ExecutionEvent, max_chars: usize) -> Self {
         Self {
             created_at_ms: event.created_at_ms,
             success: event.result.success,
-            source: source_to_string(event.context.source),
-            document_path: event.context.document_path,
+            source: source_to_string(event.context.source.clone()),
+            document_path: event.context.document_path.clone(),
             duration_ms: event.result.execution_time_ms,
-            code: truncate(&collect_code(&event), max_chars),
+            code: truncate(&collect_code(event), max_chars),
             output: truncate(event.result.output.trim(), max_chars),
             error: event
                 .result
                 .error
+                .as_ref() // Use as_ref() to borrow the Option content
                 .map(|err| truncate(err.trim(), max_chars)),
             plot_count: event.result.plots.len(),
         }
@@ -110,7 +111,7 @@ pub fn fetch_console_logs(
     let summaries = response
         .events
         .into_iter()
-        .map(|event| ConsoleLogSummary::from_event(event, max_chars))
+        .map(|event| ConsoleLogSummary::from_event(&event, max_chars))
         .collect();
 
     Ok(summaries)

--- a/core/src/executor/r_executor.rs
+++ b/core/src/executor/r_executor.rs
@@ -186,6 +186,7 @@ impl RExecutor {
 # Auto-generated plot capture wrapper
 .reprod_plot_dir <- "{temp_dir}"
 .reprod_state_path <- file.path(.reprod_plot_dir, ".reprod_state.RData")
+.reprod_packages_path <- file.path(.reprod_plot_dir, ".reprod_packages.rds")
 
 # Ensure plot directory exists
 if (!dir.exists(.reprod_plot_dir)) {{
@@ -200,10 +201,29 @@ if (file.exists(.reprod_state_path)) {{
   )
 }}
 
+# Restore loaded packages if it exists
+if (file.exists(.reprod_packages_path)) {{
+  tryCatch(
+    {{
+      pkgs <- readRDS(.reprod_packages_path)
+      # Filter out base packages that are always loaded
+      base_pkgs <- c("stats", "graphics", "grDevices", "utils", "datasets", "methods", "base")
+      pkgs <- setdiff(pkgs, base_pkgs)
+      for (pkg in pkgs) {{
+        if (!require(pkg, character.only = TRUE, quietly = TRUE)) {{
+          message("Warning: Failed to restore package: ", pkg)
+        }}
+      }}
+    }},
+    error = function(e) message("Failed to restore packages: ", e)
+  )
+}}
+
 # Reset run-scoped state to avoid stale values from previous sessions
 .reprod_plot_dir <- "{temp_dir}"
 .reprod_plot_prefix <- "{plot_prefix}"
 .reprod_state_path <- file.path(.reprod_plot_dir, ".reprod_state.RData")
+.reprod_packages_path <- file.path(.reprod_plot_dir, ".reprod_packages.rds")
 .reprod_exit_code <- 0
 
 # Open PNG device
@@ -257,6 +277,15 @@ try({{
 tryCatch(
   save.image(file = .reprod_state_path),
   error = function(e) message("Failed to save workspace: ", e)
+)
+
+# Persist loaded packages for next run
+tryCatch(
+  {{
+    pkgs <- .packages()
+    saveRDS(pkgs, file = .reprod_packages_path)
+  }},
+  error = function(e) message("Failed to save packages: ", e)
 )
 
 quit(status = .reprod_exit_code, runLast = FALSE)


### PR DESCRIPTION
## Description

This PR addresses issue #139 by ensuring that loaded R packages persist across non-consecutive code selections.

The solution modifies the `wrap_code_with_plot_capture` function in `core/src/executor/r_executor.rs` to:
- Save the currently loaded R packages to a `.reprod_packages.rds` file at the end of each execution.
- Load these packages from the `.reprod_packages.rds` file at the beginning of subsequent executions, filtering out base R packages to avoid warnings.

This provides a more RStudio-like experience where `library()` calls in one selection are remembered for later selections, fixing the reported bug.

Also includes minor fixes to `core/src/ai/tools/console.rs` to correctly handle `ExecutionEvent` references and cloning, resolving compilation errors introduced by recent type changes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`cargo check`)
- [ ] New tests added for new features/bug fixes (R code changes are difficult to unit test at this level; manual verification is key)
- [ ] Documentation updated (N/A)

## Testing

1.  Open an R file in the editor.
2.  Select and run `library(changepoint)` (or any other installable package).
3.  Select and run `cpt.mean(data)` (assuming `data` is defined or loaded elsewhere, or use a simple function from the package).
4.  Verify that `cpt.mean` executes successfully, indicating the `changepoint` package was loaded persistently.
5.  Repeat with other packages or scenarios where state needs to persist.

## Related Issues

Closes #139
