### PR TITLE
feat: Set up Biome auto-formatter with pre-commit hook (#138)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Pre-commit hook for Re-prod project
+# This hook runs before git commit to format code
+#
+# Managed by Husky - see package.json prepare script
+# To bypass this hook (not recommended), use: git commit --no-verify
+#
+
+set -e
+
+echo "🎨 Running pre-commit checks..."
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Track if any checks fail
+FAILED=0
+
+# Function to print status
+print_status() {
+    if [ $1 -eq 0 ]; then
+        echo -e "${GREEN}✓${NC} $2"
+    else
+        echo -e "${RED}✗${NC} $2"
+        FAILED=1
+    fi
+}
+
+# Get staged files
+STAGED_TS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx|json)$' || true)
+STAGED_RS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.rs$' || true)
+
+# Check 1: Format TypeScript/JavaScript/JSON files with Biome
+if [ -n "$STAGED_TS_FILES" ]; then
+    echo -e "${YELLOW}[1/2]${NC} Formatting TypeScript/JavaScript/JSON with Biome..."
+    # Only format, skip linting in pre-commit (linting happens in pre-push)
+    if echo "$STAGED_TS_FILES" | xargs pnpm biome format --write --no-errors-on-unmatched; then
+        print_status 0 "Biome formatting applied"
+        # Re-add formatted files
+        echo "$STAGED_TS_FILES" | xargs git add
+    else
+        print_status 1 "Biome formatting failed"
+        echo "  → Check the errors above"
+        echo ""
+    fi
+else
+    echo -e "${YELLOW}[1/2]${NC} No TypeScript/JavaScript/JSON files to format"
+fi
+
+# Check 2: Format Rust files
+if [ -n "$STAGED_RS_FILES" ]; then
+    echo -e "${YELLOW}[2/2]${NC} Formatting Rust code..."
+    if cargo fmt --manifest-path core/Cargo.toml; then
+        print_status 0 "Rust formatting applied"
+        # Re-add formatted files
+        echo "$STAGED_RS_FILES" | xargs git add
+    else
+        print_status 1 "Rust formatting failed"
+        echo "  → Check the errors above"
+        echo ""
+    fi
+else
+    echo -e "${YELLOW}[2/2]${NC} No Rust files to format"
+fi
+
+# Summary
+echo ""
+if [ $FAILED -eq 0 ]; then
+    echo -e "${GREEN}✓ All pre-commit checks passed!${NC}"
+    echo "📝 Proceeding with commit..."
+    exit 0
+else
+    echo -e "${RED}✗ Pre-commit checks failed!${NC}"
+    echo ""
+    echo "Please fix the issues above before committing."
+    echo "To bypass this check (not recommended), use: git commit --no-verify"
+    exit 1
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -31,8 +31,18 @@ print_status() {
     fi
 }
 
-# Check 1: Rust formatting
-echo -e "${YELLOW}[1/3]${NC} Checking Rust formatting..."
+# Check 1: Biome formatting check
+echo -e "${YELLOW}[1/4]${NC} Checking Biome formatting..."
+if pnpm biome format > /dev/null 2>&1; then
+    print_status 0 "Biome formatting check passed"
+else
+    print_status 1 "Biome formatting issues found"
+    echo "  → Run 'pnpm format' to fix formatting"
+    echo ""
+fi
+
+# Check 2: Rust formatting
+echo -e "${YELLOW}[2/4]${NC} Checking Rust formatting..."
 if cargo fmt --check --manifest-path core/Cargo.toml > /dev/null 2>&1; then
     print_status 0 "Rust code is properly formatted"
 else
@@ -41,8 +51,8 @@ else
     echo ""
 fi
 
-# Check 2: Rust linting with Clippy
-echo -e "${YELLOW}[2/3]${NC} Running Rust linter (clippy)..."
+# Check 3: Rust linting with Clippy
+echo -e "${YELLOW}[3/4]${NC} Running Rust linter (clippy)..."
 if cargo clippy --manifest-path core/Cargo.toml --lib --all-features 2>&1 | grep -q "^error\[E"; then
     print_status 1 "Clippy found compilation errors"
     echo "  → Run 'cargo clippy' to see details"
@@ -51,8 +61,8 @@ else
     print_status 0 "Clippy checks passed (warnings allowed)"
 fi
 
-# Check 3: TypeScript/JavaScript linting
-echo -e "${YELLOW}[3/3]${NC} Running TypeScript linter..."
+# Check 4: TypeScript/JavaScript linting
+echo -e "${YELLOW}[4/4]${NC} Running TypeScript linter..."
 if pnpm run lint > /dev/null 2>&1; then
     print_status 0 "TypeScript/JavaScript linting passed"
 else

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.3.7/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"ignoreUnknown": false
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"lineWidth": 100
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"suspicious": {
+				"noExplicitAny": "warn"
+			},
+			"a11y": {
+				"noLabelWithoutControl": "warn"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,38 +1,38 @@
 {
-  "name": "client",
-  "version": "0.1.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build",
-    "preview": "vite preview",
-    "type-check": "tsc --noEmit",
-    "lint": "tsc --noEmit",
-    "test": "vitest"
-  },
-  "dependencies": {
-    "@monaco-editor/react": "^4.6.0",
-    "@tauri-apps/api": "^2",
-    "@xterm/addon-fit": "^0.10.0",
-    "@xterm/addon-web-links": "^0.11.0",
-    "@xterm/xterm": "^5.3.0",
-    "allotment": "^1.20.0",
-    "monaco-editor": "^0.54.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "zustand": "^4.4.7"
-  },
-  "devDependencies": {
-    "@testing-library/jest-dom": "^6.9.1",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^14.6.1",
-    "@types/react": "^18.2.45",
-    "@types/react-dom": "^18.2.18",
-    "@vitejs/plugin-react": "^4.2.1",
-    "jsdom": "^24.1.3",
-    "typescript": "^5.3.3",
-    "vite": "^5.0.8",
-    "vitest": "^4.0.1"
-  }
+	"name": "client",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "vite",
+		"build": "tsc && vite build",
+		"preview": "vite preview",
+		"type-check": "tsc --noEmit",
+		"lint": "tsc --noEmit",
+		"test": "vitest"
+	},
+	"dependencies": {
+		"@monaco-editor/react": "^4.6.0",
+		"@tauri-apps/api": "^2",
+		"@xterm/addon-fit": "^0.10.0",
+		"@xterm/addon-web-links": "^0.11.0",
+		"@xterm/xterm": "^5.3.0",
+		"allotment": "^1.20.0",
+		"monaco-editor": "^0.54.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"zustand": "^4.4.7"
+	},
+	"devDependencies": {
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/react": "^16.3.0",
+		"@testing-library/user-event": "^14.6.1",
+		"@types/react": "^18.2.45",
+		"@types/react-dom": "^18.2.18",
+		"@vitejs/plugin-react": "^4.2.1",
+		"jsdom": "^24.1.3",
+		"typescript": "^5.3.3",
+		"vite": "^5.0.8",
+		"vitest": "^4.0.1"
+	}
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,14 +1,20 @@
-import { useEffect, useState } from "react";
 import { Allotment } from "allotment";
+import { useEffect, useState } from "react";
 import "allotment/dist/style.css";
-import { MenuBar, StatusBar } from "@/components/menu";
-import { EditorPanel } from "@/components/editor";
 import { AIPanel } from "@/components/ai-panel";
 import { BottomPane } from "@/components/bottom-pane";
+import { EditorPanel } from "@/components/editor";
 import { ExportDialog } from "@/components/export";
-import { TimelineDialog } from "@/components/timeline";
 import { FileBrowserPane } from "@/components/file-browser/FileBrowserPane";
-import { AboutModal, KeyboardShortcutsModal, ProjectManagerModal, SessionInfoModal, SettingsModal } from "@/components/modals";
+import { MenuBar, StatusBar } from "@/components/menu";
+import {
+	AboutModal,
+	KeyboardShortcutsModal,
+	ProjectManagerModal,
+	SessionInfoModal,
+	SettingsModal,
+} from "@/components/modals";
+import { TimelineDialog } from "@/components/timeline";
 import { useStore } from "@/core";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useProjectSession } from "@/hooks/useProjectSession";
@@ -17,106 +23,91 @@ import { useSettingsPersistence } from "@/hooks/useSettingsPersistence";
 import { useSocketConnection } from "@/hooks/useSocketConnection";
 
 function App(): JSX.Element {
-  const panes = useStore((state) => state.view.panes);
-  const theme = useStore((state) => state.settings.theme);
-  const [exportDialogOpen, setExportDialogOpen] = useState(false);
-  const [timelineDialogOpen, setTimelineDialogOpen] = useState(false);
-  const [shortcutsOpen, setShortcutsOpen] = useState(false);
-  const [aboutOpen, setAboutOpen] = useState(false);
-  const [sessionInfoOpen, setSessionInfoOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [projectManagerOpen, setProjectManagerOpen] = useState(false);
+	const panes = useStore((state) => state.view.panes);
+	const theme = useStore((state) => state.settings.theme);
+	const [exportDialogOpen, setExportDialogOpen] = useState(false);
+	const [timelineDialogOpen, setTimelineDialogOpen] = useState(false);
+	const [shortcutsOpen, setShortcutsOpen] = useState(false);
+	const [aboutOpen, setAboutOpen] = useState(false);
+	const [sessionInfoOpen, setSessionInfoOpen] = useState(false);
+	const [settingsOpen, setSettingsOpen] = useState(false);
+	const [projectManagerOpen, setProjectManagerOpen] = useState(false);
 
-  // Enable global keyboard shortcuts
-  useKeyboardShortcuts();
-  useProjectSession();
-  useSocketConnection();
-  useSettingsPersistence();
-  useSessionControlEvents();
+	// Enable global keyboard shortcuts
+	useKeyboardShortcuts();
+	useProjectSession();
+	useSocketConnection();
+	useSettingsPersistence();
+	useSessionControlEvents();
 
-  useEffect(() => {
-    document.documentElement.dataset.theme = theme;
-  }, [theme]);
+	useEffect(() => {
+		document.documentElement.dataset.theme = theme;
+	}, [theme]);
 
-  useEffect(() => {
-    const globalScope = window as typeof window & Record<string, () => void>;
-    globalScope.openExportDialog = () => setExportDialogOpen(true);
-    globalScope.openTimelineDialog = () => setTimelineDialogOpen(true);
-    globalScope.openShortcutsDialog = () => setShortcutsOpen(true);
-    globalScope.openAboutDialog = () => setAboutOpen(true);
-    globalScope.openSessionInfoDialog = () => setSessionInfoOpen(true);
-    globalScope.openSettingsDialog = () => setSettingsOpen(true);
-    globalScope.openProjectsDialog = () => setProjectManagerOpen(true);
+	useEffect(() => {
+		const globalScope = window as typeof window & Record<string, () => void>;
+		globalScope.openExportDialog = () => setExportDialogOpen(true);
+		globalScope.openTimelineDialog = () => setTimelineDialogOpen(true);
+		globalScope.openShortcutsDialog = () => setShortcutsOpen(true);
+		globalScope.openAboutDialog = () => setAboutOpen(true);
+		globalScope.openSessionInfoDialog = () => setSessionInfoOpen(true);
+		globalScope.openSettingsDialog = () => setSettingsOpen(true);
+		globalScope.openProjectsDialog = () => setProjectManagerOpen(true);
 
-    return () => {
-      delete globalScope.openExportDialog;
-      delete globalScope.openTimelineDialog;
-      delete globalScope.openShortcutsDialog;
-      delete globalScope.openAboutDialog;
-      delete globalScope.openSessionInfoDialog;
-      delete globalScope.openSettingsDialog;
-      delete globalScope.openProjectsDialog;
-    };
-  }, []);
+		return () => {
+			delete globalScope.openExportDialog;
+			delete globalScope.openTimelineDialog;
+			delete globalScope.openShortcutsDialog;
+			delete globalScope.openAboutDialog;
+			delete globalScope.openSessionInfoDialog;
+			delete globalScope.openSettingsDialog;
+			delete globalScope.openProjectsDialog;
+		};
+	}, []);
 
-  return (
-    <div className="app">
-      <MenuBar />
-      <div className="workspace-shell">
-        <Allotment>
-          {panes.files && (
-            <Allotment.Pane minSize={220} preferredSize={240}>
-              <FileBrowserPane />
-            </Allotment.Pane>
-          )}
-          {/* Left side: Editor + Bottom Pane */}
-          <Allotment.Pane minSize={400} preferredSize="75%">
-            <Allotment vertical>
-              {panes.editor && (
-                <Allotment.Pane minSize={300} preferredSize="65%">
-                  <EditorPanel />
-                </Allotment.Pane>
-              )}
-              <Allotment.Pane
-                minSize={150}
-                preferredSize={panes.editor ? "35%" : "100%"}
-              >
-                <BottomPane />
-              </Allotment.Pane>
-            </Allotment>
-          </Allotment.Pane>
-          {/* Right side: AI Assistant (full height) */}
-          {panes.assistant && (
-            <Allotment.Pane minSize={260} preferredSize="25%">
-              <div className="ai-pane-wrapper">
-                <AIPanel />
-              </div>
-            </Allotment.Pane>
-          )}
-        </Allotment>
-      </div>
-      <StatusBar />
-      <ExportDialog
-        open={exportDialogOpen}
-        onClose={() => setExportDialogOpen(false)}
-      />
-      <TimelineDialog
-        open={timelineDialogOpen}
-        onClose={() => setTimelineDialogOpen(false)}
-      />
-      <KeyboardShortcutsModal
-        open={shortcutsOpen}
-        onClose={() => setShortcutsOpen(false)}
-      />
-      <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
-      <SessionInfoModal
-        open={sessionInfoOpen}
-        onClose={() => setSessionInfoOpen(false)}
-      />
-      <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
-      <ProjectManagerModal open={projectManagerOpen} onClose={() => setProjectManagerOpen(false)} />
-    </div>
-  );
+	return (
+		<div className="app">
+			<MenuBar />
+			<div className="workspace-shell">
+				<Allotment>
+					{panes.files && (
+						<Allotment.Pane minSize={220} preferredSize={240}>
+							<FileBrowserPane />
+						</Allotment.Pane>
+					)}
+					{/* Left side: Editor + Bottom Pane */}
+					<Allotment.Pane minSize={400} preferredSize="75%">
+						<Allotment vertical>
+							{panes.editor && (
+								<Allotment.Pane minSize={300} preferredSize="65%">
+									<EditorPanel />
+								</Allotment.Pane>
+							)}
+							<Allotment.Pane minSize={150} preferredSize={panes.editor ? "35%" : "100%"}>
+								<BottomPane />
+							</Allotment.Pane>
+						</Allotment>
+					</Allotment.Pane>
+					{/* Right side: AI Assistant (full height) */}
+					{panes.assistant && (
+						<Allotment.Pane minSize={260} preferredSize="25%">
+							<div className="ai-pane-wrapper">
+								<AIPanel />
+							</div>
+						</Allotment.Pane>
+					)}
+				</Allotment>
+			</div>
+			<StatusBar />
+			<ExportDialog open={exportDialogOpen} onClose={() => setExportDialogOpen(false)} />
+			<TimelineDialog open={timelineDialogOpen} onClose={() => setTimelineDialogOpen(false)} />
+			<KeyboardShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
+			<AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
+			<SessionInfoModal open={sessionInfoOpen} onClose={() => setSessionInfoOpen(false)} />
+			<SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+			<ProjectManagerModal open={projectManagerOpen} onClose={() => setProjectManagerOpen(false)} />
+		</div>
+	);
 }
 
 export default App;

--- a/client/src/assets/icons/definitions.ts
+++ b/client/src/assets/icons/definitions.ts
@@ -1,168 +1,215 @@
 export interface IconDefinition {
-  viewBox: string;
-  content: JSX.Element;
+	viewBox: string;
+	content: JSX.Element;
 }
 
 export const iconDefinitions = {
-  play: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'polygon', points: '6 4 19 12 6 20 6 4', fill: 'currentColor', stroke: 'none' }
-    ]
-  },
-  playCircle: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'circle', cx: 12, cy: 12, r: 10 },
-      { type: 'polygon', points: '10 8 16 12 10 16 10 8', fill: 'currentColor', stroke: 'none' }
-    ]
-  },
-  robot: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'rect', x: 4, y: 7, width: 16, height: 12, rx: 3, ry: 3 },
-      { type: 'circle', cx: 9, cy: 13, r: 1.6, fill: 'currentColor', stroke: 'none' },
-      { type: 'circle', cx: 15, cy: 13, r: 1.6, fill: 'currentColor', stroke: 'none' },
-      { type: 'path', d: 'M12 3v4' }
-    ]
-  },
-  send: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'polyline', points: '4 4 20 12 4 20 7 12 4 4' }
-    ]
-  },
-  plus: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'path', d: 'M12 5v14' },
-      { type: 'path', d: 'M5 12h14' }
-    ]
-  },
-  square: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'rect', x: 6, y: 6, width: 12, height: 12, rx: 2 }
-    ]
-  },
-  clipboard: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'rect', x: 6, y: 5, width: 12, height: 16, rx: 2 },
-      { type: 'path', d: 'M9 5V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v1' },
-      { type: 'rect', x: 9, y: 9, width: 6, height: 2, rx: 0.5, fill: 'currentColor', stroke: 'none' },
-      { type: 'rect', x: 9, y: 13, width: 6, height: 2, rx: 0.5, fill: 'currentColor', stroke: 'none', opacity: 0.6 }
-    ]
-  },
-  check: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'polyline', points: '5 12.5 10 17 19 7' }
-    ]
-  },
-  trash: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'path', d: 'M3 7h18' },
-      { type: 'path', d: 'M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2' },
-      { type: 'path', d: 'M9 11v6' },
-      { type: 'path', d: 'M12 11v6' },
-      { type: 'path', d: 'M15 11v6' },
-      { type: 'rect', x: 5, y: 7, width: 14, height: 13, rx: 2, ry: 2 }
-    ]
-  },
-  barChart: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'path', d: 'M4 20h16' },
-      { type: 'rect', x: 6, y: 10, width: 3, height: 7, rx: 1 },
-      { type: 'rect', x: 11, y: 6, width: 3, height: 11, rx: 1 },
-      { type: 'rect', x: 16, y: 8, width: 3, height: 9, rx: 1 }
-    ]
-  },
-  checkCircle: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'circle', cx: 12, cy: 12, r: 10 },
-      { type: 'polyline', points: '8 12 11 15 16 9' }
-    ]
-  },
-  xCircle: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'circle', cx: 12, cy: 12, r: 10 },
-      { type: 'line', x1: 9, y1: 9, x2: 15, y2: 15 },
-      { type: 'line', x1: 15, y1: 9, x2: 9, y2: 15 }
-    ]
-  },
-  chevronLeft: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'polyline', points: '15 18 9 12 15 6' }
-    ]
-  },
-  chevronRight: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'polyline', points: '9 18 15 12 9 6' }
-    ]
-  },
-  chevronDown: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'polyline', points: '6 9 12 15 18 9' }
-    ]
-  },
-  lightbulb: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'path', d: 'M9 18h6' },
-      { type: 'path', d: 'M10 22h4' },
-      { type: 'path', d: 'M12 2a7 7 0 0 0-7 7c0 2.6 1.4 4.4 3 6a5 5 0 0 1 1.4 3.1V19h5.2v-0.9c0-1.2.5-2.3 1.4-3.1 1.6-1.6 3-3.4 3-6a7 7 0 0 0-7-7z' }
-    ]
-  },
-  info: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'circle', cx: 12, cy: 12, r: 10 },
-      { type: 'line', x1: 12, y1: 10, x2: 12, y2: 16 },
-      { type: 'circle', cx: 12, cy: 7, r: 0.8, fill: 'currentColor', stroke: 'none' }
-    ]
-  },
-  settings: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'circle', cx: 12, cy: 12, r: 3 },
-      { type: 'path', d: 'M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.09a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.09a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.09a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z' }
-    ]
-  },
-  keyboard: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'rect', x: 3, y: 7, width: 18, height: 10, rx: 2 },
-      { type: 'path', d: 'M7 10h0' },
-      { type: 'path', d: 'M10 10h0' },
-      { type: 'path', d: 'M13 10h0' },
-      { type: 'path', d: 'M16 10h0' },
-      { type: 'path', d: 'M7 13h0' },
-      { type: 'path', d: 'M10 13h0' },
-      { type: 'path', d: 'M13 13h0' },
-      { type: 'path', d: 'M16 13.5h2' }
-    ]
-  },
-  refresh: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'polyline', points: '23 4 23 10 17 10' },
-      { type: 'polyline', points: '1 20 1 14 7 14' },
-      { type: 'path', d: 'M3.51 9a9 9 0 0 1 14.13-3.36L23 10' },
-      { type: 'path', d: 'M20.49 15a9 9 0 0 1-14.13 3.36L1 14' }
-    ]
-  },
-  folder: {
-    viewBox: '0 0 24 24',
-    paths: [
-      { type: 'path', d: 'M3 7h5l2 2h11a1 1 0 0 1 1 1v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a1 1 0 0 1 1-1z' }
-    ]
-  }
+	play: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{
+				type: "polygon",
+				points: "6 4 19 12 6 20 6 4",
+				fill: "currentColor",
+				stroke: "none",
+			},
+		],
+	},
+	playCircle: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "circle", cx: 12, cy: 12, r: 10 },
+			{
+				type: "polygon",
+				points: "10 8 16 12 10 16 10 8",
+				fill: "currentColor",
+				stroke: "none",
+			},
+		],
+	},
+	robot: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "rect", x: 4, y: 7, width: 16, height: 12, rx: 3, ry: 3 },
+			{
+				type: "circle",
+				cx: 9,
+				cy: 13,
+				r: 1.6,
+				fill: "currentColor",
+				stroke: "none",
+			},
+			{
+				type: "circle",
+				cx: 15,
+				cy: 13,
+				r: 1.6,
+				fill: "currentColor",
+				stroke: "none",
+			},
+			{ type: "path", d: "M12 3v4" },
+		],
+	},
+	send: {
+		viewBox: "0 0 24 24",
+		paths: [{ type: "polyline", points: "4 4 20 12 4 20 7 12 4 4" }],
+	},
+	plus: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "path", d: "M12 5v14" },
+			{ type: "path", d: "M5 12h14" },
+		],
+	},
+	square: {
+		viewBox: "0 0 24 24",
+		paths: [{ type: "rect", x: 6, y: 6, width: 12, height: 12, rx: 2 }],
+	},
+	clipboard: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "rect", x: 6, y: 5, width: 12, height: 16, rx: 2 },
+			{ type: "path", d: "M9 5V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v1" },
+			{
+				type: "rect",
+				x: 9,
+				y: 9,
+				width: 6,
+				height: 2,
+				rx: 0.5,
+				fill: "currentColor",
+				stroke: "none",
+			},
+			{
+				type: "rect",
+				x: 9,
+				y: 13,
+				width: 6,
+				height: 2,
+				rx: 0.5,
+				fill: "currentColor",
+				stroke: "none",
+				opacity: 0.6,
+			},
+		],
+	},
+	check: {
+		viewBox: "0 0 24 24",
+		paths: [{ type: "polyline", points: "5 12.5 10 17 19 7" }],
+	},
+	trash: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "path", d: "M3 7h18" },
+			{ type: "path", d: "M8 7V5a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" },
+			{ type: "path", d: "M9 11v6" },
+			{ type: "path", d: "M12 11v6" },
+			{ type: "path", d: "M15 11v6" },
+			{ type: "rect", x: 5, y: 7, width: 14, height: 13, rx: 2, ry: 2 },
+		],
+	},
+	barChart: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "path", d: "M4 20h16" },
+			{ type: "rect", x: 6, y: 10, width: 3, height: 7, rx: 1 },
+			{ type: "rect", x: 11, y: 6, width: 3, height: 11, rx: 1 },
+			{ type: "rect", x: 16, y: 8, width: 3, height: 9, rx: 1 },
+		],
+	},
+	checkCircle: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "circle", cx: 12, cy: 12, r: 10 },
+			{ type: "polyline", points: "8 12 11 15 16 9" },
+		],
+	},
+	xCircle: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "circle", cx: 12, cy: 12, r: 10 },
+			{ type: "line", x1: 9, y1: 9, x2: 15, y2: 15 },
+			{ type: "line", x1: 15, y1: 9, x2: 9, y2: 15 },
+		],
+	},
+	chevronLeft: {
+		viewBox: "0 0 24 24",
+		paths: [{ type: "polyline", points: "15 18 9 12 15 6" }],
+	},
+	chevronRight: {
+		viewBox: "0 0 24 24",
+		paths: [{ type: "polyline", points: "9 18 15 12 9 6" }],
+	},
+	chevronDown: {
+		viewBox: "0 0 24 24",
+		paths: [{ type: "polyline", points: "6 9 12 15 18 9" }],
+	},
+	lightbulb: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "path", d: "M9 18h6" },
+			{ type: "path", d: "M10 22h4" },
+			{
+				type: "path",
+				d: "M12 2a7 7 0 0 0-7 7c0 2.6 1.4 4.4 3 6a5 5 0 0 1 1.4 3.1V19h5.2v-0.9c0-1.2.5-2.3 1.4-3.1 1.6-1.6 3-3.4 3-6a7 7 0 0 0-7-7z",
+			},
+		],
+	},
+	info: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "circle", cx: 12, cy: 12, r: 10 },
+			{ type: "line", x1: 12, y1: 10, x2: 12, y2: 16 },
+			{
+				type: "circle",
+				cx: 12,
+				cy: 7,
+				r: 0.8,
+				fill: "currentColor",
+				stroke: "none",
+			},
+		],
+	},
+	settings: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "circle", cx: 12, cy: 12, r: 3 },
+			{
+				type: "path",
+				d: "M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.09a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.09a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.09a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z",
+			},
+		],
+	},
+	keyboard: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "rect", x: 3, y: 7, width: 18, height: 10, rx: 2 },
+			{ type: "path", d: "M7 10h0" },
+			{ type: "path", d: "M10 10h0" },
+			{ type: "path", d: "M13 10h0" },
+			{ type: "path", d: "M16 10h0" },
+			{ type: "path", d: "M7 13h0" },
+			{ type: "path", d: "M10 13h0" },
+			{ type: "path", d: "M13 13h0" },
+			{ type: "path", d: "M16 13.5h2" },
+		],
+	},
+	refresh: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{ type: "polyline", points: "23 4 23 10 17 10" },
+			{ type: "polyline", points: "1 20 1 14 7 14" },
+			{ type: "path", d: "M3.51 9a9 9 0 0 1 14.13-3.36L23 10" },
+			{ type: "path", d: "M20.49 15a9 9 0 0 1-14.13 3.36L1 14" },
+		],
+	},
+	folder: {
+		viewBox: "0 0 24 24",
+		paths: [
+			{
+				type: "path",
+				d: "M3 7h5l2 2h11a1 1 0 0 1 1 1v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a1 1 0 0 1 1-1z",
+			},
+		],
+	},
 } as const;

--- a/client/src/components/Terminal/TerminalPane.tsx
+++ b/client/src/components/Terminal/TerminalPane.tsx
@@ -1,143 +1,143 @@
-import { useCallback, useEffect, useMemo } from 'react';
-import { useRef } from 'react';
-import { PanelTabs } from '@/components/shared';
-import { IconPlus, IconXCircle } from '@/components/shared';
-import { useTerminal } from '@/hooks/useTerminal';
-import { TerminalSession } from './TerminalSession';
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { IconPlus, IconXCircle, PanelTabs } from "@/components/shared";
+import { useTerminal } from "@/hooks/useTerminal";
+import { TerminalSession } from "./TerminalSession";
 
-const TERMINAL_NEW_EVENT = 'terminal:new';
+const TERMINAL_NEW_EVENT = "terminal:new";
 
 export function TerminalPane(): JSX.Element {
-  const {
-    state,
-    isAvailable,
-    error,
-    errorDetail,
-    createSession,
-    closeSession,
-    setActiveSession,
-    writeToSession,
-    resizeSession,
-    registerOutputHandler,
-    unregisterOutputHandler,
-  } = useTerminal();
+	const {
+		state,
+		isAvailable,
+		error,
+		errorDetail,
+		createSession,
+		closeSession,
+		setActiveSession,
+		writeToSession,
+		resizeSession,
+		registerOutputHandler,
+		unregisterOutputHandler,
+	} = useTerminal();
 
-  const { sessions, activeSessionId } = state;
-  const didBootstrapRef = useRef(false);
+	const { sessions, activeSessionId } = state;
+	const didBootstrapRef = useRef(false);
 
-  const sessionTabs = useMemo(
-    () => sessions.map((session) => ({ id: session.id, label: session.title })),
-    [sessions]
-  );
+	const sessionTabs = useMemo(
+		() => sessions.map((session) => ({ id: session.id, label: session.title })),
+		[sessions],
+	);
 
-  useEffect(() => {
-    if (!isAvailable || didBootstrapRef.current) {
-      return;
-    }
+	useEffect(() => {
+		if (!isAvailable || didBootstrapRef.current) {
+			return;
+		}
 
-    if (sessions.length === 0) {
-      didBootstrapRef.current = true;
-      void createSession();
-    }
-  }, [isAvailable, sessions.length, createSession]);
+		if (sessions.length === 0) {
+			didBootstrapRef.current = true;
+			void createSession();
+		}
+	}, [isAvailable, sessions.length, createSession]);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
+	useEffect(() => {
+		if (typeof window === "undefined") {
+			return;
+		}
 
-    const handleNewSession = () => {
-      void createSession();
-    };
+		const handleNewSession = () => {
+			void createSession();
+		};
 
-    window.addEventListener(TERMINAL_NEW_EVENT, handleNewSession);
+		window.addEventListener(TERMINAL_NEW_EVENT, handleNewSession);
 
-    return () => {
-      window.removeEventListener(TERMINAL_NEW_EVENT, handleNewSession);
-    };
-  }, [createSession]);
+		return () => {
+			window.removeEventListener(TERMINAL_NEW_EVENT, handleNewSession);
+		};
+	}, [createSession]);
 
-  const handleCreateSession = useCallback(() => {
-    void createSession();
-  }, [createSession]);
+	const handleCreateSession = useCallback(() => {
+		void createSession();
+	}, [createSession]);
 
-  const handleCloseSession = useCallback(() => {
-    if (!activeSessionId) {
-      return;
-    }
+	const handleCloseSession = useCallback(() => {
+		if (!activeSessionId) {
+			return;
+		}
 
-    void closeSession(activeSessionId);
-  }, [activeSessionId, closeSession]);
+		void closeSession(activeSessionId);
+	}, [activeSessionId, closeSession]);
 
-  return (
-    <div className="terminal-pane">
-      <div className="terminal-pane__header">
-        {sessionTabs.length > 0 && (
-          <PanelTabs
-            items={sessionTabs}
-            activeId={activeSessionId ?? sessionTabs[0].id}
-            onSelect={setActiveSession}
-            className="terminal-pane__tabs panel-tabs--compact"
-          />
-        )}
-        <div className="terminal-pane__actions">
-          <button
-            className="btn btn-icon"
-            type="button"
-            title="New terminal session"
-            aria-label="New terminal session"
-            onClick={handleCreateSession}
-            disabled={!isAvailable}>
-            <IconPlus width={18} height={18} aria-hidden />
-          </button>
-          <button
-            className="btn btn-icon"
-            type="button"
-            title="Close terminal session"
-            aria-label="Close terminal session"
-            onClick={handleCloseSession}
-            disabled={!activeSessionId}>
-            <IconXCircle width={18} height={18} aria-hidden />
-          </button>
-        </div>
-      </div>
-      <div className="terminal-pane__content">
-        {error && (
-          <div className="alert alert-error mb-2">
-            <p>{error}</p>
-            {errorDetail && <p className="muted">{errorDetail}</p>}
-          </div>
-        )}
-        {!isAvailable && (
-          <div className="terminal-pane__empty">
-            <p>Terminal access is only available inside the desktop experience.</p>
-          </div>
-        )}
-        {isAvailable && sessionTabs.length === 0 && (
-          <div className="terminal-pane__empty">
-            <p>Starting terminal session...</p>
-          </div>
-        )}
-        {isAvailable && sessionTabs.length > 0 && (
-          <div className="terminal-pane__sessions">
-            {sessions.map((session) => (
-              <TerminalSession
-                key={session.id}
-                sessionId={session.id}
-                isActive={session.id === activeSessionId}
-                onInput={(data) => {
-                  void writeToSession(session.id, data);
-                }}
-                onResize={(cols, rows) => {
-                  void resizeSession(session.id, cols, rows);
-                }}
-                registerOutputHandler={registerOutputHandler}
-                unregisterOutputHandler={unregisterOutputHandler}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+	return (
+		<div className="terminal-pane">
+			<div className="terminal-pane__header">
+				{sessionTabs.length > 0 && (
+					<PanelTabs
+						items={sessionTabs}
+						activeId={activeSessionId ?? sessionTabs[0].id}
+						onSelect={setActiveSession}
+						className="terminal-pane__tabs panel-tabs--compact"
+					/>
+				)}
+				<div className="terminal-pane__actions">
+					<button
+						className="btn btn-icon"
+						type="button"
+						title="New terminal session"
+						aria-label="New terminal session"
+						onClick={handleCreateSession}
+						disabled={!isAvailable}
+					>
+						<IconPlus width={18} height={18} aria-hidden />
+					</button>
+					<button
+						className="btn btn-icon"
+						type="button"
+						title="Close terminal session"
+						aria-label="Close terminal session"
+						onClick={handleCloseSession}
+						disabled={!activeSessionId}
+					>
+						<IconXCircle width={18} height={18} aria-hidden />
+					</button>
+				</div>
+			</div>
+			<div className="terminal-pane__content">
+				{error && (
+					<div className="alert alert-error mb-2">
+						<p>{error}</p>
+						{errorDetail && <p className="muted">{errorDetail}</p>}
+					</div>
+				)}
+				{!isAvailable && (
+					<div className="terminal-pane__empty">
+						<p>Terminal access is only available inside the desktop experience.</p>
+					</div>
+				)}
+				{isAvailable && sessionTabs.length === 0 && (
+					<div className="terminal-pane__empty">
+						<p>Starting terminal session...</p>
+					</div>
+				)}
+				{isAvailable && sessionTabs.length > 0 && (
+					<div className="terminal-pane__sessions">
+						{sessions.map((session) => (
+							<TerminalSession
+								key={session.id}
+								sessionId={session.id}
+								isActive={session.id === activeSessionId}
+								onInput={(data) => {
+									void writeToSession(session.id, data);
+								}}
+								onResize={(cols, rows) => {
+									void resizeSession(session.id, cols, rows);
+								}}
+								registerOutputHandler={registerOutputHandler}
+								unregisterOutputHandler={unregisterOutputHandler}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/Terminal/TerminalSession.tsx
+++ b/client/src/components/Terminal/TerminalSession.tsx
@@ -1,67 +1,67 @@
-import { useCallback, useEffect, useRef } from 'react';
-import type { Terminal } from '@xterm/xterm';
-import { XTermWrapper } from './XTermWrapper';
+import type { Terminal } from "@xterm/xterm";
+import { useCallback, useEffect, useRef } from "react";
+import { XTermWrapper } from "./XTermWrapper";
 
 interface TerminalSessionProps {
-  sessionId: string;
-  isActive: boolean;
-  onInput: (value: string) => void;
-  onResize: (cols: number, rows: number) => void;
-  registerOutputHandler: (sessionId: string, handler: (chunk: string) => void) => void;
-  unregisterOutputHandler: (sessionId: string) => void;
+	sessionId: string;
+	isActive: boolean;
+	onInput: (value: string) => void;
+	onResize: (cols: number, rows: number) => void;
+	registerOutputHandler: (sessionId: string, handler: (chunk: string) => void) => void;
+	unregisterOutputHandler: (sessionId: string) => void;
 }
 
 export function TerminalSession({
-  sessionId,
-  isActive,
-  onInput,
-  onResize,
-  registerOutputHandler,
-  unregisterOutputHandler,
+	sessionId,
+	isActive,
+	onInput,
+	onResize,
+	registerOutputHandler,
+	unregisterOutputHandler,
 }: TerminalSessionProps): JSX.Element {
-  const termRef = useRef<Terminal | null>(null);
+	const termRef = useRef<Terminal | null>(null);
 
-  const handleReady = useCallback((term: Terminal) => {
-    termRef.current = term;
-  }, []);
+	const handleReady = useCallback((term: Terminal) => {
+		termRef.current = term;
+	}, []);
 
-  const handleTerminalOutput = useCallback((chunk: string) => {
-    const terminal = termRef.current;
-    if (!terminal) {
-      return;
-    }
+	const handleTerminalOutput = useCallback((chunk: string) => {
+		const terminal = termRef.current;
+		if (!terminal) {
+			return;
+		}
 
-    terminal.write(chunk);
-    terminal.scrollToBottom();
-  }, []);
+		terminal.write(chunk);
+		terminal.scrollToBottom();
+	}, []);
 
-  useEffect(() => {
-    registerOutputHandler(sessionId, handleTerminalOutput);
-    return () => {
-      unregisterOutputHandler(sessionId);
-    };
-  }, [sessionId, registerOutputHandler, unregisterOutputHandler, handleTerminalOutput]);
+	useEffect(() => {
+		registerOutputHandler(sessionId, handleTerminalOutput);
+		return () => {
+			unregisterOutputHandler(sessionId);
+		};
+	}, [sessionId, registerOutputHandler, unregisterOutputHandler, handleTerminalOutput]);
 
-  useEffect(() => {
-    if (isActive) {
-      termRef.current?.focus();
-    }
-  }, [isActive]);
+	useEffect(() => {
+		if (isActive) {
+			termRef.current?.focus();
+		}
+	}, [isActive]);
 
-  const className = [
-    'terminal-session',
-    isActive ? 'terminal-session--active' : 'terminal-session--inactive',
-  ].join(' ');
+	const className = [
+		"terminal-session",
+		isActive ? "terminal-session--active" : "terminal-session--inactive",
+	].join(" ");
 
-  return (
-    <div className={className}>
-      <XTermWrapper
-        className="terminal-session__term"
-        onInput={onInput}
-        onResize={onResize}
-        onReady={handleReady}
-        autoFocus={isActive}
-      />
-    </div>
-  );
+	return (
+		<div className={className}>
+			<XTermWrapper
+				className="terminal-session__term"
+				onInput={onInput}
+				onResize={onResize}
+				onReady={handleReady}
+				autoFocus={isActive}
+			/>
+		</div>
+	);
 }

--- a/client/src/components/Terminal/XTermWrapper.tsx
+++ b/client/src/components/Terminal/XTermWrapper.tsx
@@ -1,90 +1,91 @@
-import { useEffect, useRef } from 'react';
-import { Terminal } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
-import { WebLinksAddon } from '@xterm/addon-web-links';
-import '@xterm/xterm/css/xterm.css';
+import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import { Terminal } from "@xterm/xterm";
+import { useEffect, useRef } from "react";
+import "@xterm/xterm/css/xterm.css";
 
 interface XTermWrapperProps {
-  className?: string;
-  autoFocus?: boolean;
-  onInput?: (data: string) => void;
-  onResize?: (cols: number, rows: number) => void;
-  onReady?: (terminal: Terminal) => void;
+	className?: string;
+	autoFocus?: boolean;
+	onInput?: (data: string) => void;
+	onResize?: (cols: number, rows: number) => void;
+	onReady?: (terminal: Terminal) => void;
 }
 
 export function XTermWrapper({
-  className,
-  autoFocus = false,
-  onInput,
-  onResize,
-  onReady,
+	className,
+	autoFocus = false,
+	onInput,
+	onResize,
+	onReady,
 }: XTermWrapperProps): JSX.Element {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const termRef = useRef<Terminal | null>(null);
+	const containerRef = useRef<HTMLDivElement | null>(null);
+	const termRef = useRef<Terminal | null>(null);
 
-  useEffect(() => {
-    const element = containerRef.current;
+	useEffect(() => {
+		const element = containerRef.current;
 
-    if (!element) {
-      return;
-    }
+		if (!element) {
+			return;
+		}
 
-    const terminal = new Terminal({
-      convertEol: true,
-      cursorBlink: true,
-      fontFamily: 'Menlo, Monaco, Consolas, "Liberation Mono", monospace',
-      scrollback: 2000,
-      fontSize: 13,
-      theme: {
-        background: '#f6f7fb',
-        foreground: '#111827',
-        cursor: '#1d4ed8',
-        cursorAccent: '#f6f7fb',
-        selectionBackground: '#c7d2fe80',
-      },
-    });
+		const terminal = new Terminal({
+			convertEol: true,
+			cursorBlink: true,
+			fontFamily: 'Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+			scrollback: 2000,
+			fontSize: 13,
+			theme: {
+				background: "#f6f7fb",
+				foreground: "#111827",
+				cursor: "#1d4ed8",
+				cursorAccent: "#f6f7fb",
+				selectionBackground: "#c7d2fe80",
+			},
+		});
 
-    const fitAddon = new FitAddon();
-    terminal.loadAddon(fitAddon);
-    terminal.loadAddon(new WebLinksAddon());
-    terminal.open(element);
-    fitAddon.fit();
-    onResize?.(terminal.cols, terminal.rows);
-    // Show a subtle placeholder prompt until the real shell prompt arrives
-    terminal.write('\u001b[90mbash-5.2$ \u001b[0m');
+		const fitAddon = new FitAddon();
+		terminal.loadAddon(fitAddon);
+		terminal.loadAddon(new WebLinksAddon());
+		terminal.open(element);
+		fitAddon.fit();
+		onResize?.(terminal.cols, terminal.rows);
+		// Show a subtle placeholder prompt until the real shell prompt arrives
+		terminal.write("\u001b[90mbash-5.2$ \u001b[0m");
 
-    const inputListener = terminal.onData((data) => {
-      // Let backend/PTy handle echo to avoid double-echoing and maintain canonical behavior.
-      onInput?.(data);
-    });
+		const inputListener = terminal.onData((data) => {
+			// Let backend/PTy handle echo to avoid double-echoing and maintain canonical behavior.
+			onInput?.(data);
+		});
 
-    const handleResize = () => {
-      fitAddon.fit();
-      onResize?.(terminal.cols, terminal.rows);
-    };
+		const handleResize = () => {
+			fitAddon.fit();
+			onResize?.(terminal.cols, terminal.rows);
+		};
 
-    const observer = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(handleResize) : null;
-    observer?.observe(element);
+		const observer =
+			typeof ResizeObserver !== "undefined" ? new ResizeObserver(handleResize) : null;
+		observer?.observe(element);
 
-    if (autoFocus) {
-      terminal.focus();
-    }
+		if (autoFocus) {
+			terminal.focus();
+		}
 
-    termRef.current = terminal;
-    onReady?.(terminal);
+		termRef.current = terminal;
+		onReady?.(terminal);
 
-    return () => {
-      inputListener.dispose();
-      observer?.disconnect();
-      terminal.dispose();
-    };
-  }, [autoFocus, onInput, onResize, onReady]);
+		return () => {
+			inputListener.dispose();
+			observer?.disconnect();
+			terminal.dispose();
+		};
+	}, [autoFocus, onInput, onResize, onReady]);
 
-  useEffect(() => {
-    if (autoFocus) {
-      termRef.current?.focus();
-    }
-  }, [autoFocus]);
+	useEffect(() => {
+		if (autoFocus) {
+			termRef.current?.focus();
+		}
+	}, [autoFocus]);
 
-  return <div ref={containerRef} className={className ?? 'terminal-session__canvas'} />;
+	return <div ref={containerRef} className={className ?? "terminal-session__canvas"} />;
 }

--- a/client/src/components/Terminal/index.ts
+++ b/client/src/components/Terminal/index.ts
@@ -1,1 +1,1 @@
-export { TerminalPane } from './TerminalPane';
+export { TerminalPane } from "./TerminalPane";

--- a/client/src/components/ai-panel/AIPanel.tsx
+++ b/client/src/components/ai-panel/AIPanel.tsx
@@ -1,145 +1,136 @@
-import { useRef, useEffect, useState } from 'react';
-import type { AIMode } from '@shared/types';
-import { IconSend, IconSquare } from '@/components/shared';
-import { StreamingMessage } from './StreamingMessage';
-import { useAIConversation } from '@/hooks/useAIConversation';
-import { ProviderSwitcher } from './ProviderSwitcher';
+import type { AIMode } from "@shared/types";
+import { useEffect, useRef, useState } from "react";
+import { IconSend, IconSquare } from "@/components/shared";
+import { useAIConversation } from "@/hooks/useAIConversation";
+import { ProviderSwitcher } from "./ProviderSwitcher";
+import { StreamingMessage } from "./StreamingMessage";
 
 export function AIPanel(): JSX.Element {
-  const {
-    input,
-    setInput,
-    messages,
-    isLoading,
-    handleAsk,
-    handleStop,
-    handleApplyCode,
-  } = useAIConversation();
+	const { input, setInput, messages, isLoading, handleAsk, handleStop, handleApplyCode } =
+		useAIConversation();
 
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [messages]);
 
-  // Auto-resize textarea
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
+	// Auto-resize textarea
+	useEffect(() => {
+		const textarea = textareaRef.current;
+		if (!textarea) return;
 
-    const adjustHeight = () => {
-      textarea.style.height = 'auto';
-      textarea.style.height = `${Math.min(textarea.scrollHeight, 300)}px`;
-    };
+		const adjustHeight = () => {
+			textarea.style.height = "auto";
+			textarea.style.height = `${Math.min(textarea.scrollHeight, 300)}px`;
+		};
 
-    adjustHeight();
-    textarea.addEventListener('input', adjustHeight);
-    return () => textarea.removeEventListener('input', adjustHeight);
-  }, [input]);
+		adjustHeight();
+		textarea.addEventListener("input", adjustHeight);
+		return () => textarea.removeEventListener("input", adjustHeight);
+	}, [input]);
 
-  const [mode, setMode] = useState<AIMode>('agent');
-  const placeholder = mode === 'agent' ? 'Describe a task...' : 'Ask a question...';
+	const [mode, setMode] = useState<AIMode>("agent");
+	const placeholder = mode === "agent" ? "Describe a task..." : "Ask a question...";
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
-    if (e.key === 'Enter' && !e.shiftKey && !e.altKey && !e.metaKey) {
-      e.preventDefault();
-      handleAsk(mode);
-    }
-  };
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
+		if (e.key === "Enter" && !e.shiftKey && !e.altKey && !e.metaKey) {
+			e.preventDefault();
+			handleAsk(mode);
+		}
+	};
 
-  return (
-    <div className="panel ai-panel">
-      <div className="panel-header">
-        <div className="panel-title">AI Assistant</div>
-        <ProviderSwitcher />
-      </div>
-      <div className="panel-content">
-        <div className="ai-messages">
-          {messages.length === 0 ? (
-            <div className="ai-welcome">
-              <h3>AI Assistant</h3>
-              <p>Ask me anything about R programming, data analysis, or visualization.</p>
-            </div>
-          ) : (
-            <>
-              {messages.map((message) => (
-                message.role === 'assistant' ? (
-                  <StreamingMessage
-                    key={message.id}
-                    message={message}
-                    onApplyCode={handleApplyCode}
-                  />
-                ) : (
-                  <div key={message.id} className="message message-user">
-                    <div className="message-header">
-                      <span className="message-role">You</span>
-                    </div>
-                    <div className="message-content">
-                      {message.content}
-                    </div>
-                  </div>
-                )
-              ))}
-              <div ref={messagesEndRef} />
-            </>
-          )}
-        </div>
-        <div className="ai-input-container-wrapper">
-          <div className="ai-input-container vscode-style">
-            <textarea
-              ref={textareaRef}
-              className="ai-input"
-              placeholder={placeholder}
-              aria-label={placeholder}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              disabled={isLoading}
-              rows={5}
-            />
-            <div className="input-controls-bar">
-              <div className="input-controls-left">
-                <select
-                  className="mode-dropdown"
-                  value={mode}
-                  onChange={(e) => setMode(e.target.value as AIMode)}
-                  disabled={isLoading}
-                  aria-label="AI interaction mode"
-                >
-                  <option value="agent">Agent</option>
-                  <option value="chat">Chat</option>
-                </select>
-              </div>
-              <div className="input-controls-right">
-                {isLoading ? (
-                  <button
-                    type="button"
-                    className="icon-btn stop-btn"
-                    onClick={handleStop}
-                    title="Stop generation (Esc)"
-                    aria-label="Stop generation"
-                  >
-                    <IconSquare width={16} height={16} aria-hidden />
-                  </button>
-                ) : (
-                  <button
-                    type="button"
-                    className="send-btn"
-                    onClick={() => handleAsk(mode)}
-                    disabled={!input.trim()}
-                    title="Send message (Enter)"
-                    aria-label="Send message"
-                  >
-                    <IconSend width={16} height={16} aria-hidden />
-                    <span>Send</span>
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+	return (
+		<div className="panel ai-panel">
+			<div className="panel-header">
+				<div className="panel-title">AI Assistant</div>
+				<ProviderSwitcher />
+			</div>
+			<div className="panel-content">
+				<div className="ai-messages">
+					{messages.length === 0 ? (
+						<div className="ai-welcome">
+							<h3>AI Assistant</h3>
+							<p>Ask me anything about R programming, data analysis, or visualization.</p>
+						</div>
+					) : (
+						<>
+							{messages.map((message) =>
+								message.role === "assistant" ? (
+									<StreamingMessage
+										key={message.id}
+										message={message}
+										onApplyCode={handleApplyCode}
+									/>
+								) : (
+									<div key={message.id} className="message message-user">
+										<div className="message-header">
+											<span className="message-role">You</span>
+										</div>
+										<div className="message-content">{message.content}</div>
+									</div>
+								),
+							)}
+							<div ref={messagesEndRef} />
+						</>
+					)}
+				</div>
+				<div className="ai-input-container-wrapper">
+					<div className="ai-input-container vscode-style">
+						<textarea
+							ref={textareaRef}
+							className="ai-input"
+							placeholder={placeholder}
+							aria-label={placeholder}
+							value={input}
+							onChange={(e) => setInput(e.target.value)}
+							onKeyDown={handleKeyDown}
+							disabled={isLoading}
+							rows={5}
+						/>
+						<div className="input-controls-bar">
+							<div className="input-controls-left">
+								<select
+									className="mode-dropdown"
+									value={mode}
+									onChange={(e) => setMode(e.target.value as AIMode)}
+									disabled={isLoading}
+									aria-label="AI interaction mode"
+								>
+									<option value="agent">Agent</option>
+									<option value="chat">Chat</option>
+								</select>
+							</div>
+							<div className="input-controls-right">
+								{isLoading ? (
+									<button
+										type="button"
+										className="icon-btn stop-btn"
+										onClick={handleStop}
+										title="Stop generation (Esc)"
+										aria-label="Stop generation"
+									>
+										<IconSquare width={16} height={16} aria-hidden />
+									</button>
+								) : (
+									<button
+										type="button"
+										className="send-btn"
+										onClick={() => handleAsk(mode)}
+										disabled={!input.trim()}
+										title="Send message (Enter)"
+										aria-label="Send message"
+									>
+										<IconSend width={16} height={16} aria-hidden />
+										<span>Send</span>
+									</button>
+								)}
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/ai-panel/AIPlanCard.tsx
+++ b/client/src/components/ai-panel/AIPlanCard.tsx
@@ -1,32 +1,32 @@
-import type { PlanStep, PlanStepStatus } from '@shared/types';
+import type { PlanStep, PlanStepStatus } from "@shared/types";
 
 interface Props {
-  steps?: PlanStep[];
+	steps?: PlanStep[];
 }
 
 const STATUS_LABEL: Record<PlanStepStatus, string> = {
-  pending: '⏳ Pending',
-  running: '⚙️ Running',
-  done: '✅ Done',
-  error: '⚠️ Error',
+	pending: "⏳ Pending",
+	running: "⚙️ Running",
+	done: "✅ Done",
+	error: "⚠️ Error",
 };
 
 export function AIPlanCard({ steps }: Props): JSX.Element | null {
-  if (!steps || steps.length === 0) {
-    return null;
-  }
+	if (!steps || steps.length === 0) {
+		return null;
+	}
 
-  return (
-    <div className="ai-plan-card">
-      <div className="ai-plan-card__title">Plan</div>
-      <ol>
-        {steps.map((step) => (
-          <li key={step.id} data-status={step.status}>
-            <span className="ai-plan-card__status">{STATUS_LABEL[step.status]}</span>
-            <span className="ai-plan-card__text">{step.title}</span>
-          </li>
-        ))}
-      </ol>
-    </div>
-  );
+	return (
+		<div className="ai-plan-card">
+			<div className="ai-plan-card__title">Plan</div>
+			<ol>
+				{steps.map((step) => (
+					<li key={step.id} data-status={step.status}>
+						<span className="ai-plan-card__status">{STATUS_LABEL[step.status]}</span>
+						<span className="ai-plan-card__text">{step.title}</span>
+					</li>
+				))}
+			</ol>
+		</div>
+	);
 }

--- a/client/src/components/ai-panel/CodeBlockDiffPreview.tsx
+++ b/client/src/components/ai-panel/CodeBlockDiffPreview.tsx
@@ -1,98 +1,100 @@
-import { useMemo } from 'react';
-import { DiffEditor } from '@monaco-editor/react';
-import { useStore } from '@/core';
-import type { CodeBlock, CodeRange } from '@shared/types';
+import { DiffEditor } from "@monaco-editor/react";
+import type { CodeBlock, CodeRange } from "@shared/types";
+import { useMemo } from "react";
+import { useStore } from "@/core";
 
 interface Props {
-  codeBlock: CodeBlock;
-  onRetry?: () => void;
+	codeBlock: CodeBlock;
+	onRetry?: () => void;
 }
 
 function sliceContent(content: string, range: CodeRange): string {
-  const lines = content.split(/\r?\n/);
-  const startIdx = Math.max(range.startLine - 1, 0);
-  const endIdx = Math.min(range.endLine, lines.length);
-  const selected = lines.slice(startIdx, endIdx);
+	const lines = content.split(/\r?\n/);
+	const startIdx = Math.max(range.startLine - 1, 0);
+	const endIdx = Math.min(range.endLine, lines.length);
+	const selected = lines.slice(startIdx, endIdx);
 
-  if (selected.length === 0) {
-    return '';
-  }
+	if (selected.length === 0) {
+		return "";
+	}
 
-  const first = selected[0];
-  const last = selected[selected.length - 1];
+	const first = selected[0];
+	const last = selected[selected.length - 1];
 
-  selected[0] = first.slice(Math.max(range.startColumn - 1, 0));
-  selected[selected.length - 1] = last.slice(0, Math.max(range.endColumn - 1, 0));
+	selected[0] = first.slice(Math.max(range.startColumn - 1, 0));
+	selected[selected.length - 1] = last.slice(0, Math.max(range.endColumn - 1, 0));
 
-  return selected.join('\n');
+	return selected.join("\n");
 }
 
 export function CodeBlockDiffPreview({ codeBlock, onRetry }: Props): JSX.Element | null {
-  const editorContent = useStore((state) => state.editor.content);
-  const editorFilepath = useStore((state) => state.editor.filepath);
+	const editorContent = useStore((state) => state.editor.content);
+	const editorFilepath = useStore((state) => state.editor.filepath);
 
-  const { baseline, isStale, lineDelta } = useMemo(() => {
-    const localSlice =
-      codeBlock.targetRange && (!codeBlock.filepath || codeBlock.filepath === editorFilepath)
-        ? sliceContent(editorContent, codeBlock.targetRange)
-        : null;
+	const { baseline, isStale, lineDelta } = useMemo(() => {
+		const localSlice =
+			codeBlock.targetRange && (!codeBlock.filepath || codeBlock.filepath === editorFilepath)
+				? sliceContent(editorContent, codeBlock.targetRange)
+				: null;
 
-    const original = codeBlock.originalCode ?? localSlice;
-    const stale = Boolean(codeBlock.originalCode && localSlice && codeBlock.originalCode !== localSlice);
+		const original = codeBlock.originalCode ?? localSlice;
+		const stale = Boolean(
+			codeBlock.originalCode && localSlice && codeBlock.originalCode !== localSlice,
+		);
 
-    const originalLines = original ? original.split(/\r?\n/) : [];
-    const newLines = codeBlock.code ? codeBlock.code.split(/\r?\n/) : [];
+		const originalLines = original ? original.split(/\r?\n/) : [];
+		const newLines = codeBlock.code ? codeBlock.code.split(/\r?\n/) : [];
 
-    return {
-      baseline: original,
-      isStale: stale,
-      lineDelta: (() => {
-        if (!original) {
-          return codeBlock.code ? codeBlock.code.split(/\r?\n/).length : 0;
-        }
-        return Math.abs(newLines.length - originalLines.length);
-      })(),
-    };
-  }, [codeBlock, editorContent, editorFilepath]);
+		return {
+			baseline: original,
+			isStale: stale,
+			lineDelta: (() => {
+				if (!original) {
+					return codeBlock.code ? codeBlock.code.split(/\r?\n/).length : 0;
+				}
+				return Math.abs(newLines.length - originalLines.length);
+			})(),
+		};
+	}, [codeBlock, editorContent, editorFilepath]);
 
-  if (!baseline) {
-    return null;
-  }
+	if (!baseline) {
+		return null;
+	}
 
-  return (
-    <div className="code-diff-preview" data-testid="code-diff-preview">
-      {isStale && (
-        <div className="code-diff-warning" data-testid="code-diff-warning" role="status">
-          Editor content changed since this suggestion was generated.
-          {onRetry && (
-            <button
-              type="button"
-              className="btn btn-link"
-              onClick={onRetry}
-              data-testid="code-diff-retry"
-            >
-              Retry context match
-            </button>
-          )}
-        </div>
-      )}
-      <DiffEditor
-        height="240px"
-        original={baseline}
-        modified={codeBlock.code}
-        theme="vs"
-        language={codeBlock.language}
-        options={{
-          readOnly: true,
-          minimap: { enabled: false },
-          renderSideBySide: false,
-          automaticLayout: true,
-          scrollBeyondLastLine: false,
-        }}
-      />
-      <div className="code-diff-stats">
-        {lineDelta > 0 ? `Lines changed: ${lineDelta}` : 'Lines unchanged'}
-      </div>
-    </div>
-  );
+	return (
+		<div className="code-diff-preview" data-testid="code-diff-preview">
+			{isStale && (
+				<div className="code-diff-warning" data-testid="code-diff-warning" role="status">
+					Editor content changed since this suggestion was generated.
+					{onRetry && (
+						<button
+							type="button"
+							className="btn btn-link"
+							onClick={onRetry}
+							data-testid="code-diff-retry"
+						>
+							Retry context match
+						</button>
+					)}
+				</div>
+			)}
+			<DiffEditor
+				height="240px"
+				original={baseline}
+				modified={codeBlock.code}
+				theme="vs"
+				language={codeBlock.language}
+				options={{
+					readOnly: true,
+					minimap: { enabled: false },
+					renderSideBySide: false,
+					automaticLayout: true,
+					scrollBeyondLastLine: false,
+				}}
+			/>
+			<div className="code-diff-stats">
+				{lineDelta > 0 ? `Lines changed: ${lineDelta}` : "Lines unchanged"}
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/ai-panel/CodeBlockWithApply.tsx
+++ b/client/src/components/ai-panel/CodeBlockWithApply.tsx
@@ -1,112 +1,109 @@
-import { useEffect, useState } from 'react';
-import { IconClipboard, IconCheck, IconLightbulb } from '@/components/shared';
-import { CodeBlockDiffPreview } from './CodeBlockDiffPreview';
-import { getCodeActionLabel } from '@/core/ai/codeBlockActions';
-import type { CodeBlock } from '@shared/types';
+import type { CodeBlock } from "@shared/types";
+import { useEffect, useState } from "react";
+import { IconCheck, IconClipboard, IconLightbulb } from "@/components/shared";
+import { getCodeActionLabel } from "@/core/ai/codeBlockActions";
+import { CodeBlockDiffPreview } from "./CodeBlockDiffPreview";
 
 interface Props {
-  codeBlock: CodeBlock;
-  onApply: (codeBlock: CodeBlock) => Promise<void>;
-  showDiffPreview: boolean;
+	codeBlock: CodeBlock;
+	onApply: (codeBlock: CodeBlock) => Promise<void>;
+	showDiffPreview: boolean;
 }
 
 const isStructuredCodeBlock = (block: CodeBlock): boolean => {
-  return Boolean(
-    block.patchText ||
-      (block.patchChunks && block.patchChunks.length > 0) ||
-      (block.simpleChanges && block.simpleChanges.length > 0) ||
-      block.targetRange ||
-      block.originalCode,
-  );
+	return Boolean(
+		block.patchText ||
+			(block.patchChunks && block.patchChunks.length > 0) ||
+			(block.simpleChanges && block.simpleChanges.length > 0) ||
+			block.targetRange ||
+			block.originalCode,
+	);
 };
 
 export function CodeBlockWithApply({ codeBlock, onApply, showDiffPreview }: Props): JSX.Element {
-  const [applied, setApplied] = useState(false);
-  const [currentBlock, setCurrentBlock] = useState<CodeBlock>(codeBlock);
-  const shouldShowDiffPreview = showDiffPreview && isStructuredCodeBlock(currentBlock);
+	const [applied, setApplied] = useState(false);
+	const [currentBlock, setCurrentBlock] = useState<CodeBlock>(codeBlock);
+	const shouldShowDiffPreview = showDiffPreview && isStructuredCodeBlock(currentBlock);
 
-  useEffect(() => {
-    setCurrentBlock(codeBlock);
-    setApplied(false);
-  }, [codeBlock]);
+	useEffect(() => {
+		setCurrentBlock(codeBlock);
+		setApplied(false);
+	}, [codeBlock]);
 
-  const handleApply = async (): Promise<void> => {
-    try {
-    await onApply(currentBlock);
-    setApplied(true);
-    } catch (error) {
-      console.error('Failed to apply code block', error);
-    }
-  };
+	const handleApply = async (): Promise<void> => {
+		try {
+			await onApply(currentBlock);
+			setApplied(true);
+		} catch (error) {
+			console.error("Failed to apply code block", error);
+		}
+	};
 
-  const handleCopy = (): void => {
-    navigator.clipboard.writeText(codeBlock.code);
-  };
+	const handleCopy = (): void => {
+		navigator.clipboard.writeText(codeBlock.code);
+	};
 
-  const handleRetry = (): void => {
-    setCurrentBlock((prev) => ({
-      ...prev,
-      targetRange: undefined,
-    }));
-  };
+	const handleRetry = (): void => {
+		setCurrentBlock((prev) => ({
+			...prev,
+			targetRange: undefined,
+		}));
+	};
 
-  return (
-      <div className="code-block-container">
-      {codeBlock.explanation && (
-        <div className="code-explanation">
-          <IconLightbulb width={16} height={16} aria-hidden />
-          <span>{codeBlock.explanation}</span>
-        </div>
-      )}
+	return (
+		<div className="code-block-container">
+			{codeBlock.explanation && (
+				<div className="code-explanation">
+					<IconLightbulb width={16} height={16} aria-hidden />
+					<span>{codeBlock.explanation}</span>
+				</div>
+			)}
 
-      <div className="code-block">
-        <div className="code-header">
-          <span className="code-language">R</span>
-          <span className="code-target">
-            {codeBlock.filepath ? `${codeBlock.filepath}` : 'Current file'} • {getCodeActionLabel(codeBlock)}
-          </span>
-        </div>
+			<div className="code-block">
+				<div className="code-header">
+					<span className="code-language">R</span>
+					<span className="code-target">
+						{codeBlock.filepath ? `${codeBlock.filepath}` : "Current file"} •{" "}
+						{getCodeActionLabel(codeBlock)}
+					</span>
+				</div>
 
-        {shouldShowDiffPreview && (
-          <CodeBlockDiffPreview codeBlock={currentBlock} onRetry={handleRetry} />
-        )}
+				{shouldShowDiffPreview && (
+					<CodeBlockDiffPreview codeBlock={currentBlock} onRetry={handleRetry} />
+				)}
 
-        <pre className="code-content">
-          <code>{currentBlock.code}</code>
-        </pre>
+				<pre className="code-content">
+					<code>{currentBlock.code}</code>
+				</pre>
 
-        <div className="code-actions">
-          <button
-            className="btn"
-            onClick={handleCopy}
-            title="Copy to clipboard"
-          >
-            <>
-              <IconClipboard width={16} height={16} aria-hidden />
-              Copy
-            </>
-          </button>
+				<div className="code-actions">
+					<button className="btn" onClick={handleCopy} title="Copy to clipboard">
+						<>
+							<IconClipboard width={16} height={16} aria-hidden />
+							Copy
+						</>
+					</button>
 
-          <button
-            className="btn btn-primary"
-            onClick={handleApply}
-            disabled={applied}
-            title={applied ? 'Already applied' : 'Apply to editor'}
-          >
-            {applied ? (
-              <>
-                <IconCheck width={16} height={16} aria-hidden />
-                Applied
-              </>
-            ) : (
-              <>
-                <IconCheck width={16} height={16} aria-hidden />
-                Apply to Editor
-              </>
-            )}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+					<button
+						className="btn btn-primary"
+						onClick={handleApply}
+						disabled={applied}
+						title={applied ? "Already applied" : "Apply to editor"}
+					>
+						{applied ? (
+							<>
+								<IconCheck width={16} height={16} aria-hidden />
+								Applied
+							</>
+						) : (
+							<>
+								<IconCheck width={16} height={16} aria-hidden />
+								Apply to Editor
+							</>
+						)}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/ai-panel/ProviderSwitcher.css
+++ b/client/src/components/ai-panel/ProviderSwitcher.css
@@ -1,24 +1,24 @@
 .provider-switcher {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 12px;
 }
 
 .switcher-select {
-  background: transparent;
-  border: none;
-  color: var(--text-secondary);
-  font-size: 12px;
-  cursor: pointer;
-  padding-right: 4px;
+	background: transparent;
+	border: none;
+	color: var(--text-secondary);
+	font-size: 12px;
+	cursor: pointer;
+	padding-right: 4px;
 }
 
 .switcher-select:hover {
-  color: var(--text-primary);
+	color: var(--text-primary);
 }
 
 .warning-icon {
-  font-size: 12px;
-  cursor: help;
+	font-size: 12px;
+	cursor: help;
 }

--- a/client/src/components/ai-panel/ProviderSwitcher.tsx
+++ b/client/src/components/ai-panel/ProviderSwitcher.tsx
@@ -1,29 +1,31 @@
-import React from 'react';
-import { useSettingsStore } from '../../core/state/slices/settingsStore';
-import './ProviderSwitcher.css';
+import type React from "react";
+import { useSettingsStore } from "../../core/state/slices/settingsStore";
+import "./ProviderSwitcher.css";
 
 export const ProviderSwitcher: React.FC = () => {
-  const { activeProvider, providers, setActiveProvider } = useSettingsStore();
-  
-  // We want to show the display name of the active provider
-  const currentProvider = providers.find(p => p.name === activeProvider);
+	const { activeProvider, providers, setActiveProvider } = useSettingsStore();
 
-  return (
-    <div className="provider-switcher">
-      <select 
-        value={activeProvider}
-        onChange={(e) => setActiveProvider(e.target.value)}
-        className="switcher-select"
-      >
-        {providers.map(p => (
-          <option key={p.name} value={p.name}>
-            {p.displayName}
-          </option>
-        ))}
-      </select>
-      {currentProvider && !currentProvider.isConfigured && (
-        <span className="warning-icon" title="Provider not configured">⚠️</span>
-      )}
-    </div>
-  );
+	// We want to show the display name of the active provider
+	const currentProvider = providers.find((p) => p.name === activeProvider);
+
+	return (
+		<div className="provider-switcher">
+			<select
+				value={activeProvider}
+				onChange={(e) => setActiveProvider(e.target.value)}
+				className="switcher-select"
+			>
+				{providers.map((p) => (
+					<option key={p.name} value={p.name}>
+						{p.displayName}
+					</option>
+				))}
+			</select>
+			{currentProvider && !currentProvider.isConfigured && (
+				<span className="warning-icon" title="Provider not configured">
+					⚠️
+				</span>
+			)}
+		</div>
+	);
 };

--- a/client/src/components/ai-panel/StreamingMessage.tsx
+++ b/client/src/components/ai-panel/StreamingMessage.tsx
@@ -1,69 +1,72 @@
-import { CodeBlockWithApply } from './CodeBlockWithApply';
-import { AIPlanCard } from './AIPlanCard';
-import { ToolCallLog } from './ToolCallLog';
-import type { AIMessage, CodeBlock } from '@shared/types';
+import type { AIMessage, CodeBlock } from "@shared/types";
+import { AIPlanCard } from "./AIPlanCard";
+import { CodeBlockWithApply } from "./CodeBlockWithApply";
+import { ToolCallLog } from "./ToolCallLog";
 
 interface Props {
-  message: AIMessage;
-  onApplyCode: (codeBlock: CodeBlock) => Promise<void>;
+	message: AIMessage;
+	onApplyCode: (codeBlock: CodeBlock) => Promise<void>;
 }
 
 // Remove patch blocks from content for display
 function stripPatchBlocks(content: string): string {
-  return content.replace(/\*\*\* Begin Patch[\s\S]*?\*\*\* End Patch/g, '').trim();
+	return content.replace(/\*\*\* Begin Patch[\s\S]*?\*\*\* End Patch/g, "").trim();
 }
 
 export function StreamingMessage({ message, onApplyCode }: Props): JSX.Element {
-  const isAssistant = message.role === 'assistant';
-  const isStreaming = Boolean(message.streamingId && !message.isComplete);
-  const hasPlan = Boolean(message.planSteps && message.planSteps.length > 0);
-  const hasTools = Boolean(message.toolLogs && message.toolLogs.length > 0);
-  const hasCodeBlocks = Boolean(message.codeBlocks && message.codeBlocks.length > 0);
-  const shouldShowLegacyCode = Boolean(message.code && !hasCodeBlocks);
+	const isAssistant = message.role === "assistant";
+	const isStreaming = Boolean(message.streamingId && !message.isComplete);
+	const hasPlan = Boolean(message.planSteps && message.planSteps.length > 0);
+	const hasTools = Boolean(message.toolLogs && message.toolLogs.length > 0);
+	const hasCodeBlocks = Boolean(message.codeBlocks && message.codeBlocks.length > 0);
+	const shouldShowLegacyCode = Boolean(message.code && !hasCodeBlocks);
 
-  // Strip patch blocks from content to avoid duplicate display
-  const displayContent = message.content ? stripPatchBlocks(message.content) : '';
+	// Strip patch blocks from content to avoid duplicate display
+	const displayContent = message.content ? stripPatchBlocks(message.content) : "";
 
-  return (
-    <div className={`message message-${message.role}`} data-streaming={isStreaming ? 'true' : 'false'}>
-      <div className="message-header">
-        <span className="message-role">{isAssistant ? 'AI' : 'You'}</span>
-      </div>
-      <div className="message-content message-streaming">
-        {isStreaming && (
-          <div className="message-streaming-indicator">
-            <span className="spinner" aria-hidden />
-            <span>Streaming response…</span>
-          </div>
-        )}
-        {displayContent && (
-          <pre className="message-streaming-text">{displayContent}</pre>
-        )}
-      </div>
+	return (
+		<div
+			className={`message message-${message.role}`}
+			data-streaming={isStreaming ? "true" : "false"}
+		>
+			<div className="message-header">
+				<span className="message-role">{isAssistant ? "AI" : "You"}</span>
+			</div>
+			<div className="message-content message-streaming">
+				{isStreaming && (
+					<div className="message-streaming-indicator">
+						<span className="spinner" aria-hidden />
+						<span>Streaming response…</span>
+					</div>
+				)}
+				{displayContent && <pre className="message-streaming-text">{displayContent}</pre>}
+			</div>
 
-      {isAssistant && (
-        <>
-          {hasPlan && <AIPlanCard steps={message.planSteps} />}
+			{isAssistant && (
+				<>
+					{hasPlan && <AIPlanCard steps={message.planSteps} />}
 
-          {hasTools && <ToolCallLog logs={message.toolLogs} />}
+					{hasTools && <ToolCallLog logs={message.toolLogs} />}
 
-          {shouldShowLegacyCode && (
-            <div className="message-code">
-              <pre><code>{message.code}</code></pre>
-            </div>
-          )}
+					{shouldShowLegacyCode && (
+						<div className="message-code">
+							<pre>
+								<code>{message.code}</code>
+							</pre>
+						</div>
+					)}
 
-          {hasCodeBlocks &&
-            message.codeBlocks!.map((codeBlock) => (
-              <CodeBlockWithApply
-                key={codeBlock.id}
-                codeBlock={codeBlock}
-                onApply={onApplyCode}
-                showDiffPreview={message.mode === 'agent'}
-              />
-            ))}
-        </>
-      )}
-    </div>
-  );
+					{hasCodeBlocks &&
+						message.codeBlocks!.map((codeBlock) => (
+							<CodeBlockWithApply
+								key={codeBlock.id}
+								codeBlock={codeBlock}
+								onApply={onApplyCode}
+								showDiffPreview={message.mode === "agent"}
+							/>
+						))}
+				</>
+			)}
+		</div>
+	);
 }

--- a/client/src/components/ai-panel/ToolCallLog.tsx
+++ b/client/src/components/ai-panel/ToolCallLog.tsx
@@ -1,51 +1,51 @@
-import type { ToolCallLog as ToolCallLogEntry } from '@shared/types';
+import type { ToolCallLog as ToolCallLogEntry } from "@shared/types";
 
 interface Props {
-  logs?: ToolCallLogEntry[];
+	logs?: ToolCallLogEntry[];
 }
 
-const STATUS_LABEL: Record<ToolCallLogEntry['status'], string> = {
-  pending: 'Pending',
-  running: 'Running',
-  done: 'Completed',
-  error: 'Error',
+const STATUS_LABEL: Record<ToolCallLogEntry["status"], string> = {
+	pending: "Pending",
+	running: "Running",
+	done: "Completed",
+	error: "Error",
 };
 
 export function ToolCallLog({ logs }: Props): JSX.Element | null {
-  if (!logs || logs.length === 0) {
-    return null;
-  }
+	if (!logs || logs.length === 0) {
+		return null;
+	}
 
-  return (
-    <div className="ai-tool-log">
-      <div className="ai-tool-log__title">Tool activity</div>
-      <ul>
-        {logs.map((log) => (
-          <li key={log.id}>
-            <details open={log.status === 'running'}>
-              <summary>
-                <span className="ai-tool-log__tool">{log.name ?? log.id}</span>
-                <span className={`ai-tool-log__status is-${log.status}`}>
-                  {STATUS_LABEL[log.status]}
-                </span>
-              </summary>
-              {log.input && (
-                <div className="ai-tool-log__block">
-                  <div className="ai-tool-log__label">Input</div>
-                  <pre>{JSON.stringify(log.input, null, 2)}</pre>
-                </div>
-              )}
-              {log.output && (
-                <div className="ai-tool-log__block">
-                  <div className="ai-tool-log__label">Output</div>
-                  <pre>{JSON.stringify(log.output, null, 2)}</pre>
-                </div>
-              )}
-              {log.error && <div className="ai-tool-log__error">{log.error}</div>}
-            </details>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+	return (
+		<div className="ai-tool-log">
+			<div className="ai-tool-log__title">Tool activity</div>
+			<ul>
+				{logs.map((log) => (
+					<li key={log.id}>
+						<details open={log.status === "running"}>
+							<summary>
+								<span className="ai-tool-log__tool">{log.name ?? log.id}</span>
+								<span className={`ai-tool-log__status is-${log.status}`}>
+									{STATUS_LABEL[log.status]}
+								</span>
+							</summary>
+							{log.input && (
+								<div className="ai-tool-log__block">
+									<div className="ai-tool-log__label">Input</div>
+									<pre>{JSON.stringify(log.input, null, 2)}</pre>
+								</div>
+							)}
+							{log.output && (
+								<div className="ai-tool-log__block">
+									<div className="ai-tool-log__label">Output</div>
+									<pre>{JSON.stringify(log.output, null, 2)}</pre>
+								</div>
+							)}
+							{log.error && <div className="ai-tool-log__error">{log.error}</div>}
+						</details>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/client/src/components/ai-panel/__tests__/CodeBlockDiffPreview.test.tsx
+++ b/client/src/components/ai-panel/__tests__/CodeBlockDiffPreview.test.tsx
@@ -1,75 +1,75 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { CodeBlockDiffPreview } from '../CodeBlockDiffPreview';
-import { useStore } from '@/core';
-import type { CodeBlock } from '@shared/types';
+import type { CodeBlock } from "@shared/types";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useStore } from "@/core";
+import { CodeBlockDiffPreview } from "../CodeBlockDiffPreview";
 
-vi.mock('@monaco-editor/react', () => ({
-  DiffEditor: ({ original, modified }: { original: string; modified: string }) => (
-    <div data-testid="diff-editor">
-      <div>orig:{original}</div>
-      <div>mod:{modified}</div>
-    </div>
-  ),
+vi.mock("@monaco-editor/react", () => ({
+	DiffEditor: ({ original, modified }: { original: string; modified: string }) => (
+		<div data-testid="diff-editor">
+			<div>orig:{original}</div>
+			<div>mod:{modified}</div>
+		</div>
+	),
 }));
 
 const baseBlock: CodeBlock = {
-  id: 'code-test',
-  code: 'print("new")',
-  language: 'r',
-  action: 'replace-range',
-  targetRange: {
-    startLine: 1,
-    startColumn: 1,
-    endLine: 1,
-    endColumn: 5,
-  },
+	id: "code-test",
+	code: 'print("new")',
+	language: "r",
+	action: "replace-range",
+	targetRange: {
+		startLine: 1,
+		startColumn: 1,
+		endLine: 1,
+		endColumn: 5,
+	},
 };
 
 beforeEach(() => {
-  useStore.setState((state) => ({
-    editor: {
-      ...state.editor,
-      content: 'print("old")',
-      filepath: 'analysis.R',
-    },
-  }));
+	useStore.setState((state) => ({
+		editor: {
+			...state.editor,
+			content: 'print("old")',
+			filepath: "analysis.R",
+		},
+	}));
 });
 
-describe('CodeBlockDiffPreview', () => {
-  it('renders diff when originalCode exists', () => {
-    render(
-      <CodeBlockDiffPreview
-        codeBlock={{
-          ...baseBlock,
-          filepath: 'analysis.R',
-          originalCode: 'original code',
-        }}
-      />,
-    );
+describe("CodeBlockDiffPreview", () => {
+	it("renders diff when originalCode exists", () => {
+		render(
+			<CodeBlockDiffPreview
+				codeBlock={{
+					...baseBlock,
+					filepath: "analysis.R",
+					originalCode: "original code",
+				}}
+			/>,
+		);
 
-    expect(screen.getByTestId('diff-editor')).toBeInTheDocument();
-  });
+		expect(screen.getByTestId("diff-editor")).toBeInTheDocument();
+	});
 
-  it('shows warning when editor content changed since suggestion', () => {
-    useStore.setState((state) => ({
-      editor: {
-        ...state.editor,
-        content: 'different content',
-        filepath: 'analysis.R',
-      },
-    }));
+	it("shows warning when editor content changed since suggestion", () => {
+		useStore.setState((state) => ({
+			editor: {
+				...state.editor,
+				content: "different content",
+				filepath: "analysis.R",
+			},
+		}));
 
-    render(
-      <CodeBlockDiffPreview
-        codeBlock={{
-          ...baseBlock,
-          filepath: 'analysis.R',
-          originalCode: 'original code',
-        }}
-      />,
-    );
+		render(
+			<CodeBlockDiffPreview
+				codeBlock={{
+					...baseBlock,
+					filepath: "analysis.R",
+					originalCode: "original code",
+				}}
+			/>,
+		);
 
-    expect(screen.getByTestId('code-diff-warning')).toBeInTheDocument();
-  });
+		expect(screen.getByTestId("code-diff-warning")).toBeInTheDocument();
+	});
 });

--- a/client/src/components/ai-panel/index.ts
+++ b/client/src/components/ai-panel/index.ts
@@ -1,5 +1,5 @@
-export { AIPanel } from './AIPanel';
-export { CodeBlockWithApply } from './CodeBlockWithApply';
-export { AIPlanCard } from './AIPlanCard';
-export { ToolCallLog } from './ToolCallLog';
-export { StreamingMessage } from './StreamingMessage';
+export { AIPanel } from "./AIPanel";
+export { AIPlanCard } from "./AIPlanCard";
+export { CodeBlockWithApply } from "./CodeBlockWithApply";
+export { StreamingMessage } from "./StreamingMessage";
+export { ToolCallLog } from "./ToolCallLog";

--- a/client/src/components/bottom-pane/BottomPane.tsx
+++ b/client/src/components/bottom-pane/BottomPane.tsx
@@ -1,138 +1,149 @@
+import { ConsolePanel } from "@/components/console";
 import {
-  IconBarChart,
-  IconChevronLeft,
-  IconChevronRight,
-  IconTrash,
-  PanelTabs,
-} from '@/components/shared';
-import { TerminalPane } from '@/components/Terminal';
-import { ConsolePanel } from '@/components/console';
-import { useBottomPaneState } from '@/hooks/useBottomPaneState';
+	IconBarChart,
+	IconChevronLeft,
+	IconChevronRight,
+	IconTrash,
+	PanelTabs,
+} from "@/components/shared";
+import { TerminalPane } from "@/components/Terminal";
+import { useBottomPaneState } from "@/hooks/useBottomPaneState";
 
 export function BottomPane(): JSX.Element {
-  const {
-    tabs,
-    activeTab,
-    setActiveTab,
-    navigation,
-    allPlots,
-    currentPlot,
-    selectPreviousPlot,
-    selectNextPlot,
-    clearExecutionResults,
-  } = useBottomPaneState();
+	const {
+		tabs,
+		activeTab,
+		setActiveTab,
+		navigation,
+		allPlots,
+		currentPlot,
+		selectPreviousPlot,
+		selectNextPlot,
+		clearExecutionResults,
+	} = useBottomPaneState();
 
-  const { selectedPlotIndex, totalPlots } = navigation;
-  const showClear = activeTab === 'console' || activeTab === 'history';
-  const showPlotNav = activeTab === 'plots' && totalPlots > 0;
+	const { selectedPlotIndex, totalPlots } = navigation;
+	const showClear = activeTab === "console" || activeTab === "history";
+	const showPlotNav = activeTab === "plots" && totalPlots > 0;
 
-  return (
-    <div className="panel panel--transparent bottom-pane">
-      <div className="panel-header panel-header--plain">
-        <PanelTabs
-          items={tabs}
-          activeId={activeTab}
-          onSelect={setActiveTab}
-          className="panel-tabs--flush panel-tabs--equal-width panel-tabs--compact"
-        />
-        {(showClear || showPlotNav) && (
-          <div className="panel-actions panel-actions--compact">
-            {showClear && (
-              <button
-                className="btn btn-icon"
-                title="Clear console"
-                aria-label="Clear console"
-                onClick={clearExecutionResults}>
-                <IconTrash width={16} height={16} aria-hidden />
-              </button>
-            )}
-            {showPlotNav && (
-              <>
-                <button
-                  className="btn btn-icon"
-                  onClick={selectPreviousPlot}
-                  disabled={selectedPlotIndex === 0}
-                  title="Previous plot"
-                  aria-label="Previous plot">
-                  <IconChevronLeft width={16} height={16} aria-hidden />
-                </button>
-                <span className="plot-counter">
-                  {selectedPlotIndex + 1} / {totalPlots}
-                </span>
-                <button
-                  className="btn btn-icon"
-                  onClick={selectNextPlot}
-                  disabled={selectedPlotIndex >= totalPlots - 1}
-                  title="Next plot"
-                  aria-label="Next plot">
-                  <IconChevronRight width={16} height={16} aria-hidden />
-                </button>
-              </>
-            )}
-          </div>
-        )}
-      </div>
-      <div className="panel-content">
-        {activeTab === 'console' && <ConsolePanel view="console" />}
-        {activeTab === 'history' && <ConsolePanel view="history" />}
-        {activeTab === 'terminal' && <TerminalPane />}
+	return (
+		<div className="panel panel--transparent bottom-pane">
+			<div className="panel-header panel-header--plain">
+				<PanelTabs
+					items={tabs}
+					activeId={activeTab}
+					onSelect={setActiveTab}
+					className="panel-tabs--flush panel-tabs--equal-width panel-tabs--compact"
+				/>
+				{(showClear || showPlotNav) && (
+					<div className="panel-actions panel-actions--compact">
+						{showClear && (
+							<button
+								className="btn btn-icon"
+								title="Clear console"
+								aria-label="Clear console"
+								onClick={clearExecutionResults}
+							>
+								<IconTrash width={16} height={16} aria-hidden />
+							</button>
+						)}
+						{showPlotNav && (
+							<>
+								<button
+									className="btn btn-icon"
+									onClick={selectPreviousPlot}
+									disabled={selectedPlotIndex === 0}
+									title="Previous plot"
+									aria-label="Previous plot"
+								>
+									<IconChevronLeft width={16} height={16} aria-hidden />
+								</button>
+								<span className="plot-counter">
+									{selectedPlotIndex + 1} / {totalPlots}
+								</span>
+								<button
+									className="btn btn-icon"
+									onClick={selectNextPlot}
+									disabled={selectedPlotIndex >= totalPlots - 1}
+									title="Next plot"
+									aria-label="Next plot"
+								>
+									<IconChevronRight width={16} height={16} aria-hidden />
+								</button>
+							</>
+						)}
+					</div>
+				)}
+			</div>
+			<div className="panel-content">
+				{activeTab === "console" && <ConsolePanel view="console" />}
+				{activeTab === "history" && <ConsolePanel view="history" />}
+				{activeTab === "terminal" && <TerminalPane />}
 
-        {activeTab === 'plots' && (
-          <div className="plots-container">
-            {allPlots.length === 0 ? (
-              <div className="empty-state">
-                <div className="empty-icon">
-                  <IconBarChart width={48} height={48} aria-hidden />
-                </div>
-                <p>No plots yet</p>
-                <p className="empty-hint">Run R code to generate visualizations</p>
-              </div>
-            ) : (
-              <div className="plot-viewer">
-                {currentPlot && (
-                  <img
-                    src={currentPlot.data}
-                    alt={`Plot ${selectedPlotIndex + 1}`}
-                    className="plot-image"
-                  />
-                )}
-              </div>
-            )}
-          </div>
-        )}
-        {activeTab === 'help' && (
-          <div className="help-container">
-            <div className="help-content">
-              <h3>Re-prod Help</h3>
-              <div className="help-section">
-                <h4>Getting Started</h4>
-                <ul>
-                  <li>Write R code in the editor</li>
-                  <li>Organize code using section markers: <code># Section Name ----</code></li>
-                  <li>View results in the Console panel</li>
-                  <li>Plots appear automatically in this panel</li>
-                </ul>
-              </div>
-              <div className="help-section">
-                <h4>Keyboard Shortcuts</h4>
-                <ul>
-                  <li><strong>Cmd/Ctrl + Enter:</strong> Run current cell or selection</li>
-                  <li><strong>Shift + Enter:</strong> Run cell and move to next</li>
-                  <li><strong>Cmd/Ctrl + Shift + Enter:</strong> Run all code</li>
-                </ul>
-              </div>
-              <div className="help-section">
-                <h4>AI Assistant</h4>
-                <ul>
-                  <li>Ask questions about R programming</li>
-                  <li>Get code suggestions and explanations</li>
-                  <li>Apply suggested code to your editor</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+				{activeTab === "plots" && (
+					<div className="plots-container">
+						{allPlots.length === 0 ? (
+							<div className="empty-state">
+								<div className="empty-icon">
+									<IconBarChart width={48} height={48} aria-hidden />
+								</div>
+								<p>No plots yet</p>
+								<p className="empty-hint">Run R code to generate visualizations</p>
+							</div>
+						) : (
+							<div className="plot-viewer">
+								{currentPlot && (
+									<img
+										src={currentPlot.data}
+										alt={`Plot ${selectedPlotIndex + 1}`}
+										className="plot-image"
+									/>
+								)}
+							</div>
+						)}
+					</div>
+				)}
+				{activeTab === "help" && (
+					<div className="help-container">
+						<div className="help-content">
+							<h3>Re-prod Help</h3>
+							<div className="help-section">
+								<h4>Getting Started</h4>
+								<ul>
+									<li>Write R code in the editor</li>
+									<li>
+										Organize code using section markers: <code># Section Name ----</code>
+									</li>
+									<li>View results in the Console panel</li>
+									<li>Plots appear automatically in this panel</li>
+								</ul>
+							</div>
+							<div className="help-section">
+								<h4>Keyboard Shortcuts</h4>
+								<ul>
+									<li>
+										<strong>Cmd/Ctrl + Enter:</strong> Run current cell or selection
+									</li>
+									<li>
+										<strong>Shift + Enter:</strong> Run cell and move to next
+									</li>
+									<li>
+										<strong>Cmd/Ctrl + Shift + Enter:</strong> Run all code
+									</li>
+								</ul>
+							</div>
+							<div className="help-section">
+								<h4>AI Assistant</h4>
+								<ul>
+									<li>Ask questions about R programming</li>
+									<li>Get code suggestions and explanations</li>
+									<li>Apply suggested code to your editor</li>
+								</ul>
+							</div>
+						</div>
+					</div>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/bottom-pane/index.ts
+++ b/client/src/components/bottom-pane/index.ts
@@ -1,1 +1,1 @@
-export { BottomPane } from './BottomPane';
+export { BottomPane } from "./BottomPane";

--- a/client/src/components/console/ConsolePanel.tsx
+++ b/client/src/components/console/ConsolePanel.tsx
@@ -1,106 +1,100 @@
-import { IconBarChart, IconCheckCircle, IconXCircle } from '@/components/shared';
-import type { ConsoleTabId } from '@/types/panels';
-import { useConsolePanelState } from '@/hooks/useConsolePanelState';
+import { IconBarChart, IconCheckCircle, IconXCircle } from "@/components/shared";
+import { useConsolePanelState } from "@/hooks/useConsolePanelState";
+import type { ConsoleTabId } from "@/types/panels";
 
 interface ConsolePanelProps {
-  view: ConsoleTabId;
+	view: ConsoleTabId;
 }
 
 export function ConsolePanel({ view }: ConsolePanelProps): JSX.Element {
-  const { execution, consoleEndRef } = useConsolePanelState();
+	const { execution, consoleEndRef } = useConsolePanelState();
 
-  return (
-    <div className="panel panel--transparent console-panel">
-      <div className="panel-content console-content">
-        {view === 'console' && (
-          <div className="console-output">
-            {execution.results.length === 0 ? (
-              <div className="console-welcome">
-                <p>Console ready. Run R code to see output here.</p>
-              </div>
-            ) : (
-              <>
-                {execution.results.map((result, index) => (
-                  <div key={index} className="console-entry">
-                    <div className="console-meta">
-                      <span className="console-time">
-                        {new Date(result.timestamp).toLocaleTimeString()}
-                      </span>
-                      <span className="console-duration">
-                        ({result.duration}ms)
-                      </span>
-                      {!result.success && (
-                        <span className="console-error-badge">Error</span>
-                      )}
-                    </div>
-                    {result.stdout && (
-                      <pre className="console-stdout">{result.stdout}</pre>
-                    )}
-                    {result.stderr && (
-                      <pre className="console-stderr">{result.stderr}</pre>
-                    )}
-                    {result.plots.length > 0 && (
-                      <div
-                        className="console-plots-info clickable"
-                        onClick={() => {
-                          const previousPlots = execution.results
-                            .slice(0, index)
-                            .reduce((sum, r) => sum + r.plots.length, 0);
+	return (
+		<div className="panel panel--transparent console-panel">
+			<div className="panel-content console-content">
+				{view === "console" && (
+					<div className="console-output">
+						{execution.results.length === 0 ? (
+							<div className="console-welcome">
+								<p>Console ready. Run R code to see output here.</p>
+							</div>
+						) : (
+							<>
+								{execution.results.map((result, index) => (
+									<div key={index} className="console-entry">
+										<div className="console-meta">
+											<span className="console-time">
+												{new Date(result.timestamp).toLocaleTimeString()}
+											</span>
+											<span className="console-duration">({result.duration}ms)</span>
+											{!result.success && <span className="console-error-badge">Error</span>}
+										</div>
+										{result.stdout && <pre className="console-stdout">{result.stdout}</pre>}
+										{result.stderr && <pre className="console-stderr">{result.stderr}</pre>}
+										{result.plots.length > 0 && (
+											<div
+												className="console-plots-info clickable"
+												onClick={() => {
+													const previousPlots = execution.results
+														.slice(0, index)
+														.reduce((sum, r) => sum + r.plots.length, 0);
 
-                          window.dispatchEvent(
-                            new CustomEvent('focusPlot', {
-                              detail: { plotIndex: previousPlots },
-                            })
-                          );
-                        }}
-                        role="button"
-                        tabIndex={0}
-                        title="Click to view plot">
-                        <IconBarChart width={16} height={16} aria-hidden />
-                        Generated {result.plots.length} plot{result.plots.length > 1 ? 's' : ''}
-                      </div>
-                    )}
-                  </div>
-                ))}
-                <div ref={consoleEndRef} />
-              </>
-            )}
-          </div>
-        )}
-        {view === 'history' && (
-          <div className="console-history">
-            {execution.history.length === 0 ? (
-              <div className="console-welcome">
-                <p>Execution history will appear here.</p>
-              </div>
-            ) : (
-              <div className="history-list">
-                {execution.history.map((result, index) => (
-                  <div key={index} className="history-item">
-                    <div className="history-header">
-                      <span className="history-number">#{index + 1}</span>
-                      <span className="history-time">
-                        {new Date(result.timestamp).toLocaleString()}
-                      </span>
-                      <span className={`history-status ${result.success ? 'success' : 'error'}`}>
-                        {result.success ? (
-                          <IconCheckCircle width={14} height={14} aria-hidden />
-                        ) : (
-                          <IconXCircle width={14} height={14} aria-hidden />
-                        )}
-                      </span>
-                    </div>
-                    <div className="history-summary">
-                      {result.plots.length > 0 && `${result.plots.length} plot(s) · `}
-                      {result.duration}ms
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-    </div>
-  );
+													window.dispatchEvent(
+														new CustomEvent("focusPlot", {
+															detail: { plotIndex: previousPlots },
+														}),
+													);
+												}}
+												role="button"
+												tabIndex={0}
+												title="Click to view plot"
+											>
+												<IconBarChart width={16} height={16} aria-hidden />
+												Generated {result.plots.length} plot
+												{result.plots.length > 1 ? "s" : ""}
+											</div>
+										)}
+									</div>
+								))}
+								<div ref={consoleEndRef} />
+							</>
+						)}
+					</div>
+				)}
+				{view === "history" && (
+					<div className="console-history">
+						{execution.history.length === 0 ? (
+							<div className="console-welcome">
+								<p>Execution history will appear here.</p>
+							</div>
+						) : (
+							<div className="history-list">
+								{execution.history.map((result, index) => (
+									<div key={index} className="history-item">
+										<div className="history-header">
+											<span className="history-number">#{index + 1}</span>
+											<span className="history-time">
+												{new Date(result.timestamp).toLocaleString()}
+											</span>
+											<span className={`history-status ${result.success ? "success" : "error"}`}>
+												{result.success ? (
+													<IconCheckCircle width={14} height={14} aria-hidden />
+												) : (
+													<IconXCircle width={14} height={14} aria-hidden />
+												)}
+											</span>
+										</div>
+										<div className="history-summary">
+											{result.plots.length > 0 && `${result.plots.length} plot(s) · `}
+											{result.duration}ms
+										</div>
+									</div>
+								))}
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/console/index.ts
+++ b/client/src/components/console/index.ts
@@ -1,1 +1,1 @@
-export { ConsolePanel } from './ConsolePanel';
+export { ConsolePanel } from "./ConsolePanel";

--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -1,488 +1,478 @@
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-} from "react";
+import Editor, { type Monaco } from "@monaco-editor/react";
+import type { CodeBlock, CodeRange } from "@shared/types";
+import type { editor as MonacoEditor } from "monaco-editor";
 import type { ForwardedRef } from "react";
-import Editor, { Monaco } from "@monaco-editor/react";
-import { IconPlay, IconPlayCircle, ConfirmDialog } from "@/components/shared";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from "react";
+import { ConfirmDialog, IconPlay, IconPlayCircle } from "@/components/shared";
 import { useStore } from "@/core";
+import { computeTargetRange, findCodeInEditor, matchPatchChunk } from "@/core/ai/contextMatcher";
+import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { useEditorCells } from "@/hooks/useEditorCells";
 import { useEditorDecorations } from "@/hooks/useEditorDecorations";
 import { useEditorExecution } from "@/hooks/useEditorExecution";
-import { useConfirmDialog } from "@/hooks/useConfirmDialog";
-import { computeTargetRange, matchPatchChunk, findCodeInEditor } from "@/core/ai/contextMatcher";
-import type { editor as MonacoEditor } from "monaco-editor";
-import type { CodeBlock, CodeRange } from "@shared/types";
 import type { EditorRef } from "./editorRef";
 
 function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Element {
-  const editor = useStore((state) => state.editor);
-  const execution = useStore((state) => state.execution);
-  const settings = useStore((state) => state.settings);
-  const setEditorContent = useStore((state) => state.setEditorContent);
-  const setEditorCursorPosition = useStore((state) => state.setEditorCursorPosition);
-  const setApplyCodeChange = useStore((state) => state.setApplyCodeChange);
-  const setRunCurrentCell = useStore((state) => state.setRunCurrentCell);
-  const setRunAll = useStore((state) => state.setRunAll);
-  const setMonacoEditor = useStore((state) => state.setMonacoEditor);
-  const setEditorRef = useStore((state) => state.setEditorRef);
-  const recordPatchMatchFailure = useStore((state) => state.recordPatchMatchFailure);
-  const recordPatchMatchSuccess = useStore((state) => state.recordPatchMatchSuccess);
-  const editorMethodsRef = useRef<EditorRef | null>(null);
-  const monacoEditorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
-  const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
+	const editor = useStore((state) => state.editor);
+	const execution = useStore((state) => state.execution);
+	const settings = useStore((state) => state.settings);
+	const setEditorContent = useStore((state) => state.setEditorContent);
+	const setEditorCursorPosition = useStore((state) => state.setEditorCursorPosition);
+	const setApplyCodeChange = useStore((state) => state.setApplyCodeChange);
+	const setRunCurrentCell = useStore((state) => state.setRunCurrentCell);
+	const setRunAll = useStore((state) => state.setRunAll);
+	const setMonacoEditor = useStore((state) => state.setMonacoEditor);
+	const setEditorRef = useStore((state) => state.setEditorRef);
+	const recordPatchMatchFailure = useStore((state) => state.recordPatchMatchFailure);
+	const recordPatchMatchSuccess = useStore((state) => state.recordPatchMatchSuccess);
+	const editorMethodsRef = useRef<EditorRef | null>(null);
+	const monacoEditorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
+	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
 
-  const cells = useEditorCells(editor.content, editor.filepath);
-  const {
-    executingCellIndex,
-    handleRunAll,
-    handleRunCurrentCell,
-    handleRunCellAndMoveNext,
-  } = useEditorExecution({ editorRef: monacoEditorRef, cells });
+	const cells = useEditorCells(editor.content, editor.filepath);
+	const { executingCellIndex, handleRunAll, handleRunCurrentCell, handleRunCellAndMoveNext } =
+		useEditorExecution({ editorRef: monacoEditorRef, cells });
 
-  useEditorDecorations(monacoEditorRef, cells, {
-    showCellDecorations: settings.showCellDecorations,
-    highlightExecutingCell: settings.highlightExecutingCell,
-    executingCellIndex,
-  });
+	useEditorDecorations(monacoEditorRef, cells, {
+		showCellDecorations: settings.showCellDecorations,
+		highlightExecutingCell: settings.highlightExecutingCell,
+		executingCellIndex,
+	});
 
-  const handleEditorChange = (value: string | undefined): void => {
-    if (value !== undefined) {
-      setEditorContent(value);
-    }
-  };
+	const handleEditorChange = (value: string | undefined): void => {
+		if (value !== undefined) {
+			setEditorContent(value);
+		}
+	};
 
-  const navigateToLine = useCallback((lineNumber: number): void => {
-    const monacoEditor = monacoEditorRef.current;
-    if (!monacoEditor) {
-      return;
-    }
+	const navigateToLine = useCallback((lineNumber: number): void => {
+		const monacoEditor = monacoEditorRef.current;
+		if (!monacoEditor) {
+			return;
+		}
 
-    const model = monacoEditor.getModel();
-    if (!model) {
-      return;
-    }
+		const model = monacoEditor.getModel();
+		if (!model) {
+			return;
+		}
 
-    const clampLine = Math.min(Math.max(lineNumber, 1), model.getLineCount());
-    monacoEditor.revealLine(clampLine);
-    monacoEditor.setPosition({ lineNumber: clampLine, column: 1 });
-    monacoEditor.focus();
-  }, []);
+		const clampLine = Math.min(Math.max(lineNumber, 1), model.getLineCount());
+		monacoEditor.revealLine(clampLine);
+		monacoEditor.setPosition({ lineNumber: clampLine, column: 1 });
+		monacoEditor.focus();
+	}, []);
 
-  const focusEditor = useCallback((): void => {
-    const monacoEditor = monacoEditorRef.current;
-    if (!monacoEditor) {
-      return;
-    }
+	const focusEditor = useCallback((): void => {
+		const monacoEditor = monacoEditorRef.current;
+		if (!monacoEditor) {
+			return;
+		}
 
-    monacoEditor.focus();
-  }, []);
+		monacoEditor.focus();
+	}, []);
 
-  const editorMethods = useMemo(
-    () => ({
-      navigateToLine,
-      focus: focusEditor,
-    }),
-    [focusEditor, navigateToLine],
-  );
+	const editorMethods = useMemo(
+		() => ({
+			navigateToLine,
+			focus: focusEditor,
+		}),
+		[focusEditor, navigateToLine],
+	);
 
-  useImperativeHandle(ref, () => editorMethods, [editorMethods]);
-  useImperativeHandle(editorMethodsRef, () => editorMethods, [editorMethods]);
+	useImperativeHandle(ref, () => editorMethods, [editorMethods]);
+	useImperativeHandle(editorMethodsRef, () => editorMethods, [editorMethods]);
 
-  // Apply code changes from AI
-  const applyCodeChange = useCallback(
-    (codeBlock: CodeBlock): void => {
-      const monacoEditor = monacoEditorRef.current;
-      if (!monacoEditor) {
-        console.error("Editor not ready");
-        return;
-      }
+	// Apply code changes from AI
+	const applyCodeChange = useCallback(
+		(codeBlock: CodeBlock): void => {
+			const monacoEditor = monacoEditorRef.current;
+			if (!monacoEditor) {
+				console.error("Editor not ready");
+				return;
+			}
 
-      const model = monacoEditor.getModel();
-      if (!model) {
-        return;
-      }
+			const model = monacoEditor.getModel();
+			if (!model) {
+				return;
+			}
 
-      const clampLine = (line: number): number =>
-        Math.min(Math.max(line, 1), model.getLineCount());
+			const clampLine = (line: number): number => Math.min(Math.max(line, 1), model.getLineCount());
 
-      const clampColumn = (line: number, column?: number): number => {
-        const maxColumn = model.getLineMaxColumn(line);
-        const requested = column ?? 1;
-        return Math.min(Math.max(requested, 1), maxColumn);
-      };
+			const clampColumn = (line: number, column?: number): number => {
+				const maxColumn = model.getLineMaxColumn(line);
+				const requested = column ?? 1;
+				return Math.min(Math.max(requested, 1), maxColumn);
+			};
 
-      const editorContent = monacoEditor.getValue();
-      const contextAlertMessage =
-        "Unable to locate the suggested context in the current editor. Try running the suggestion again after scrolling the intended section into view.";
-      let contextMatchingFailed = false;
-      let contextAlertPending = false;
+			const editorContent = monacoEditor.getValue();
+			const contextAlertMessage =
+				"Unable to locate the suggested context in the current editor. Try running the suggestion again after scrolling the intended section into view.";
+			let contextMatchingFailed = false;
+			let contextAlertPending = false;
 
-      const resolveTargetRange = (): CodeRange | undefined => {
-        if (codeBlock.targetRange) {
-          return codeBlock.targetRange;
-        }
+			const resolveTargetRange = (): CodeRange | undefined => {
+				if (codeBlock.targetRange) {
+					return codeBlock.targetRange;
+				}
 
-        if (codeBlock.originalCode) {
-          return computeTargetRange(editorContent, codeBlock.originalCode) ?? undefined;
-        }
+				if (codeBlock.originalCode) {
+					return computeTargetRange(editorContent, codeBlock.originalCode) ?? undefined;
+				}
 
-        return undefined;
-      };
+				return undefined;
+			};
 
-      const applyRange = (range: CodeRange, text: string): void => {
-        monacoEditor.executeEdits("ai-apply", [
-          {
-            range: {
-              startLineNumber: clampLine(range.startLine),
-              startColumn: clampColumn(range.startLine, range.startColumn),
-              endLineNumber: clampLine(range.endLine),
-              endColumn: clampColumn(range.endLine, range.endColumn),
-            },
-            text,
-          },
-        ]);
-        setEditorContent(monacoEditor.getValue());
-      };
+			const applyRange = (range: CodeRange, text: string): void => {
+				monacoEditor.executeEdits("ai-apply", [
+					{
+						range: {
+							startLineNumber: clampLine(range.startLine),
+							startColumn: clampColumn(range.startLine, range.startColumn),
+							endLineNumber: clampLine(range.endLine),
+							endColumn: clampColumn(range.endLine, range.endColumn),
+						},
+						text,
+					},
+				]);
+				setEditorContent(monacoEditor.getValue());
+			};
 
-      const applySnapshotEdit = (snapshot: string, range: CodeRange, text: string): string => {
-        const lines = snapshot.split(/\r?\n/);
-        const startIndex = Math.max(range.startLine - 1, 0);
-        const endIndex = Math.min(range.endLine, lines.length);
-        const replacement = text.length ? text.split(/\r?\n/) : [];
-        return [...lines.slice(0, startIndex), ...replacement, ...lines.slice(endIndex)].join("\n");
-      };
+			const applySnapshotEdit = (snapshot: string, range: CodeRange, text: string): string => {
+				const lines = snapshot.split(/\r?\n/);
+				const startIndex = Math.max(range.startLine - 1, 0);
+				const endIndex = Math.min(range.endLine, lines.length);
+				const replacement = text.length ? text.split(/\r?\n/) : [];
+				return [...lines.slice(0, startIndex), ...replacement, ...lines.slice(endIndex)].join("\n");
+			};
 
-      const applySimpleChanges = (): boolean => {
-        if (!codeBlock.simpleChanges?.length) {
-          return false;
-        }
+			const applySimpleChanges = (): boolean => {
+				if (!codeBlock.simpleChanges?.length) {
+					return false;
+				}
 
-        const plannedEdits: Array<{ range: CodeRange; text: string }> = [];
-        let snapshot = editorContent;
-        let appliedCount = 0;
+				const plannedEdits: Array<{ range: CodeRange; text: string }> = [];
+				let snapshot = editorContent;
+				let appliedCount = 0;
 
-        for (const change of codeBlock.simpleChanges) {
-          const range = findCodeInEditor(snapshot, change.oldLines, change.beforeContext, change.afterContext);
-          if (!range) {
-            // If the new lines already exist, treat as already applied and continue.
-            const alreadyApplied = findCodeInEditor(snapshot, change.newLines, [], []);
-            if (alreadyApplied) {
-              appliedCount += 1;
-              continue;
-            }
-            contextMatchingFailed = true;
-            contextAlertPending = true;
-            recordPatchMatchFailure('Unable to match contextual diff block', codeBlock.id);
-            continue;
-          }
+				for (const change of codeBlock.simpleChanges) {
+					const range = findCodeInEditor(
+						snapshot,
+						change.oldLines,
+						change.beforeContext,
+						change.afterContext,
+					);
+					if (!range) {
+						// If the new lines already exist, treat as already applied and continue.
+						const alreadyApplied = findCodeInEditor(snapshot, change.newLines, [], []);
+						if (alreadyApplied) {
+							appliedCount += 1;
+							continue;
+						}
+						contextMatchingFailed = true;
+						contextAlertPending = true;
+						recordPatchMatchFailure("Unable to match contextual diff block", codeBlock.id);
+						continue;
+					}
 
-          const replacement = change.newLines.join("\n");
-          plannedEdits.push({ range, text: replacement });
-          snapshot = applySnapshotEdit(snapshot, range, replacement);
-          appliedCount += 1;
-        }
+					const replacement = change.newLines.join("\n");
+					plannedEdits.push({ range, text: replacement });
+					snapshot = applySnapshotEdit(snapshot, range, replacement);
+					appliedCount += 1;
+				}
 
-        if (!appliedCount) {
-          return false;
-        }
+				if (!appliedCount) {
+					return false;
+				}
 
-        for (const edit of plannedEdits) {
-          applyRange(edit.range, edit.text);
-        }
+				for (const edit of plannedEdits) {
+					applyRange(edit.range, edit.text);
+				}
 
-        recordPatchMatchSuccess();
-        return true;
-      };
+				recordPatchMatchSuccess();
+				return true;
+			};
 
-      const applyPatchChunks = (): boolean => {
-        if (!codeBlock.patchChunks?.length) {
-          return false;
-        }
+			const applyPatchChunks = (): boolean => {
+				if (!codeBlock.patchChunks?.length) {
+					return false;
+				}
 
-        const plannedEdits: Array<{ range: CodeRange; text: string }> = [];
-        let snapshot = editorContent;
+				const plannedEdits: Array<{ range: CodeRange; text: string }> = [];
+				let snapshot = editorContent;
 
-        for (const chunk of codeBlock.patchChunks) {
-          const range = matchPatchChunk(snapshot, chunk);
-          if (!range) {
-            const alreadyApplied = chunk.newLines.length
-              ? findCodeInEditor(snapshot, chunk.newLines, [], [])
-              : null;
-            if (alreadyApplied) {
-              continue;
-            }
-            console.warn("Unable to find context for patch chunk", chunk.context);
-            recordPatchMatchFailure(
-              `Unable to match patch chunk: ${chunk.context ?? 'missing context'}`,
-              codeBlock.id,
-            );
-            contextMatchingFailed = true;
-            contextAlertPending = true;
-            return false;
-          }
+				for (const chunk of codeBlock.patchChunks) {
+					const range = matchPatchChunk(snapshot, chunk);
+					if (!range) {
+						const alreadyApplied = chunk.newLines.length
+							? findCodeInEditor(snapshot, chunk.newLines, [], [])
+							: null;
+						if (alreadyApplied) {
+							continue;
+						}
+						console.warn("Unable to find context for patch chunk", chunk.context);
+						recordPatchMatchFailure(
+							`Unable to match patch chunk: ${chunk.context ?? "missing context"}`,
+							codeBlock.id,
+						);
+						contextMatchingFailed = true;
+						contextAlertPending = true;
+						return false;
+					}
 
-          const replacement = chunk.newLines.join("\n");
-          plannedEdits.push({ range, text: replacement });
-          snapshot = applySnapshotEdit(snapshot, range, replacement);
-        }
+					const replacement = chunk.newLines.join("\n");
+					plannedEdits.push({ range, text: replacement });
+					snapshot = applySnapshotEdit(snapshot, range, replacement);
+				}
 
-        for (const edit of plannedEdits) {
-          applyRange(edit.range, edit.text);
-        }
+				for (const edit of plannedEdits) {
+					applyRange(edit.range, edit.text);
+				}
 
-        recordPatchMatchSuccess();
-        return true;
-      };
+				recordPatchMatchSuccess();
+				return true;
+			};
 
-      const applyRangeChange = (text: string, alertOnFail = true): boolean => {
-        const range = resolveTargetRange();
-        if (!range) {
-          if (alertOnFail) {
-            console.warn("Missing target range for AI apply action", codeBlock.action);
-            recordPatchMatchFailure(
-              `Missing target range for ${codeBlock.action}`,
-              codeBlock.id,
-            );
-            const hasExplicitContext = Boolean(codeBlock.targetRange);
-            if (alertOnFail && contextAlertPending && hasExplicitContext && typeof window !== "undefined") {
-              window.alert(contextAlertMessage);
-            }
-          }
-          return false;
-        }
+			const applyRangeChange = (text: string, alertOnFail = true): boolean => {
+				const range = resolveTargetRange();
+				if (!range) {
+					if (alertOnFail) {
+						console.warn("Missing target range for AI apply action", codeBlock.action);
+						recordPatchMatchFailure(`Missing target range for ${codeBlock.action}`, codeBlock.id);
+						const hasExplicitContext = Boolean(codeBlock.targetRange);
+						if (
+							alertOnFail &&
+							contextAlertPending &&
+							hasExplicitContext &&
+							typeof window !== "undefined"
+						) {
+							window.alert(contextAlertMessage);
+						}
+					}
+					return false;
+				}
 
-        applyRange(range, text);
-        recordPatchMatchSuccess();
-        return true;
-      };
+				applyRange(range, text);
+				recordPatchMatchSuccess();
+				return true;
+			};
 
-      const hasStructuredContext = Boolean(
-        codeBlock.simpleChanges?.length ||
-          codeBlock.patchChunks?.length ||
-          codeBlock.targetRange,
-      );
+			const hasStructuredContext = Boolean(
+				codeBlock.simpleChanges?.length || codeBlock.patchChunks?.length || codeBlock.targetRange,
+			);
 
-      const effectiveAction =
-        codeBlock.action === "insert" && codeBlock.simpleChanges?.length
-          ? "replace-range"
-          : codeBlock.action === "insert" && !hasStructuredContext
-            ? "replace-all"
-            : codeBlock.action;
+			const effectiveAction =
+				codeBlock.action === "insert" && codeBlock.simpleChanges?.length
+					? "replace-range"
+					: codeBlock.action === "insert" && !hasStructuredContext
+						? "replace-all"
+						: codeBlock.action;
 
-      switch (effectiveAction) {
-        case "replace-all": {
-          const simpleApplied = applySimpleChanges();
-          const patchApplied = applyPatchChunks();
-          if (simpleApplied || patchApplied) {
-            break;
-          }
+			switch (effectiveAction) {
+				case "replace-all": {
+					const simpleApplied = applySimpleChanges();
+					const patchApplied = applyPatchChunks();
+					if (simpleApplied || patchApplied) {
+						break;
+					}
 
-          const appliedRange = applyRangeChange(codeBlock.code, false);
-          if (appliedRange) {
-            break;
-          }
+					const appliedRange = applyRangeChange(codeBlock.code, false);
+					if (appliedRange) {
+						break;
+					}
 
-          // Show confirmation dialog asynchronously
-          const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
-          const confirmationMessage = contextMatchingFailed
-            ? `Context matching failed, so this action will replace the entire ${target}. Proceed only if you understand the change.`
-            : `This AI suggestion will replace the entire ${target}. Proceed only if you understand the change.`;
-          showConfirm("Confirm Replace All", confirmationMessage).then((confirmed) => {
-            if (confirmed) {
-              monacoEditor.setValue(codeBlock.code);
-              setEditorContent(codeBlock.code);
-            }
-          });
-          break;
-        }
-        case "replace-range": {
-          const simpleApplied = applySimpleChanges();
-          const patchApplied = applyPatchChunks();
-          if (!simpleApplied && !patchApplied) {
-            const applied = applyRangeChange(codeBlock.code, contextMatchingFailed);
-            if (!applied) {
-              // No explicit context; offer to replace the whole file as a fallback
-              const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
-              showConfirm(
-                "Confirm Replace All",
-                `Could not match the suggested context. Replace the entire ${target} with the suggested code?`,
-              ).then((confirmed) => {
-                if (confirmed) {
-                  monacoEditor.setValue(codeBlock.code);
-                  setEditorContent(codeBlock.code);
-                }
-              });
-            }
-          }
-          break;
-        }
-        case "delete-range": {
-          const simpleApplied = applySimpleChanges();
-          const patchApplied = applyPatchChunks();
-          if (!simpleApplied && !patchApplied) {
-            applyRangeChange("", contextMatchingFailed);
-          }
-          break;
-        }
-        case "insert": {
-          const position = monacoEditor.getPosition();
-          if (position) {
-            applyRange(
-              {
-                startLine: position.lineNumber,
-                startColumn: position.column,
-                endLine: position.lineNumber,
-                endColumn: position.column,
-              },
-              codeBlock.code,
-            );
-          }
-          break;
-        }
-        case "create-file":
-          console.info("create-file action will be handled by file service");
-          break;
-        default:
-          console.warn("Unknown code block action", codeBlock.action);
-      }
-    },
-    [setEditorContent, showConfirm, recordPatchMatchFailure, recordPatchMatchSuccess],
-  );
+					// Show confirmation dialog asynchronously
+					const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
+					const confirmationMessage = contextMatchingFailed
+						? `Context matching failed, so this action will replace the entire ${target}. Proceed only if you understand the change.`
+						: `This AI suggestion will replace the entire ${target}. Proceed only if you understand the change.`;
+					showConfirm("Confirm Replace All", confirmationMessage).then((confirmed) => {
+						if (confirmed) {
+							monacoEditor.setValue(codeBlock.code);
+							setEditorContent(codeBlock.code);
+						}
+					});
+					break;
+				}
+				case "replace-range": {
+					const simpleApplied = applySimpleChanges();
+					const patchApplied = applyPatchChunks();
+					if (!simpleApplied && !patchApplied) {
+						const applied = applyRangeChange(codeBlock.code, contextMatchingFailed);
+						if (!applied) {
+							// No explicit context; offer to replace the whole file as a fallback
+							const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
+							showConfirm(
+								"Confirm Replace All",
+								`Could not match the suggested context. Replace the entire ${target} with the suggested code?`,
+							).then((confirmed) => {
+								if (confirmed) {
+									monacoEditor.setValue(codeBlock.code);
+									setEditorContent(codeBlock.code);
+								}
+							});
+						}
+					}
+					break;
+				}
+				case "delete-range": {
+					const simpleApplied = applySimpleChanges();
+					const patchApplied = applyPatchChunks();
+					if (!simpleApplied && !patchApplied) {
+						applyRangeChange("", contextMatchingFailed);
+					}
+					break;
+				}
+				case "insert": {
+					const position = monacoEditor.getPosition();
+					if (position) {
+						applyRange(
+							{
+								startLine: position.lineNumber,
+								startColumn: position.column,
+								endLine: position.lineNumber,
+								endColumn: position.column,
+							},
+							codeBlock.code,
+						);
+					}
+					break;
+				}
+				case "create-file":
+					console.info("create-file action will be handled by file service");
+					break;
+				default:
+					console.warn("Unknown code block action", codeBlock.action);
+			}
+		},
+		[setEditorContent, showConfirm, recordPatchMatchFailure, recordPatchMatchSuccess],
+	);
 
-  useEffect(() => {
-    setApplyCodeChange(applyCodeChange);
-  }, [applyCodeChange, setApplyCodeChange]);
+	useEffect(() => {
+		setApplyCodeChange(applyCodeChange);
+	}, [applyCodeChange, setApplyCodeChange]);
 
-  useEffect(() => {
-    setEditorRef(editorMethodsRef);
-    return () => {
-      setEditorRef(null);
-    };
-  }, [editorMethodsRef, setEditorRef]);
+	useEffect(() => {
+		setEditorRef(editorMethodsRef);
+		return () => {
+			setEditorRef(null);
+		};
+	}, [editorMethodsRef, setEditorRef]);
 
-  useEffect(() => {
-    setRunCurrentCell(handleRunCurrentCell);
-    setRunAll(handleRunAll);
-  }, [handleRunCurrentCell, handleRunAll, setRunCurrentCell, setRunAll]);
+	useEffect(() => {
+		setRunCurrentCell(handleRunCurrentCell);
+		setRunAll(handleRunAll);
+	}, [handleRunCurrentCell, handleRunAll, setRunCurrentCell, setRunAll]);
 
-  const handleEditorDidMount = (
-    monacoEditor: MonacoEditor.IStandaloneCodeEditor,
-    monaco: Monaco,
-  ): void => {
-    monacoEditorRef.current = monacoEditor;
-    setMonacoEditor(monacoEditor);
+	const handleEditorDidMount = (
+		monacoEditor: MonacoEditor.IStandaloneCodeEditor,
+		monaco: Monaco,
+	): void => {
+		monacoEditorRef.current = monacoEditor;
+		setMonacoEditor(monacoEditor);
 
-    // Track cursor position
-    monacoEditor.onDidChangeCursorPosition((e) => {
-      setEditorCursorPosition({
-        line: e.position.lineNumber,
-        column: e.position.column,
-      });
-    });
+		// Track cursor position
+		monacoEditor.onDidChangeCursorPosition((e) => {
+			setEditorCursorPosition({
+				line: e.position.lineNumber,
+				column: e.position.column,
+			});
+		});
 
-    // Keyboard shortcuts
-    // Cmd/Ctrl + Enter: Run current cell
-    monacoEditor.addCommand(
-      monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
-      () => {
-        handleRunCurrentCell();
-      },
-    );
+		// Keyboard shortcuts
+		// Cmd/Ctrl + Enter: Run current cell
+		monacoEditor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+			handleRunCurrentCell();
+		});
 
-    // Shift + Enter: Run current cell and move to next
-    monacoEditor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
-      handleRunCellAndMoveNext();
-    });
+		// Shift + Enter: Run current cell and move to next
+		monacoEditor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
+			handleRunCellAndMoveNext();
+		});
 
-    // Cmd/Ctrl + Shift + Enter: Run all
-    monacoEditor.addCommand(
-      monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter,
-      () => {
-        handleRunAll();
-      },
-    );
-  };
+		// Cmd/Ctrl + Shift + Enter: Run all
+		monacoEditor.addCommand(
+			monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter,
+			() => {
+				handleRunAll();
+			},
+		);
+	};
 
-  return (
-    <>
-      <div className="panel editor-panel">
-        <div className="panel-header">
-          <div className="panel-title">
-            {editor.filepath || "Untitled.R"}
-            {editor.isDirty && <span className="dirty-marker"> •</span>}
-          </div>
-          <div className="panel-actions">
-            <button
-              className="btn"
-              onClick={handleRunCurrentCell}
-              disabled={execution.isRunning}
-              title="Run Current Cell (Cmd/Ctrl+Enter)"
-            >
-              <IconPlay width={16} height={16} aria-hidden />
-              Run Selection
-            </button>
-            <button
-              className="btn btn-primary"
-              onClick={handleRunAll}
-              disabled={execution.isRunning}
-              title="Run All (Cmd/Ctrl+Shift+Enter)"
-            >
-              {execution.isRunning ? (
-                <>
-                  <div className="spinner"></div>
-                  Running
-                </>
-              ) : (
-                <>
-                  <IconPlayCircle width={16} height={16} aria-hidden />
-                  Run All
-                </>
-              )}
-            </button>
-          </div>
-        </div>
-        <div className="panel-content">
-          <Editor
-            height="100%"
-            defaultLanguage="r"
-            theme="vs"
-            value={editor.content}
-            onChange={handleEditorChange}
-          options={{
-            fontSize: settings.fontSize,
-            fontFamily: "Monaco, Menlo, Consolas, monospace",
-            minimap: { enabled: false },
-            scrollBeyondLastLine: false,
-              wordWrap: "on",
-              lineNumbers: "on",
-              renderWhitespace: "selection",
-              tabSize: 2,
-              automaticLayout: true,
-              padding: { top: 8, bottom: 8 },
-              scrollbar: {
-                useShadows: false,
-                verticalScrollbarSize: 12,
-                horizontalScrollbarSize: 12,
-              },
-            }}
-            onMount={handleEditorDidMount}
-          />
-        </div>
-      </div>
-      <ConfirmDialog
-        open={dialogState.open}
-        title={dialogState.title}
-        message={dialogState.message}
-        onConfirm={handleConfirm}
-        onCancel={handleCancel}
-      />
-    </>
-  );
+	return (
+		<>
+			<div className="panel editor-panel">
+				<div className="panel-header">
+					<div className="panel-title">
+						{editor.filepath || "Untitled.R"}
+						{editor.isDirty && <span className="dirty-marker"> •</span>}
+					</div>
+					<div className="panel-actions">
+						<button
+							className="btn"
+							onClick={handleRunCurrentCell}
+							disabled={execution.isRunning}
+							title="Run Current Cell (Cmd/Ctrl+Enter)"
+						>
+							<IconPlay width={16} height={16} aria-hidden />
+							Run Selection
+						</button>
+						<button
+							className="btn btn-primary"
+							onClick={handleRunAll}
+							disabled={execution.isRunning}
+							title="Run All (Cmd/Ctrl+Shift+Enter)"
+						>
+							{execution.isRunning ? (
+								<>
+									<div className="spinner"></div>
+									Running
+								</>
+							) : (
+								<>
+									<IconPlayCircle width={16} height={16} aria-hidden />
+									Run All
+								</>
+							)}
+						</button>
+					</div>
+				</div>
+				<div className="panel-content">
+					<Editor
+						height="100%"
+						defaultLanguage="r"
+						theme="vs"
+						value={editor.content}
+						onChange={handleEditorChange}
+						options={{
+							fontSize: settings.fontSize,
+							fontFamily: "Monaco, Menlo, Consolas, monospace",
+							minimap: { enabled: false },
+							scrollBeyondLastLine: false,
+							wordWrap: "on",
+							lineNumbers: "on",
+							renderWhitespace: "selection",
+							tabSize: 2,
+							automaticLayout: true,
+							padding: { top: 8, bottom: 8 },
+							scrollbar: {
+								useShadows: false,
+								verticalScrollbarSize: 12,
+								horizontalScrollbarSize: 12,
+							},
+						}}
+						onMount={handleEditorDidMount}
+					/>
+				</div>
+			</div>
+			<ConfirmDialog
+				open={dialogState.open}
+				title={dialogState.title}
+				message={dialogState.message}
+				onConfirm={handleConfirm}
+				onCancel={handleCancel}
+			/>
+		</>
+	);
 }
 
 export const EditorPanel = forwardRef<EditorRef>(EditorPanelComponent);

--- a/client/src/components/editor/editorRef.ts
+++ b/client/src/components/editor/editorRef.ts
@@ -1,4 +1,4 @@
 export interface EditorRef {
-  navigateToLine: (lineNumber: number) => void;
-  focus: () => void;
+	navigateToLine: (lineNumber: number) => void;
+	focus: () => void;
 }

--- a/client/src/components/editor/index.ts
+++ b/client/src/components/editor/index.ts
@@ -1,1 +1,1 @@
-export { EditorPanel } from './EditorPanel';
+export { EditorPanel } from "./EditorPanel";

--- a/client/src/components/export/ExportDialog.tsx
+++ b/client/src/components/export/ExportDialog.tsx
@@ -1,281 +1,277 @@
-import { useExportDialog } from '@/hooks/useExportDialog';
+import { useExportDialog } from "@/hooks/useExportDialog";
 
 interface ExportDialogProps {
-  open: boolean;
-  onClose: () => void;
+	open: boolean;
+	onClose: () => void;
 }
 
 export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element | null {
-  const {
-    format,
-    setFormat,
-    mode,
-    setMode,
-    options,
-    setOption,
-    documentPath,
-    setDocumentPath,
-    outputPath,
-    setOutputPath,
-    exporting,
-    error,
-    handleExport,
-  } = useExportDialog({ open, onClose });
+	const {
+		format,
+		setFormat,
+		mode,
+		setMode,
+		options,
+		setOption,
+		documentPath,
+		setDocumentPath,
+		outputPath,
+		setOutputPath,
+		exporting,
+		error,
+		handleExport,
+	} = useExportDialog({ open, onClose });
 
-  if (!open) return null;
+	if (!open) return null;
 
-  return (
-    <div
-      className="export-dialog-overlay"
-      onClick={exporting ? undefined : onClose}
-      tabIndex={-1}
-      onKeyDown={(e) => {
-        if (!exporting && e.key === 'Escape') {
-          onClose();
-        }
-      }}
-    >
-      <div
-        className="export-dialog"
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="export-dialog-title"
-        aria-describedby="export-dialog-description"
-      >
-        <div className="export-dialog-header">
-          <h2 id="export-dialog-title">Export Analysis</h2>
-          <button
-            className="btn btn-icon"
-            onClick={onClose}
-            disabled={exporting}
-            aria-label="Close dialog"
-          >
-            ×
-          </button>
-        </div>
+	return (
+		<div
+			className="export-dialog-overlay"
+			onClick={exporting ? undefined : onClose}
+			tabIndex={-1}
+			onKeyDown={(e) => {
+				if (!exporting && e.key === "Escape") {
+					onClose();
+				}
+			}}
+		>
+			<div
+				className="export-dialog"
+				onClick={(e) => e.stopPropagation()}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="export-dialog-title"
+				aria-describedby="export-dialog-description"
+			>
+				<div className="export-dialog-header">
+					<h2 id="export-dialog-title">Export Analysis</h2>
+					<button
+						className="btn btn-icon"
+						onClick={onClose}
+						disabled={exporting}
+						aria-label="Close dialog"
+					>
+						×
+					</button>
+				</div>
 
-        <div className={`export-dialog-content ${exporting ? 'loading' : ''}`}>
-          <div className="export-section">
-            <label className="export-label" id="format-label">
-              Format
-            </label>
-            <div className="export-radio-group" role="radiogroup" aria-labelledby="format-label">
-              <label className="export-radio">
-                <input
-                  type="radio"
-                  name="format"
-                  value="bundle"
-                  checked={format === 'bundle'}
-                  onChange={(e) => setFormat(e.target.value as typeof format)}
-                  disabled={exporting}
-                  aria-label="Reproduction Bundle"
-                />
-                <span>Reproduction Bundle (.tar.gz)</span>
-              </label>
-              <label className="export-radio">
-                <input
-                  type="radio"
-                  name="format"
-                  value="rmarkdown"
-                  checked={format === 'rmarkdown'}
-                  onChange={(e) => setFormat(e.target.value as typeof format)}
-                  disabled={exporting}
-                  aria-label="RMarkdown Document"
-                />
-                <span>RMarkdown Document (.Rmd)</span>
-              </label>
-              <label className="export-radio">
-                <input
-                  type="radio"
-                  name="format"
-                  value="both"
-                  checked={format === 'both'}
-                  onChange={(e) => setFormat(e.target.value as typeof format)}
-                  disabled={exporting}
-                  aria-label="Both formats"
-                />
-                <span>Both</span>
-              </label>
-            </div>
-          </div>
+				<div className={`export-dialog-content ${exporting ? "loading" : ""}`}>
+					<div className="export-section">
+						<label className="export-label" id="format-label">
+							Format
+						</label>
+						<div className="export-radio-group" role="radiogroup" aria-labelledby="format-label">
+							<label className="export-radio">
+								<input
+									type="radio"
+									name="format"
+									value="bundle"
+									checked={format === "bundle"}
+									onChange={(e) => setFormat(e.target.value as typeof format)}
+									disabled={exporting}
+									aria-label="Reproduction Bundle"
+								/>
+								<span>Reproduction Bundle (.tar.gz)</span>
+							</label>
+							<label className="export-radio">
+								<input
+									type="radio"
+									name="format"
+									value="rmarkdown"
+									checked={format === "rmarkdown"}
+									onChange={(e) => setFormat(e.target.value as typeof format)}
+									disabled={exporting}
+									aria-label="RMarkdown Document"
+								/>
+								<span>RMarkdown Document (.Rmd)</span>
+							</label>
+							<label className="export-radio">
+								<input
+									type="radio"
+									name="format"
+									value="both"
+									checked={format === "both"}
+									onChange={(e) => setFormat(e.target.value as typeof format)}
+									disabled={exporting}
+									aria-label="Both formats"
+								/>
+								<span>Both</span>
+							</label>
+						</div>
+					</div>
 
-          {(format === 'rmarkdown' || format === 'both') && (
-            <>
-              <div className="export-section">
-                <label className="export-label" id="mode-label">
-                  Export Mode
-                </label>
-                <div className="export-radio-group" role="radiogroup" aria-labelledby="mode-label">
-                  <label className="export-radio">
-                    <input
-                      type="radio"
-                      name="mode"
-                      value="timeline"
-                      checked={mode === 'timeline'}
-                      onChange={(e) => setMode(e.target.value as typeof mode)}
-                      disabled={exporting}
-                      aria-label="Timeline-Based mode"
-                    />
-                    <div className="export-radio-content">
-                      <span className="export-radio-title">Timeline-Based (Actual Execution)</span>
-                      <span className="export-radio-description">
-                        Export what actually ran in console, including AI suggestions and exploration
-                        attempts
-                      </span>
-                    </div>
-                  </label>
-                  <label className="export-radio">
-                    <input
-                      type="radio"
-                      name="mode"
-                      value="document"
-                      checked={mode === 'document'}
-                      onChange={(e) => setMode(e.target.value as typeof mode)}
-                      disabled={exporting}
-                      aria-label="Document-Based mode"
-                    />
-                    <div className="export-radio-content">
-                      <span className="export-radio-title">Document-Based (Current File)</span>
-                      <span className="export-radio-description">
-                        Export the currently open .R file with cleaned, curated code
-                      </span>
-                    </div>
-                  </label>
-                </div>
-              </div>
+					{(format === "rmarkdown" || format === "both") && (
+						<>
+							<div className="export-section">
+								<label className="export-label" id="mode-label">
+									Export Mode
+								</label>
+								<div className="export-radio-group" role="radiogroup" aria-labelledby="mode-label">
+									<label className="export-radio">
+										<input
+											type="radio"
+											name="mode"
+											value="timeline"
+											checked={mode === "timeline"}
+											onChange={(e) => setMode(e.target.value as typeof mode)}
+											disabled={exporting}
+											aria-label="Timeline-Based mode"
+										/>
+										<div className="export-radio-content">
+											<span className="export-radio-title">Timeline-Based (Actual Execution)</span>
+											<span className="export-radio-description">
+												Export what actually ran in console, including AI suggestions and
+												exploration attempts
+											</span>
+										</div>
+									</label>
+									<label className="export-radio">
+										<input
+											type="radio"
+											name="mode"
+											value="document"
+											checked={mode === "document"}
+											onChange={(e) => setMode(e.target.value as typeof mode)}
+											disabled={exporting}
+											aria-label="Document-Based mode"
+										/>
+										<div className="export-radio-content">
+											<span className="export-radio-title">Document-Based (Current File)</span>
+											<span className="export-radio-description">
+												Export the currently open .R file with cleaned, curated code
+											</span>
+										</div>
+									</label>
+								</div>
+							</div>
 
-              {mode === 'document' && (
-                <div className="export-section">
-                  <label className="export-label" htmlFor="documentPath">
-                    Document Path
-                  </label>
-                  <input
-                    type="text"
-                    id="documentPath"
-                    className="export-input"
-                    value={documentPath}
-                    onChange={(e) => setDocumentPath(e.target.value)}
-                    placeholder="analysis.R"
-                    disabled={exporting}
-                    aria-required="true"
-                    aria-describedby="documentPath-hint"
-                  />
-                  <p id="documentPath-hint" className="export-hint">
-                    Path to the R file to export
-                  </p>
-                </div>
-              )}
+							{mode === "document" && (
+								<div className="export-section">
+									<label className="export-label" htmlFor="documentPath">
+										Document Path
+									</label>
+									<input
+										type="text"
+										id="documentPath"
+										className="export-input"
+										value={documentPath}
+										onChange={(e) => setDocumentPath(e.target.value)}
+										placeholder="analysis.R"
+										disabled={exporting}
+										aria-required="true"
+										aria-describedby="documentPath-hint"
+									/>
+									<p id="documentPath-hint" className="export-hint">
+										Path to the R file to export
+									</p>
+								</div>
+							)}
 
-              <div className="export-section">
-                <label className="export-label" id="options-label">
-                  Options
-                </label>
-                <div
-                  className="export-checkbox-group"
-                  role="group"
-                  aria-labelledby="options-label"
-                >
-                  <label className="export-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={options.includeTimestamps}
-                      onChange={(e) => setOption('includeTimestamps', e.target.checked)}
-                      disabled={exporting}
-                      aria-label="Include timestamps in export"
-                    />
-                    <span>Include timestamps</span>
-                  </label>
-                  <label className="export-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={options.showActor}
-                      onChange={(e) => setOption('showActor', e.target.checked)}
-                      disabled={exporting}
-                      aria-label="Show actor for each chunk"
-                    />
-                    <span>Show actor (User/AI) for each chunk</span>
-                  </label>
-                  <label className="export-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={options.embedPlots}
-                      onChange={(e) => setOption('embedPlots', e.target.checked)}
-                      disabled={exporting}
-                      aria-label="Embed plot images inline"
-                    />
-                    <span>Embed plot images inline</span>
-                  </label>
-                  <label className="export-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={options.includeOutputs}
-                      onChange={(e) => setOption('includeOutputs', e.target.checked)}
-                      disabled={exporting}
-                      aria-label="Include execution outputs"
-                    />
-                    <span>Include execution outputs</span>
-                  </label>
-                  <label className="export-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={options.includeErrors}
-                      onChange={(e) => setOption('includeErrors', e.target.checked)}
-                      disabled={exporting}
-                      aria-label="Include error messages"
-                    />
-                    <span>Include error messages</span>
-                  </label>
-                  <label className="export-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={options.includeSummary}
-                      onChange={(e) => setOption('includeSummary', e.target.checked)}
-                      disabled={exporting}
-                      aria-label="Add session statistics summary"
-                    />
-                    <span>Add session statistics summary</span>
-                  </label>
-                </div>
-              </div>
+							<div className="export-section">
+								<label className="export-label" id="options-label">
+									Options
+								</label>
+								<div className="export-checkbox-group" role="group" aria-labelledby="options-label">
+									<label className="export-checkbox">
+										<input
+											type="checkbox"
+											checked={options.includeTimestamps}
+											onChange={(e) => setOption("includeTimestamps", e.target.checked)}
+											disabled={exporting}
+											aria-label="Include timestamps in export"
+										/>
+										<span>Include timestamps</span>
+									</label>
+									<label className="export-checkbox">
+										<input
+											type="checkbox"
+											checked={options.showActor}
+											onChange={(e) => setOption("showActor", e.target.checked)}
+											disabled={exporting}
+											aria-label="Show actor for each chunk"
+										/>
+										<span>Show actor (User/AI) for each chunk</span>
+									</label>
+									<label className="export-checkbox">
+										<input
+											type="checkbox"
+											checked={options.embedPlots}
+											onChange={(e) => setOption("embedPlots", e.target.checked)}
+											disabled={exporting}
+											aria-label="Embed plot images inline"
+										/>
+										<span>Embed plot images inline</span>
+									</label>
+									<label className="export-checkbox">
+										<input
+											type="checkbox"
+											checked={options.includeOutputs}
+											onChange={(e) => setOption("includeOutputs", e.target.checked)}
+											disabled={exporting}
+											aria-label="Include execution outputs"
+										/>
+										<span>Include execution outputs</span>
+									</label>
+									<label className="export-checkbox">
+										<input
+											type="checkbox"
+											checked={options.includeErrors}
+											onChange={(e) => setOption("includeErrors", e.target.checked)}
+											disabled={exporting}
+											aria-label="Include error messages"
+										/>
+										<span>Include error messages</span>
+									</label>
+									<label className="export-checkbox">
+										<input
+											type="checkbox"
+											checked={options.includeSummary}
+											onChange={(e) => setOption("includeSummary", e.target.checked)}
+											disabled={exporting}
+											aria-label="Add session statistics summary"
+										/>
+										<span>Add session statistics summary</span>
+									</label>
+								</div>
+							</div>
 
-              <div className="export-section">
-                <label className="export-label" htmlFor="outputPath">
-                  Output Path
-                </label>
-                <input
-                  type="text"
-                  id="outputPath"
-                  className="export-input"
-                  value={outputPath}
-                  onChange={(e) => setOutputPath(e.target.value)}
-                  disabled={exporting}
-                  aria-required="true"
-                  aria-describedby="outputPath-hint"
-                />
-                <p id="outputPath-hint" className="export-hint">
-                  File path where the RMarkdown will be saved
-                </p>
-              </div>
-            </>
-          )}
+							<div className="export-section">
+								<label className="export-label" htmlFor="outputPath">
+									Output Path
+								</label>
+								<input
+									type="text"
+									id="outputPath"
+									className="export-input"
+									value={outputPath}
+									onChange={(e) => setOutputPath(e.target.value)}
+									disabled={exporting}
+									aria-required="true"
+									aria-describedby="outputPath-hint"
+								/>
+								<p id="outputPath-hint" className="export-hint">
+									File path where the RMarkdown will be saved
+								</p>
+							</div>
+						</>
+					)}
 
-          {error && (
-            <div className="export-error" role="alert" aria-live="polite">
-              <span>{error}</span>
-            </div>
-          )}
-        </div>
+					{error && (
+						<div className="export-error" role="alert" aria-live="polite">
+							<span>{error}</span>
+						</div>
+					)}
+				</div>
 
-        <div className="export-dialog-footer">
-          <button className="btn" onClick={onClose} disabled={exporting}>
-            Cancel
-          </button>
-          <button className="btn btn-primary" onClick={handleExport} disabled={exporting}>
-            {exporting ? 'Exporting...' : 'Export'}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+				<div className="export-dialog-footer">
+					<button className="btn" onClick={onClose} disabled={exporting}>
+						Cancel
+					</button>
+					<button className="btn btn-primary" onClick={handleExport} disabled={exporting}>
+						{exporting ? "Exporting..." : "Export"}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/export/__tests__/ExportDialog.test.tsx
+++ b/client/src/components/export/__tests__/ExportDialog.test.tsx
@@ -1,346 +1,350 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { vi } from 'vitest';
-import { ExportDialog } from '../ExportDialog';
-import { socketService } from '@/services/socket';
-
-describe('ExportDialog', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('sends the nested request payload and closes when export succeeds', async () => {
-    const sendMock = vi.fn((request, handler) => {
-      handler({
-        type: 'export_rmarkdown_response',
-        response: {
-          success: true,
-          outputPath: 'analysis_report.Rmd',
-        },
-      });
-      return true;
-    });
-
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
-
-    render(<ExportDialog open onClose={onClose} />);
-
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
-
-    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
-
-    expect(sendMock).toHaveBeenCalledTimes(1);
-    const [sentRequest] = sendMock.mock.calls[0];
-    expect(sentRequest.type).toBe('export_rmarkdown');
-    expect(sentRequest.request).toMatchObject({
-      mode: 'timeline',
-      outputPath: 'analysis_report.Rmd',
-      includeTimestamps: true,
-      showActor: true,
-      embedPlots: true,
-      includeOutputs: true,
-      includeErrors: false,
-      includeSummary: true,
-    });
-    expect(sentRequest.request.documentPath).toBeUndefined();
-  });
-
-  it('shows an error message when the backend reports a failure and keeps the dialog open', async () => {
-    const sendMock = vi.fn((request, handler) => {
-      handler({
-        type: 'export_rmarkdown_response',
-        response: {
-          success: false,
-          outputPath: '',
-          error: 'Export failed',
-        },
-      });
-      return true;
-    });
-
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
-
-    render(<ExportDialog open onClose={onClose} />);
-
-    fireEvent.click(screen.getByRole('radio', { name: /Document-Based/i }));
-    const documentPathInput = screen.getByLabelText('Document Path');
-    fireEvent.change(documentPathInput, { target: { value: '/tmp/report.R' } });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
-
-    await waitFor(() => {
-      expect(screen.getByText('Export failed')).toBeInTheDocument();
-    });
-
-    expect(onClose).not.toHaveBeenCalled();
-    const [sentRequest] = sendMock.mock.calls[0];
-    expect(sentRequest.request.documentPath).toBe('/tmp/report.R');
-  });
-
-  it('toggles includeTimestamps option correctly', async () => {
-    const sendMock = vi.fn((request, handler) => {
-      handler({
-        type: 'export_rmarkdown_response',
-        response: { success: true, outputPath: 'test.Rmd' },
-      });
-      return true;
-    });
-
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
-
-    render(<ExportDialog open onClose={onClose} />);
-
-    const timestampsCheckbox = screen.getByLabelText('Include timestamps');
-    expect(timestampsCheckbox).toBeChecked();
-
-    fireEvent.click(timestampsCheckbox);
-    expect(timestampsCheckbox).not.toBeChecked();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import { socketService } from "@/services/socket";
+import { ExportDialog } from "../ExportDialog";
+
+describe("ExportDialog", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("sends the nested request payload and closes when export succeeds", async () => {
+		const sendMock = vi.fn((request, handler) => {
+			handler({
+				type: "export_rmarkdown_response",
+				response: {
+					success: true,
+					outputPath: "analysis_report.Rmd",
+				},
+			});
+			return true;
+		});
+
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
+
+		render(<ExportDialog open onClose={onClose} />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
+
+		await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+
+		expect(sendMock).toHaveBeenCalledTimes(1);
+		const [sentRequest] = sendMock.mock.calls[0];
+		expect(sentRequest.type).toBe("export_rmarkdown");
+		expect(sentRequest.request).toMatchObject({
+			mode: "timeline",
+			outputPath: "analysis_report.Rmd",
+			includeTimestamps: true,
+			showActor: true,
+			embedPlots: true,
+			includeOutputs: true,
+			includeErrors: false,
+			includeSummary: true,
+		});
+		expect(sentRequest.request.documentPath).toBeUndefined();
+	});
+
+	it("shows an error message when the backend reports a failure and keeps the dialog open", async () => {
+		const sendMock = vi.fn((request, handler) => {
+			handler({
+				type: "export_rmarkdown_response",
+				response: {
+					success: false,
+					outputPath: "",
+					error: "Export failed",
+				},
+			});
+			return true;
+		});
+
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
+
+		render(<ExportDialog open onClose={onClose} />);
+
+		fireEvent.click(screen.getByRole("radio", { name: /Document-Based/i }));
+		const documentPathInput = screen.getByLabelText("Document Path");
+		fireEvent.change(documentPathInput, { target: { value: "/tmp/report.R" } });
+
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
+
+		await waitFor(() => {
+			expect(screen.getByText("Export failed")).toBeInTheDocument();
+		});
+
+		expect(onClose).not.toHaveBeenCalled();
+		const [sentRequest] = sendMock.mock.calls[0];
+		expect(sentRequest.request.documentPath).toBe("/tmp/report.R");
+	});
+
+	it("toggles includeTimestamps option correctly", async () => {
+		const sendMock = vi.fn((request, handler) => {
+			handler({
+				type: "export_rmarkdown_response",
+				response: { success: true, outputPath: "test.Rmd" },
+			});
+			return true;
+		});
+
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
+
+		render(<ExportDialog open onClose={onClose} />);
+
+		const timestampsCheckbox = screen.getByLabelText("Include timestamps");
+		expect(timestampsCheckbox).toBeChecked();
+
+		fireEvent.click(timestampsCheckbox);
+		expect(timestampsCheckbox).not.toBeChecked();
+
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
 
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
 
-    const [sentRequest] = sendMock.mock.calls[0];
-    expect(sentRequest.request.includeTimestamps).toBe(false);
-  });
+		const [sentRequest] = sendMock.mock.calls[0];
+		expect(sentRequest.request.includeTimestamps).toBe(false);
+	});
 
-  it('toggles showActor option correctly', async () => {
-    const sendMock = vi.fn((request, handler) => {
-      handler({
-        type: 'export_rmarkdown_response',
-        response: { success: true, outputPath: 'test.Rmd' },
-      });
-      return true;
-    });
+	it("toggles showActor option correctly", async () => {
+		const sendMock = vi.fn((request, handler) => {
+			handler({
+				type: "export_rmarkdown_response",
+				response: { success: true, outputPath: "test.Rmd" },
+			});
+			return true;
+		});
 
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
 
-    render(<ExportDialog open onClose={onClose} />);
+		render(<ExportDialog open onClose={onClose} />);
 
-    const actorCheckbox = screen.getByLabelText('Show actor (User/AI) for each chunk');
-    expect(actorCheckbox).toBeChecked();
+		const actorCheckbox = screen.getByLabelText("Show actor (User/AI) for each chunk");
+		expect(actorCheckbox).toBeChecked();
 
-    fireEvent.click(actorCheckbox);
-    expect(actorCheckbox).not.toBeChecked();
+		fireEvent.click(actorCheckbox);
+		expect(actorCheckbox).not.toBeChecked();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
 
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
 
-    const [sentRequest] = sendMock.mock.calls[0];
-    expect(sentRequest.request.showActor).toBe(false);
-  });
+		const [sentRequest] = sendMock.mock.calls[0];
+		expect(sentRequest.request.showActor).toBe(false);
+	});
 
-  it('toggles embedPlots option correctly', async () => {
-    const sendMock = vi.fn((request, handler) => {
-      handler({
-        type: 'export_rmarkdown_response',
-        response: { success: true, outputPath: 'test.Rmd' },
-      });
-      return true;
-    });
+	it("toggles embedPlots option correctly", async () => {
+		const sendMock = vi.fn((request, handler) => {
+			handler({
+				type: "export_rmarkdown_response",
+				response: { success: true, outputPath: "test.Rmd" },
+			});
+			return true;
+		});
 
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
 
-    render(<ExportDialog open onClose={onClose} />);
+		render(<ExportDialog open onClose={onClose} />);
 
-    const plotsCheckbox = screen.getByLabelText('Embed plot images inline');
-    expect(plotsCheckbox).toBeChecked();
+		const plotsCheckbox = screen.getByLabelText("Embed plot images inline");
+		expect(plotsCheckbox).toBeChecked();
 
-    fireEvent.click(plotsCheckbox);
-    expect(plotsCheckbox).not.toBeChecked();
+		fireEvent.click(plotsCheckbox);
+		expect(plotsCheckbox).not.toBeChecked();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
 
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
 
-    const [sentRequest] = sendMock.mock.calls[0];
-    expect(sentRequest.request.embedPlots).toBe(false);
-  });
+		const [sentRequest] = sendMock.mock.calls[0];
+		expect(sentRequest.request.embedPlots).toBe(false);
+	});
 
-  it('toggles includeOutputs option correctly', async () => {
-    const sendMock = vi.fn((request, handler) => {
-      handler({
-        type: 'export_rmarkdown_response',
-        response: { success: true, outputPath: 'test.Rmd' },
-      });
-      return true;
-    });
+	it("toggles includeOutputs option correctly", async () => {
+		const sendMock = vi.fn((request, handler) => {
+			handler({
+				type: "export_rmarkdown_response",
+				response: { success: true, outputPath: "test.Rmd" },
+			});
+			return true;
+		});
 
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
 
-    render(<ExportDialog open onClose={onClose} />);
+		render(<ExportDialog open onClose={onClose} />);
 
-    const outputsCheckbox = screen.getByLabelText('Include execution outputs');
-    expect(outputsCheckbox).toBeChecked();
+		const outputsCheckbox = screen.getByLabelText("Include execution outputs");
+		expect(outputsCheckbox).toBeChecked();
 
-    fireEvent.click(outputsCheckbox);
-    expect(outputsCheckbox).not.toBeChecked();
+		fireEvent.click(outputsCheckbox);
+		expect(outputsCheckbox).not.toBeChecked();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
 
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
 
-    const [sentRequest] = sendMock.mock.calls[0];
-    expect(sentRequest.request.includeOutputs).toBe(false);
-  });
+		const [sentRequest] = sendMock.mock.calls[0];
+		expect(sentRequest.request.includeOutputs).toBe(false);
+	});
 
-  it('toggles includeErrors option correctly', async () => {
-    const sendMock = vi.fn((request, handler) => {
-      handler({
-        type: 'export_rmarkdown_response',
-        response: { success: true, outputPath: 'test.Rmd' },
-      });
-      return true;
-    });
+	it("toggles includeErrors option correctly", async () => {
+		const sendMock = vi.fn((request, handler) => {
+			handler({
+				type: "export_rmarkdown_response",
+				response: { success: true, outputPath: "test.Rmd" },
+			});
+			return true;
+		});
 
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
 
-    render(<ExportDialog open onClose={onClose} />);
+		render(<ExportDialog open onClose={onClose} />);
 
-    const errorsCheckbox = screen.getByLabelText('Include error messages');
-    expect(errorsCheckbox).not.toBeChecked();
+		const errorsCheckbox = screen.getByLabelText("Include error messages");
+		expect(errorsCheckbox).not.toBeChecked();
 
-    fireEvent.click(errorsCheckbox);
-    expect(errorsCheckbox).toBeChecked();
+		fireEvent.click(errorsCheckbox);
+		expect(errorsCheckbox).toBeChecked();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
 
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
 
-    const [sentRequest] = sendMock.mock.calls[0];
-    expect(sentRequest.request.includeErrors).toBe(true);
-  });
+		const [sentRequest] = sendMock.mock.calls[0];
+		expect(sentRequest.request.includeErrors).toBe(true);
+	});
 
-  it('toggles includeSummary option correctly', async () => {
-    const sendMock = vi.fn((request, handler) => {
-      handler({
-        type: 'export_rmarkdown_response',
-        response: { success: true, outputPath: 'test.Rmd' },
-      });
-      return true;
-    });
+	it("toggles includeSummary option correctly", async () => {
+		const sendMock = vi.fn((request, handler) => {
+			handler({
+				type: "export_rmarkdown_response",
+				response: { success: true, outputPath: "test.Rmd" },
+			});
+			return true;
+		});
 
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
 
-    render(<ExportDialog open onClose={onClose} />);
+		render(<ExportDialog open onClose={onClose} />);
 
-    const summaryCheckbox = screen.getByLabelText('Add session statistics summary');
-    expect(summaryCheckbox).toBeChecked();
+		const summaryCheckbox = screen.getByLabelText("Add session statistics summary");
+		expect(summaryCheckbox).toBeChecked();
 
-    fireEvent.click(summaryCheckbox);
-    expect(summaryCheckbox).not.toBeChecked();
+		fireEvent.click(summaryCheckbox);
+		expect(summaryCheckbox).not.toBeChecked();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
 
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
 
-    const [sentRequest] = sendMock.mock.calls[0];
-    expect(sentRequest.request.includeSummary).toBe(false);
-  });
+		const [sentRequest] = sendMock.mock.calls[0];
+		expect(sentRequest.request.includeSummary).toBe(false);
+	});
 
-  it('sends all options disabled when all checkboxes are unchecked', async () => {
-    const sendMock = vi.fn((request, handler) => {
-      handler({
-        type: 'export_rmarkdown_response',
-        response: { success: true, outputPath: 'test.Rmd' },
-      });
-      return true;
-    });
+	it("sends all options disabled when all checkboxes are unchecked", async () => {
+		const sendMock = vi.fn((request, handler) => {
+			handler({
+				type: "export_rmarkdown_response",
+				response: { success: true, outputPath: "test.Rmd" },
+			});
+			return true;
+		});
 
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
 
-    render(<ExportDialog open onClose={onClose} />);
+		render(<ExportDialog open onClose={onClose} />);
 
-    // Uncheck all options that are checked by default
-    fireEvent.click(screen.getByLabelText('Include timestamps'));
-    fireEvent.click(screen.getByLabelText('Show actor (User/AI) for each chunk'));
-    fireEvent.click(screen.getByLabelText('Embed plot images inline'));
-    fireEvent.click(screen.getByLabelText('Include execution outputs'));
-    fireEvent.click(screen.getByLabelText('Add session statistics summary'));
+		// Uncheck all options that are checked by default
+		fireEvent.click(screen.getByLabelText("Include timestamps"));
+		fireEvent.click(screen.getByLabelText("Show actor (User/AI) for each chunk"));
+		fireEvent.click(screen.getByLabelText("Embed plot images inline"));
+		fireEvent.click(screen.getByLabelText("Include execution outputs"));
+		fireEvent.click(screen.getByLabelText("Add session statistics summary"));
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
 
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
 
-    const [sentRequest] = sendMock.mock.calls[0];
-    expect(sentRequest.request).toMatchObject({
-      includeTimestamps: false,
-      showActor: false,
-      embedPlots: false,
-      includeOutputs: false,
-      includeErrors: false,
-      includeSummary: false,
-    });
-  });
+		const [sentRequest] = sendMock.mock.calls[0];
+		expect(sentRequest.request).toMatchObject({
+			includeTimestamps: false,
+			showActor: false,
+			embedPlots: false,
+			includeOutputs: false,
+			includeErrors: false,
+			includeSummary: false,
+		});
+	});
 
-  it('requires document path for document mode', async () => {
-    const sendMock = vi.fn();
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
+	it("requires document path for document mode", async () => {
+		const sendMock = vi.fn();
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
 
-    render(<ExportDialog open onClose={onClose} />);
+		render(<ExportDialog open onClose={onClose} />);
 
-    // Switch to document mode
-    fireEvent.click(screen.getByRole('radio', { name: /Document-Based/i }));
+		// Switch to document mode
+		fireEvent.click(screen.getByRole("radio", { name: /Document-Based/i }));
 
-    // Try to export without document path
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+		// Try to export without document path
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
 
-    await waitFor(() => {
-      expect(screen.getByText('Document path is required for document-based export')).toBeInTheDocument();
-    });
+		await waitFor(() => {
+			expect(
+				screen.getByText("Document path is required for document-based export"),
+			).toBeInTheDocument();
+		});
 
-    expect(sendMock).not.toHaveBeenCalled();
-    expect(onClose).not.toHaveBeenCalled();
-  });
+		expect(sendMock).not.toHaveBeenCalled();
+		expect(onClose).not.toHaveBeenCalled();
+	});
 
-  it('handles WebSocket connection failure', async () => {
-    const sendMock = vi.fn(() => false);
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
+	it("handles WebSocket connection failure", async () => {
+		const sendMock = vi.fn(() => false);
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
 
-    render(<ExportDialog open onClose={onClose} />);
+		render(<ExportDialog open onClose={onClose} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
 
-    await waitFor(() => {
-      expect(screen.getByText('WebSocket not connected')).toBeInTheDocument();
-    });
+		await waitFor(() => {
+			expect(screen.getByText("WebSocket not connected")).toBeInTheDocument();
+		});
 
-    expect(onClose).not.toHaveBeenCalled();
-  });
+		expect(onClose).not.toHaveBeenCalled();
+	});
 
-  it('changes output path correctly', async () => {
-    const sendMock = vi.fn((request, handler) => {
-      handler({
-        type: 'export_rmarkdown_response',
-        response: { success: true, outputPath: 'custom_report.Rmd' },
-      });
-      return true;
-    });
+	it("changes output path correctly", async () => {
+		const sendMock = vi.fn((request, handler) => {
+			handler({
+				type: "export_rmarkdown_response",
+				response: { success: true, outputPath: "custom_report.Rmd" },
+			});
+			return true;
+		});
 
-    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
-    const onClose = vi.fn();
+		vi.spyOn(socketService, "send").mockImplementation(sendMock);
+		const onClose = vi.fn();
 
-    render(<ExportDialog open onClose={onClose} />);
+		render(<ExportDialog open onClose={onClose} />);
 
-    const outputPathInput = screen.getByLabelText('Output Path');
-    fireEvent.change(outputPathInput, { target: { value: 'custom_report.Rmd' } });
+		const outputPathInput = screen.getByLabelText("Output Path");
+		fireEvent.change(outputPathInput, {
+			target: { value: "custom_report.Rmd" },
+		});
 
-    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
 
-    await waitFor(() => expect(onClose).toHaveBeenCalled());
+		await waitFor(() => expect(onClose).toHaveBeenCalled());
 
-    const [sentRequest] = sendMock.mock.calls[0];
-    expect(sentRequest.request.outputPath).toBe('custom_report.Rmd');
-  });
+		const [sentRequest] = sendMock.mock.calls[0];
+		expect(sentRequest.request.outputPath).toBe("custom_report.Rmd");
+	});
 });

--- a/client/src/components/export/index.ts
+++ b/client/src/components/export/index.ts
@@ -1,1 +1,1 @@
-export { ExportDialog } from './ExportDialog';
+export { ExportDialog } from "./ExportDialog";

--- a/client/src/components/file-browser/FileBrowserPane.tsx
+++ b/client/src/components/file-browser/FileBrowserPane.tsx
@@ -1,835 +1,837 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useStore, useFileSystemStore } from '@/core';
-import { ROOT_PATH, normalizeRelativePath, normalizeSeparators } from '@/core/pathUtils';
-import { FileEntry, fileSystem } from '@/services/fileSystem';
-import { useFileSystemData } from '@/hooks/useFileSystemData';
-import { IconChevronDown, IconChevronRight, IconFolder, IconPlus } from '@/components/shared';
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { IconChevronDown, IconChevronRight, IconFolder, IconPlus } from "@/components/shared";
+import { useFileSystemStore, useStore } from "@/core";
+import { normalizeRelativePath, normalizeSeparators, ROOT_PATH } from "@/core/pathUtils";
+import { useFileSystemData } from "@/hooks/useFileSystemData";
+import { type FileEntry, fileSystem } from "@/services/fileSystem";
 
-const ROOT_LABEL = 'Workspace';
-const DRAG_DATA_MIME = 'application/x-reprod-paths';
+const ROOT_LABEL = "Workspace";
+const DRAG_DATA_MIME = "application/x-reprod-paths";
 
 type ClipboardState = {
-  mode: 'copy' | 'cut';
-  paths: string[];
+	mode: "copy" | "cut";
+	paths: string[];
 } | null;
 
 type ContextMenuState = {
-  x: number;
-  y: number;
-  path: string;
-  isDir: boolean;
+	x: number;
+	y: number;
+	path: string;
+	isDir: boolean;
 } | null;
 
 interface TreeNode extends FileEntry {
-  depth: number;
-  pending?: boolean;
+	depth: number;
+	pending?: boolean;
 }
 
 type TauriWindow = typeof window & {
-  __TAURI__?: {
-    shell?: {
-      open: (target: string) => Promise<void>;
-    };
-  };
+	__TAURI__?: {
+		shell?: {
+			open: (target: string) => Promise<void>;
+		};
+	};
 };
 
 const extensionColors: Record<string, string> = {
-  r: '#F38BA3',
-  rmd: '#9D8CE0',
-  rs: '#E37933',
-  rproj: '#5B8DEF',
-  md: '#4FD1C5',
-  json: '#56C4C4',
-  ts: '#2F6FED',
-  tsx: '#5A67D8',
-  js: '#F6C343',
-  jsx: '#EC7063',
-  py: '#2D9CDB',
-  rsx: '#E85858',
-  txt: '#94A3B8',
-  toml: '#FFA94D',
-  yaml: '#FFB347',
-  yml: '#FFB347',
+	r: "#F38BA3",
+	rmd: "#9D8CE0",
+	rs: "#E37933",
+	rproj: "#5B8DEF",
+	md: "#4FD1C5",
+	json: "#56C4C4",
+	ts: "#2F6FED",
+	tsx: "#5A67D8",
+	js: "#F6C343",
+	jsx: "#EC7063",
+	py: "#2D9CDB",
+	rsx: "#E85858",
+	txt: "#94A3B8",
+	toml: "#FFA94D",
+	yaml: "#FFB347",
+	yml: "#FFB347",
 };
 
 const joinPath = (parent: string, name: string): string => {
-  const parentPath = normalizeRelativePath(parent);
-  const childPath = normalizeRelativePath(name);
-  if (parentPath === ROOT_PATH) {
-    return childPath === ROOT_PATH ? ROOT_PATH : childPath;
-  }
-  if (childPath === ROOT_PATH) {
-    return parentPath;
-  }
-  return `${parentPath}/${childPath}`;
+	const parentPath = normalizeRelativePath(parent);
+	const childPath = normalizeRelativePath(name);
+	if (parentPath === ROOT_PATH) {
+		return childPath === ROOT_PATH ? ROOT_PATH : childPath;
+	}
+	if (childPath === ROOT_PATH) {
+		return parentPath;
+	}
+	return `${parentPath}/${childPath}`;
 };
 
 const getNameFromPath = (path: string): string => {
-  const normalized = normalizeSeparators(path);
-  if (!normalized) return '';
-  const parts = normalized.split('/');
-  return parts[parts.length - 1] ?? '';
+	const normalized = normalizeSeparators(path);
+	if (!normalized) return "";
+	const parts = normalized.split("/");
+	return parts[parts.length - 1] ?? "";
 };
 
 const getParentPath = (path: string): string => {
-  const normalized = normalizeRelativePath(path);
-  if (normalized === ROOT_PATH) return ROOT_PATH;
-  const segments = normalized.split('/');
-  if (segments.length <= 1) {
-    return ROOT_PATH;
-  }
-  segments.pop();
-  const parent = segments.join('/');
-  return parent || ROOT_PATH;
+	const normalized = normalizeRelativePath(path);
+	if (normalized === ROOT_PATH) return ROOT_PATH;
+	const segments = normalized.split("/");
+	if (segments.length <= 1) {
+		return ROOT_PATH;
+	}
+	segments.pop();
+	const parent = segments.join("/");
+	return parent || ROOT_PATH;
 };
 
 const isDescendantPath = (parent: string, child: string): boolean => {
-  const normalizedParent = normalizeRelativePath(parent);
-  const normalizedChild = normalizeRelativePath(child);
-  if (normalizedParent === ROOT_PATH) {
-    return normalizedChild !== ROOT_PATH;
-  }
-  return normalizedChild.startsWith(`${normalizedParent}/`);
+	const normalizedParent = normalizeRelativePath(parent);
+	const normalizedChild = normalizeRelativePath(child);
+	if (normalizedParent === ROOT_PATH) {
+		return normalizedChild !== ROOT_PATH;
+	}
+	return normalizedChild.startsWith(`${normalizedParent}/`);
 };
 
 const buildTree = (
-  entries: FileEntry[],
-  expanded: Set<string>,
-  pending: Set<string>,
-  depth = 0
+	entries: FileEntry[],
+	expanded: Set<string>,
+	pending: Set<string>,
+	depth = 0,
 ): TreeNode[] => {
-  const nodes: TreeNode[] = [];
-  for (const entry of entries) {
-    const normalizedPath = entry.path === ROOT_PATH ? ROOT_PATH : normalizeRelativePath(entry.path);
-    const node: TreeNode = {
-      ...entry,
-      path: normalizedPath,
-      depth,
-      pending: pending.has(normalizedPath),
-    };
-    nodes.push(node);
-    if (entry.is_dir && expanded.has(normalizedPath) && entry.children?.length) {
-      nodes.push(...buildTree(entry.children, expanded, pending, depth + 1));
-    }
-  }
-  return nodes;
+	const nodes: TreeNode[] = [];
+	for (const entry of entries) {
+		const normalizedPath = entry.path === ROOT_PATH ? ROOT_PATH : normalizeRelativePath(entry.path);
+		const node: TreeNode = {
+			...entry,
+			path: normalizedPath,
+			depth,
+			pending: pending.has(normalizedPath),
+		};
+		nodes.push(node);
+		if (entry.is_dir && expanded.has(normalizedPath) && entry.children?.length) {
+			nodes.push(...buildTree(entry.children, expanded, pending, depth + 1));
+		}
+	}
+	return nodes;
 };
 
 const getExtension = (name: string): string | null => {
-  const idx = name.lastIndexOf('.');
-  if (idx === -1) return null;
-  return name.slice(idx + 1).toLowerCase();
+	const idx = name.lastIndexOf(".");
+	if (idx === -1) return null;
+	return name.slice(idx + 1).toLowerCase();
 };
 
 const ensureArrayUnique = (paths: string[]): string[] => Array.from(new Set(paths));
 
 const buildAbsolutePath = (workspaceRoot: string, path: string): string => {
-  const relative = normalizeRelativePath(path);
-  if (!workspaceRoot) {
-    if (relative === ROOT_PATH) {
-      return ROOT_PATH;
-    }
-    return `/${relative}`;
-  }
-  const separator = workspaceRoot.includes('\\') ? '\\' : '/';
-  const relativeSegment =
-    relative === ROOT_PATH
-      ? ''
-      : separator === '\\'
-        ? relative.split('/').join('\\')
-        : relative;
+	const relative = normalizeRelativePath(path);
+	if (!workspaceRoot) {
+		if (relative === ROOT_PATH) {
+			return ROOT_PATH;
+		}
+		return `/${relative}`;
+	}
+	const separator = workspaceRoot.includes("\\") ? "\\" : "/";
+	const relativeSegment =
+		relative === ROOT_PATH ? "" : separator === "\\" ? relative.split("/").join("\\") : relative;
 
-  if (!relativeSegment) {
-    return workspaceRoot;
-  }
+	if (!relativeSegment) {
+		return workspaceRoot;
+	}
 
-  if (workspaceRoot === ROOT_PATH) {
-    return `${ROOT_PATH}${relativeSegment}`;
-  }
+	if (workspaceRoot === ROOT_PATH) {
+		return `${ROOT_PATH}${relativeSegment}`;
+	}
 
-  const hasTrailingSeparator =
-    workspaceRoot.endsWith('/') || workspaceRoot.endsWith('\\');
+	const hasTrailingSeparator = workspaceRoot.endsWith("/") || workspaceRoot.endsWith("\\");
 
-  return hasTrailingSeparator
-    ? `${workspaceRoot}${relativeSegment}`
-    : `${workspaceRoot}${separator}${relativeSegment}`;
+	return hasTrailingSeparator
+		? `${workspaceRoot}${relativeSegment}`
+		: `${workspaceRoot}${separator}${relativeSegment}`;
 };
 
 const useEditorActions = () => {
-  const setEditorContent = useStore((state) => state.setEditorContent);
-  const setEditorFilepath = useStore((state) => state.setEditorFilepath);
-  const setEditorIsDirty = useStore((state) => state.setEditorIsDirty);
-  return { setEditorContent, setEditorFilepath, setEditorIsDirty };
+	const setEditorContent = useStore((state) => state.setEditorContent);
+	const setEditorFilepath = useStore((state) => state.setEditorFilepath);
+	const setEditorIsDirty = useStore((state) => state.setEditorIsDirty);
+	return { setEditorContent, setEditorFilepath, setEditorIsDirty };
 };
 
 export function FileBrowserPane(): JSX.Element {
-  useFileSystemData();
-  const { setEditorContent, setEditorFilepath, setEditorIsDirty } = useEditorActions();
-  const files = useFileSystemStore((state) => state.files);
-  const expandedFolders = useFileSystemStore((state) => state.expandedFolders);
-  const pendingFolders = useFileSystemStore((state) => state.pendingFolders);
-  const selectedFiles = useFileSystemStore((state) => state.selectedFiles);
-  const loading = useFileSystemStore((state) => state.loading);
-  const error = useFileSystemStore((state) => state.error);
-  const toggleFolder = useFileSystemStore((state) => state.toggleFolder);
-  const selectPaths = useFileSystemStore((state) => state.selectPaths);
-  const toggleSelection = useFileSystemStore((state) => state.toggleSelection);
-  const clearSelection = useFileSystemStore((state) => state.clearSelection);
-  const refreshPath = useFileSystemStore((state) => state.refreshPath);
-  const setActivePath = useFileSystemStore((state) => state.setActivePath);
-  const workspaceRoot = useFileSystemStore((state) => state.workspaceRoot);
+	useFileSystemData();
+	const { setEditorContent, setEditorFilepath, setEditorIsDirty } = useEditorActions();
+	const files = useFileSystemStore((state) => state.files);
+	const expandedFolders = useFileSystemStore((state) => state.expandedFolders);
+	const pendingFolders = useFileSystemStore((state) => state.pendingFolders);
+	const selectedFiles = useFileSystemStore((state) => state.selectedFiles);
+	const loading = useFileSystemStore((state) => state.loading);
+	const error = useFileSystemStore((state) => state.error);
+	const toggleFolder = useFileSystemStore((state) => state.toggleFolder);
+	const selectPaths = useFileSystemStore((state) => state.selectPaths);
+	const toggleSelection = useFileSystemStore((state) => state.toggleSelection);
+	const clearSelection = useFileSystemStore((state) => state.clearSelection);
+	const refreshPath = useFileSystemStore((state) => state.refreshPath);
+	const setActivePath = useFileSystemStore((state) => state.setActivePath);
+	const workspaceRoot = useFileSystemStore((state) => state.workspaceRoot);
 
-  const [clipboard, setClipboard] = useState<ClipboardState>(null);
-  const [anchorPath, setAnchorPath] = useState<string | null>(null);
-  const [focusedPath, setFocusedPath] = useState<string | null>(null);
-  const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
-  const [dragOverPath, setDragOverPath] = useState<string | null>(null);
+	const [clipboard, setClipboard] = useState<ClipboardState>(null);
+	const [anchorPath, setAnchorPath] = useState<string | null>(null);
+	const [focusedPath, setFocusedPath] = useState<string | null>(null);
+	const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
+	const [dragOverPath, setDragOverPath] = useState<string | null>(null);
 
-  const nodes = useMemo(
-    () => buildTree(files, expandedFolders, pendingFolders),
-    [files, expandedFolders, pendingFolders]
-  );
+	const nodes = useMemo(
+		() => buildTree(files, expandedFolders, pendingFolders),
+		[files, expandedFolders, pendingFolders],
+	);
 
-  const closeContextMenu = useCallback(() => setContextMenu(null), []);
+	const closeContextMenu = useCallback(() => setContextMenu(null), []);
 
-  useEffect(() => {
-    if (!contextMenu) return;
-    const close = () => closeContextMenu();
-    window.addEventListener('click', close);
-    window.addEventListener('contextmenu', close);
-    return () => {
-      window.removeEventListener('click', close);
-      window.removeEventListener('contextmenu', close);
-    };
-  }, [contextMenu, closeContextMenu]);
+	useEffect(() => {
+		if (!contextMenu) return;
+		const close = () => closeContextMenu();
+		window.addEventListener("click", close);
+		window.addEventListener("contextmenu", close);
+		return () => {
+			window.removeEventListener("click", close);
+			window.removeEventListener("contextmenu", close);
+		};
+	}, [contextMenu, closeContextMenu]);
 
-  const refreshParents = useCallback(
-    async (paths: Iterable<string>) => {
-      const parents = new Set<string>();
-      for (const path of paths) {
-        parents.add(getParentPath(path));
-      }
-      for (const parent of parents) {
-        await refreshPath(parent);
-      }
-    },
-    [refreshPath]
-  );
+	const refreshParents = useCallback(
+		async (paths: Iterable<string>) => {
+			const parents = new Set<string>();
+			for (const path of paths) {
+				parents.add(getParentPath(path));
+			}
+			for (const parent of parents) {
+				await refreshPath(parent);
+			}
+		},
+		[refreshPath],
+	);
 
-  const selectSinglePath = useCallback(
-    (path: string) => {
-      selectPaths([path]);
-      setAnchorPath(path);
-      setFocusedPath(path);
-      setActivePath(path);
-    },
-    [selectPaths, setActivePath]
-  );
+	const selectSinglePath = useCallback(
+		(path: string) => {
+			selectPaths([path]);
+			setAnchorPath(path);
+			setFocusedPath(path);
+			setActivePath(path);
+		},
+		[selectPaths, setActivePath],
+	);
 
-  const selectRange = useCallback(
-    (targetPath: string) => {
-      if (!anchorPath) {
-        selectSinglePath(targetPath);
-        return;
-      }
-      const anchorIndex = nodes.findIndex((node) => node.path === anchorPath);
-      const targetIndex = nodes.findIndex((node) => node.path === targetPath);
-      if (anchorIndex === -1 || targetIndex === -1) {
-        selectSinglePath(targetPath);
-        return;
-      }
-      const [start, end] =
-        anchorIndex < targetIndex ? [anchorIndex, targetIndex] : [targetIndex, anchorIndex];
-      const range = nodes.slice(start, end + 1).map((node) => node.path);
-      selectPaths(range);
-      setFocusedPath(targetPath);
-    },
-    [anchorPath, nodes, selectPaths, selectSinglePath]
-  );
+	const selectRange = useCallback(
+		(targetPath: string) => {
+			if (!anchorPath) {
+				selectSinglePath(targetPath);
+				return;
+			}
+			const anchorIndex = nodes.findIndex((node) => node.path === anchorPath);
+			const targetIndex = nodes.findIndex((node) => node.path === targetPath);
+			if (anchorIndex === -1 || targetIndex === -1) {
+				selectSinglePath(targetPath);
+				return;
+			}
+			const [start, end] =
+				anchorIndex < targetIndex ? [anchorIndex, targetIndex] : [targetIndex, anchorIndex];
+			const range = nodes.slice(start, end + 1).map((node) => node.path);
+			selectPaths(range);
+			setFocusedPath(targetPath);
+		},
+		[anchorPath, nodes, selectPaths, selectSinglePath],
+	);
 
-  const handleNodeClick = useCallback(
-    (event: React.MouseEvent, node: TreeNode) => {
-      event.stopPropagation();
-      const isMeta = event.metaKey || event.ctrlKey;
-      const shouldToggleFolder =
-        node.is_dir && !event.shiftKey && !isMeta && event.detail === 1;
+	const handleNodeClick = useCallback(
+		(event: React.MouseEvent, node: TreeNode) => {
+			event.stopPropagation();
+			const isMeta = event.metaKey || event.ctrlKey;
+			const shouldToggleFolder = node.is_dir && !event.shiftKey && !isMeta && event.detail === 1;
 
-      if (event.shiftKey) {
-        selectRange(node.path);
-      } else if (isMeta) {
-        toggleSelection(node.path);
-        setAnchorPath(node.path);
-        setFocusedPath(node.path);
-      } else {
-        selectSinglePath(node.path);
-        if (shouldToggleFolder) {
-          void toggleFolder(node.path);
-        }
-      }
-    },
-    [selectRange, toggleSelection, selectSinglePath, toggleFolder]
-  );
+			if (event.shiftKey) {
+				selectRange(node.path);
+			} else if (isMeta) {
+				toggleSelection(node.path);
+				setAnchorPath(node.path);
+				setFocusedPath(node.path);
+			} else {
+				selectSinglePath(node.path);
+				if (shouldToggleFolder) {
+					void toggleFolder(node.path);
+				}
+			}
+		},
+		[selectRange, toggleSelection, selectSinglePath, toggleFolder],
+	);
 
-  const handleNodeDoubleClick = useCallback(
-    async (node: TreeNode) => {
-      if (node.is_dir) {
-        return;
-      }
-      try {
-        const content = await fileSystem.readFile(node.path);
-        setEditorContent(content);
-        setEditorFilepath(node.path);
-        setEditorIsDirty(false);
-      } catch (error) {
-        console.error('Failed to open file', error);
-      }
-    },
-    [setEditorContent, setEditorFilepath, setEditorIsDirty, toggleFolder]
-  );
+	const handleNodeDoubleClick = useCallback(
+		async (node: TreeNode) => {
+			if (node.is_dir) {
+				return;
+			}
+			try {
+				const content = await fileSystem.readFile(node.path);
+				setEditorContent(content);
+				setEditorFilepath(node.path);
+				setEditorIsDirty(false);
+			} catch (error) {
+				console.error("Failed to open file", error);
+			}
+		},
+		[setEditorContent, setEditorFilepath, setEditorIsDirty, toggleFolder],
+	);
 
-  const handleContextMenu = useCallback(
-    (event: React.MouseEvent, node: TreeNode) => {
-      event.preventDefault();
-      event.stopPropagation();
-      if (!selectedFiles.has(node.path)) {
-        selectSinglePath(node.path);
-      }
-      setContextMenu({
-        x: event.clientX,
-        y: event.clientY,
-        path: node.path,
-        isDir: node.is_dir,
-      });
-    },
-    [selectedFiles, selectSinglePath]
-  );
+	const handleContextMenu = useCallback(
+		(event: React.MouseEvent, node: TreeNode) => {
+			event.preventDefault();
+			event.stopPropagation();
+			if (!selectedFiles.has(node.path)) {
+				selectSinglePath(node.path);
+			}
+			setContextMenu({
+				x: event.clientX,
+				y: event.clientY,
+				path: node.path,
+				isDir: node.is_dir,
+			});
+		},
+		[selectedFiles, selectSinglePath],
+	);
 
-  const handleCreateEntry = useCallback(
-    async (targetPath: string, isDir: boolean, targetIsFolder = true) => {
-      closeContextMenu();
-      const defaultName = isDir ? 'New Folder' : 'New File.R';
-      const name = window.prompt(`Enter ${isDir ? 'folder' : 'file'} name`, defaultName);
-      if (!name) return;
-      const parentCandidate = targetIsFolder ? targetPath : getParentPath(targetPath);
-      const parent = parentCandidate === ROOT_PATH ? '' : parentCandidate;
-      const newPath = joinPath(parent, name);
-      try {
-        if (isDir) {
-          await fileSystem.createDir(newPath);
-        } else {
-          await fileSystem.writeFile(newPath, '');
-        }
-        await refreshPath(parent || ROOT_PATH);
-      } catch (error) {
-        console.error('Failed to create entry', error);
-        window.alert(`Failed to create ${isDir ? 'folder' : 'file'}: ${(error as Error).message}`);
-      }
-    },
-    [closeContextMenu, refreshPath]
-  );
+	const handleCreateEntry = useCallback(
+		async (targetPath: string, isDir: boolean, targetIsFolder = true) => {
+			closeContextMenu();
+			const defaultName = isDir ? "New Folder" : "New File.R";
+			const name = window.prompt(`Enter ${isDir ? "folder" : "file"} name`, defaultName);
+			if (!name) return;
+			const parentCandidate = targetIsFolder ? targetPath : getParentPath(targetPath);
+			const parent = parentCandidate === ROOT_PATH ? "" : parentCandidate;
+			const newPath = joinPath(parent, name);
+			try {
+				if (isDir) {
+					await fileSystem.createDir(newPath);
+				} else {
+					await fileSystem.writeFile(newPath, "");
+				}
+				await refreshPath(parent || ROOT_PATH);
+			} catch (error) {
+				console.error("Failed to create entry", error);
+				window.alert(`Failed to create ${isDir ? "folder" : "file"}: ${(error as Error).message}`);
+			}
+		},
+		[closeContextMenu, refreshPath],
+	);
 
-  const handleRename = useCallback(
-    async (path: string) => {
-      closeContextMenu();
-      const currentName = getNameFromPath(path);
-      const parent = getParentPath(path);
-      const newName = window.prompt('Enter new name', currentName);
-      if (!newName || newName === currentName) return;
-      const destination = joinPath(parent, newName);
-      try {
-        await fileSystem.renamePath(path, destination);
-        await refreshPath(parent);
-      } catch (error) {
-        console.error('Failed to rename path', error);
-        window.alert(`Failed to rename: ${(error as Error).message}`);
-      }
-    },
-    [closeContextMenu, refreshPath]
-  );
+	const handleRename = useCallback(
+		async (path: string) => {
+			closeContextMenu();
+			const currentName = getNameFromPath(path);
+			const parent = getParentPath(path);
+			const newName = window.prompt("Enter new name", currentName);
+			if (!newName || newName === currentName) return;
+			const destination = joinPath(parent, newName);
+			try {
+				await fileSystem.renamePath(path, destination);
+				await refreshPath(parent);
+			} catch (error) {
+				console.error("Failed to rename path", error);
+				window.alert(`Failed to rename: ${(error as Error).message}`);
+			}
+		},
+		[closeContextMenu, refreshPath],
+	);
 
-  const handleDeleteSelected = useCallback(async () => {
-    if (!selectedFiles.size) return;
-    const confirmDelete = window.confirm(
-      `Delete ${selectedFiles.size} item${selectedFiles.size > 1 ? 's' : ''}?`
-    );
-    if (!confirmDelete) {
-      return;
-    }
-    const targets = Array.from(selectedFiles);
-    for (const path of targets) {
-      try {
-        await fileSystem.deletePath(path);
-      } catch (error) {
-        console.error('Failed to delete path', error);
-        window.alert(`Failed to delete ${path}: ${(error as Error).message}`);
-      }
-    }
-    await refreshParents(targets);
-    clearSelection();
-    closeContextMenu();
-  }, [selectedFiles, refreshParents, clearSelection, closeContextMenu]);
+	const handleDeleteSelected = useCallback(async () => {
+		if (!selectedFiles.size) return;
+		const confirmDelete = window.confirm(
+			`Delete ${selectedFiles.size} item${selectedFiles.size > 1 ? "s" : ""}?`,
+		);
+		if (!confirmDelete) {
+			return;
+		}
+		const targets = Array.from(selectedFiles);
+		for (const path of targets) {
+			try {
+				await fileSystem.deletePath(path);
+			} catch (error) {
+				console.error("Failed to delete path", error);
+				window.alert(`Failed to delete ${path}: ${(error as Error).message}`);
+			}
+		}
+		await refreshParents(targets);
+		clearSelection();
+		closeContextMenu();
+	}, [selectedFiles, refreshParents, clearSelection, closeContextMenu]);
 
-  const handleCopyCut = useCallback(
-    (mode: 'copy' | 'cut') => {
-      if (!selectedFiles.size) return;
-      setClipboard({ mode, paths: Array.from(selectedFiles) });
-      closeContextMenu();
-    },
-    [selectedFiles, closeContextMenu]
-  );
+	const handleCopyCut = useCallback(
+		(mode: "copy" | "cut") => {
+			if (!selectedFiles.size) return;
+			setClipboard({ mode, paths: Array.from(selectedFiles) });
+			closeContextMenu();
+		},
+		[selectedFiles, closeContextMenu],
+	);
 
-  const performTransfer = useCallback(
-    async (paths: string[], destination: string, mode: 'copy' | 'cut') => {
-      const resolvedDestination = destination === ROOT_PATH ? '' : destination;
-      const targets = ensureArrayUnique(paths);
-      for (const path of targets) {
-        const name = getNameFromPath(path);
-        const destPath = joinPath(resolvedDestination, name);
-        try {
-          if (path === destPath || isDescendantPath(path, destPath)) {
-            continue;
-          }
-          if (mode === 'cut') {
-            await fileSystem.renamePath(path, destPath);
-          } else {
-            await fileSystem.copyPath(path, destPath);
-          }
-        } catch (error) {
-          console.error('Failed to move/copy path', error);
-          window.alert(`Failed to ${mode === 'copy' ? 'copy' : 'move'} ${name}: ${(error as Error).message}`);
-        }
-      }
-      await refreshPath(resolvedDestination || ROOT_PATH);
-      if (mode === 'cut') {
-        await refreshParents(targets);
-      }
-    },
-    [refreshPath, refreshParents]
-  );
+	const performTransfer = useCallback(
+		async (paths: string[], destination: string, mode: "copy" | "cut") => {
+			const resolvedDestination = destination === ROOT_PATH ? "" : destination;
+			const targets = ensureArrayUnique(paths);
+			for (const path of targets) {
+				const name = getNameFromPath(path);
+				const destPath = joinPath(resolvedDestination, name);
+				try {
+					if (path === destPath || isDescendantPath(path, destPath)) {
+						continue;
+					}
+					if (mode === "cut") {
+						await fileSystem.renamePath(path, destPath);
+					} else {
+						await fileSystem.copyPath(path, destPath);
+					}
+				} catch (error) {
+					console.error("Failed to move/copy path", error);
+					window.alert(
+						`Failed to ${mode === "copy" ? "copy" : "move"} ${name}: ${(error as Error).message}`,
+					);
+				}
+			}
+			await refreshPath(resolvedDestination || ROOT_PATH);
+			if (mode === "cut") {
+				await refreshParents(targets);
+			}
+		},
+		[refreshPath, refreshParents],
+	);
 
-  const handlePaste = useCallback(
-    async (targetPath?: string) => {
-      if (!clipboard) return;
-      const destination =
-        targetPath ??
-        (contextMenu
-          ? contextMenu.isDir
-            ? contextMenu.path
-            : getParentPath(contextMenu.path)
-          : ROOT_PATH);
-      await performTransfer(clipboard.paths, destination, clipboard.mode);
-      if (clipboard.mode === 'cut') {
-        setClipboard(null);
-      }
-      closeContextMenu();
-    },
-    [clipboard, contextMenu, closeContextMenu, performTransfer]
-  );
+	const handlePaste = useCallback(
+		async (targetPath?: string) => {
+			if (!clipboard) return;
+			const destination =
+				targetPath ??
+				(contextMenu
+					? contextMenu.isDir
+						? contextMenu.path
+						: getParentPath(contextMenu.path)
+					: ROOT_PATH);
+			await performTransfer(clipboard.paths, destination, clipboard.mode);
+			if (clipboard.mode === "cut") {
+				setClipboard(null);
+			}
+			closeContextMenu();
+		},
+		[clipboard, contextMenu, closeContextMenu, performTransfer],
+	);
 
-  const resolveAbsolutePath = useCallback(
-    (path: string): string => buildAbsolutePath(workspaceRoot, path),
-    [workspaceRoot]
-  );
+	const resolveAbsolutePath = useCallback(
+		(path: string): string => buildAbsolutePath(workspaceRoot, path),
+		[workspaceRoot],
+	);
 
-  const handleCopyPath = useCallback(
-    async (path: string, absolute = false) => {
-      const normalized = normalizeRelativePath(path);
-      const value = absolute
-        ? resolveAbsolutePath(normalized)
-        : normalized === ROOT_PATH
-          ? ROOT_PATH
-          : normalized;
-      try {
-        await navigator.clipboard.writeText(value);
-      } catch (error) {
-        console.error('Failed to copy path', error);
-      }
-      closeContextMenu();
-    },
-    [closeContextMenu, resolveAbsolutePath]
-  );
+	const handleCopyPath = useCallback(
+		async (path: string, absolute = false) => {
+			const normalized = normalizeRelativePath(path);
+			const value = absolute
+				? resolveAbsolutePath(normalized)
+				: normalized === ROOT_PATH
+					? ROOT_PATH
+					: normalized;
+			try {
+				await navigator.clipboard.writeText(value);
+			} catch (error) {
+				console.error("Failed to copy path", error);
+			}
+			closeContextMenu();
+		},
+		[closeContextMenu, resolveAbsolutePath],
+	);
 
-  const handleRevealInFinder = useCallback(
-    async (path: string) => {
-      if (!workspaceRoot) {
-        closeContextMenu();
-        window.alert('Workspace root is not available yet. Please try again after the project loads.');
-        return;
-      }
-      const absolute = resolveAbsolutePath(path);
-      const tauriWindow = window as TauriWindow;
-      const shell = tauriWindow.__TAURI__?.shell;
-      closeContextMenu();
-      if (shell?.open) {
-        try {
-          await shell.open(absolute);
-          return;
-        } catch (error) {
-          console.error('Failed to reveal path', error);
-        }
-      }
-      try {
-        await navigator.clipboard.writeText(absolute);
-        window.alert('Reveal is only available in the desktop build. Path copied to clipboard.');
-      } catch (error) {
-        console.error('Failed to copy path', error);
-      }
-    },
-    [closeContextMenu, resolveAbsolutePath, workspaceRoot]
-  );
+	const handleRevealInFinder = useCallback(
+		async (path: string) => {
+			if (!workspaceRoot) {
+				closeContextMenu();
+				window.alert(
+					"Workspace root is not available yet. Please try again after the project loads.",
+				);
+				return;
+			}
+			const absolute = resolveAbsolutePath(path);
+			const tauriWindow = window as TauriWindow;
+			const shell = tauriWindow.__TAURI__?.shell;
+			closeContextMenu();
+			if (shell?.open) {
+				try {
+					await shell.open(absolute);
+					return;
+				} catch (error) {
+					console.error("Failed to reveal path", error);
+				}
+			}
+			try {
+				await navigator.clipboard.writeText(absolute);
+				window.alert("Reveal is only available in the desktop build. Path copied to clipboard.");
+			} catch (error) {
+				console.error("Failed to copy path", error);
+			}
+		},
+		[closeContextMenu, resolveAbsolutePath, workspaceRoot],
+	);
 
-  const handleNodeDragStart = useCallback(
-    (event: React.DragEvent, node: TreeNode) => {
-      event.stopPropagation();
-      if (!selectedFiles.has(node.path)) {
-        selectSinglePath(node.path);
-      }
-      const selection = selectedFiles.has(node.path)
-        ? Array.from(selectedFiles)
-        : [node.path];
-      event.dataTransfer.setData(DRAG_DATA_MIME, JSON.stringify(selection));
-      event.dataTransfer.effectAllowed = 'move';
-    },
-    [selectedFiles, selectSinglePath]
-  );
+	const handleNodeDragStart = useCallback(
+		(event: React.DragEvent, node: TreeNode) => {
+			event.stopPropagation();
+			if (!selectedFiles.has(node.path)) {
+				selectSinglePath(node.path);
+			}
+			const selection = selectedFiles.has(node.path) ? Array.from(selectedFiles) : [node.path];
+			event.dataTransfer.setData(DRAG_DATA_MIME, JSON.stringify(selection));
+			event.dataTransfer.effectAllowed = "move";
+		},
+		[selectedFiles, selectSinglePath],
+	);
 
-  const handleNodeDragOver = useCallback((event: React.DragEvent, node: TreeNode) => {
-    if (!node.is_dir) return;
-    if (!event.dataTransfer.types.includes(DRAG_DATA_MIME)) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
-    setDragOverPath(node.path);
-  }, []);
+	const handleNodeDragOver = useCallback((event: React.DragEvent, node: TreeNode) => {
+		if (!node.is_dir) return;
+		if (!event.dataTransfer.types.includes(DRAG_DATA_MIME)) return;
+		event.preventDefault();
+		event.dataTransfer.dropEffect = "move";
+		setDragOverPath(node.path);
+	}, []);
 
-  const handleNodeDrop = useCallback(
-    async (event: React.DragEvent, node: TreeNode) => {
-      if (!node.is_dir) return;
-      const data = event.dataTransfer.getData(DRAG_DATA_MIME);
-      setDragOverPath(null);
-      if (!data) return;
-      try {
-        const paths = JSON.parse(data) as string[];
-        await performTransfer(paths, node.path, 'cut');
-      } catch (error) {
-        console.error('Failed to parse drag payload', error);
-      }
-    },
-    [performTransfer]
-  );
+	const handleNodeDrop = useCallback(
+		async (event: React.DragEvent, node: TreeNode) => {
+			if (!node.is_dir) return;
+			const data = event.dataTransfer.getData(DRAG_DATA_MIME);
+			setDragOverPath(null);
+			if (!data) return;
+			try {
+				const paths = JSON.parse(data) as string[];
+				await performTransfer(paths, node.path, "cut");
+			} catch (error) {
+				console.error("Failed to parse drag payload", error);
+			}
+		},
+		[performTransfer],
+	);
 
-  const handleRootDragOver = useCallback((event: React.DragEvent) => {
-    if (!event.dataTransfer.types.includes(DRAG_DATA_MIME)) return;
-    event.preventDefault();
-    setDragOverPath(ROOT_PATH);
-  }, []);
+	const handleRootDragOver = useCallback((event: React.DragEvent) => {
+		if (!event.dataTransfer.types.includes(DRAG_DATA_MIME)) return;
+		event.preventDefault();
+		setDragOverPath(ROOT_PATH);
+	}, []);
 
-  const handleRootDrop = useCallback(
-    async (event: React.DragEvent) => {
-      const data = event.dataTransfer.getData(DRAG_DATA_MIME);
-      setDragOverPath(null);
-      if (!data) return;
-      try {
-        const paths = JSON.parse(data) as string[];
-        await performTransfer(paths, ROOT_PATH, 'cut');
-      } catch (error) {
-        console.error('Failed to parse drag payload', error);
-      }
-    },
-    [performTransfer]
-  );
+	const handleRootDrop = useCallback(
+		async (event: React.DragEvent) => {
+			const data = event.dataTransfer.getData(DRAG_DATA_MIME);
+			setDragOverPath(null);
+			if (!data) return;
+			try {
+				const paths = JSON.parse(data) as string[];
+				await performTransfer(paths, ROOT_PATH, "cut");
+			} catch (error) {
+				console.error("Failed to parse drag payload", error);
+			}
+		},
+		[performTransfer],
+	);
 
-  const handleDragEnd = useCallback(() => {
-    setDragOverPath(null);
-  }, []);
+	const handleDragEnd = useCallback(() => {
+		setDragOverPath(null);
+	}, []);
 
-  const handleKeyDown = useCallback(
-    async (event: React.KeyboardEvent) => {
-      if (!nodes.length) return;
-      const selectionArray = Array.from(selectedFiles);
-      const currentIndex = focusedPath
-        ? nodes.findIndex((node) => node.path === focusedPath)
-        : selectionArray.length
-          ? nodes.findIndex((node) => node.path === selectionArray[0])
-          : -1;
-      const isShortcut = event.metaKey || event.ctrlKey;
-      const focusedNode = currentIndex >= 0 ? nodes[currentIndex] : null;
+	const handleKeyDown = useCallback(
+		async (event: React.KeyboardEvent) => {
+			if (!nodes.length) return;
+			const selectionArray = Array.from(selectedFiles);
+			const currentIndex = focusedPath
+				? nodes.findIndex((node) => node.path === focusedPath)
+				: selectionArray.length
+					? nodes.findIndex((node) => node.path === selectionArray[0])
+					: -1;
+			const isShortcut = event.metaKey || event.ctrlKey;
+			const focusedNode = currentIndex >= 0 ? nodes[currentIndex] : null;
 
-      if (isShortcut) {
-        switch (event.key.toLowerCase()) {
-          case 'c':
-            event.preventDefault();
-            handleCopyCut('copy');
-            return;
-          case 'x':
-            event.preventDefault();
-            handleCopyCut('cut');
-            return;
-          case 'v':
-            event.preventDefault();
-            await handlePaste(
-              focusedNode
-                ? focusedNode.is_dir
-                  ? focusedNode.path
-                  : getParentPath(focusedNode.path)
-                : ROOT_PATH
-            );
-            return;
-          default:
-            break;
-        }
-      }
+			if (isShortcut) {
+				switch (event.key.toLowerCase()) {
+					case "c":
+						event.preventDefault();
+						handleCopyCut("copy");
+						return;
+					case "x":
+						event.preventDefault();
+						handleCopyCut("cut");
+						return;
+					case "v":
+						event.preventDefault();
+						await handlePaste(
+							focusedNode
+								? focusedNode.is_dir
+									? focusedNode.path
+									: getParentPath(focusedNode.path)
+								: ROOT_PATH,
+						);
+						return;
+					default:
+						break;
+				}
+			}
 
-      const applyFocus = (index: number) => {
-        if (index < 0 || index >= nodes.length) return;
-        selectSinglePath(nodes[index].path);
-      };
+			const applyFocus = (index: number) => {
+				if (index < 0 || index >= nodes.length) return;
+				selectSinglePath(nodes[index].path);
+			};
 
-      switch (event.key) {
-        case 'ArrowDown':
-          event.preventDefault();
-          applyFocus(Math.min(nodes.length - 1, currentIndex === -1 ? 0 : currentIndex + 1));
-          break;
-        case 'ArrowUp':
-          event.preventDefault();
-          applyFocus(Math.max(0, currentIndex === -1 ? 0 : currentIndex - 1));
-          break;
-        case 'ArrowRight':
-          if (currentIndex === -1) break;
-          event.preventDefault();
-          if (focusedNode?.is_dir) {
-            if (!expandedFolders.has(focusedNode.path)) {
-              toggleFolder(focusedNode.path);
-            } else {
-              applyFocus(Math.min(nodes.length - 1, currentIndex + 1));
-            }
-          }
-          break;
-        case 'ArrowLeft':
-          if (currentIndex === -1) break;
-          event.preventDefault();
-          if (focusedNode?.is_dir && expandedFolders.has(focusedNode.path)) {
-            toggleFolder(focusedNode.path);
-          } else {
-            const parentPath = focusedNode ? getParentPath(focusedNode.path) : ROOT_PATH;
-            const parentIndex = nodes.findIndex((node) => node.path === parentPath);
-            if (parentIndex >= 0) {
-              applyFocus(parentIndex);
-            }
-          }
-          break;
-        case 'Enter':
-          if (focusedNode) {
-            event.preventDefault();
-            handleNodeDoubleClick(focusedNode);
-          }
-          break;
-        case 'Backspace':
-        case 'Delete':
-          event.preventDefault();
-          await handleDeleteSelected();
-          break;
-        default:
-          break;
-      }
-    },
-    [
-      expandedFolders,
-      focusedPath,
-      handleCopyCut,
-      handleDeleteSelected,
-      handleNodeDoubleClick,
-      handlePaste,
-      nodes,
-      selectSinglePath,
-      selectedFiles,
-      toggleFolder,
-    ]
-  );
+			switch (event.key) {
+				case "ArrowDown":
+					event.preventDefault();
+					applyFocus(Math.min(nodes.length - 1, currentIndex === -1 ? 0 : currentIndex + 1));
+					break;
+				case "ArrowUp":
+					event.preventDefault();
+					applyFocus(Math.max(0, currentIndex === -1 ? 0 : currentIndex - 1));
+					break;
+				case "ArrowRight":
+					if (currentIndex === -1) break;
+					event.preventDefault();
+					if (focusedNode?.is_dir) {
+						if (!expandedFolders.has(focusedNode.path)) {
+							toggleFolder(focusedNode.path);
+						} else {
+							applyFocus(Math.min(nodes.length - 1, currentIndex + 1));
+						}
+					}
+					break;
+				case "ArrowLeft":
+					if (currentIndex === -1) break;
+					event.preventDefault();
+					if (focusedNode?.is_dir && expandedFolders.has(focusedNode.path)) {
+						toggleFolder(focusedNode.path);
+					} else {
+						const parentPath = focusedNode ? getParentPath(focusedNode.path) : ROOT_PATH;
+						const parentIndex = nodes.findIndex((node) => node.path === parentPath);
+						if (parentIndex >= 0) {
+							applyFocus(parentIndex);
+						}
+					}
+					break;
+				case "Enter":
+					if (focusedNode) {
+						event.preventDefault();
+						handleNodeDoubleClick(focusedNode);
+					}
+					break;
+				case "Backspace":
+				case "Delete":
+					event.preventDefault();
+					await handleDeleteSelected();
+					break;
+				default:
+					break;
+			}
+		},
+		[
+			expandedFolders,
+			focusedPath,
+			handleCopyCut,
+			handleDeleteSelected,
+			handleNodeDoubleClick,
+			handlePaste,
+			nodes,
+			selectSinglePath,
+			selectedFiles,
+			toggleFolder,
+		],
+	);
 
-  const renderContextMenu = () => {
-    if (!contextMenu) return null;
-    const menuTarget = contextMenu;
-    return (
-      <div
-        className="file-context-menu"
-        style={{ left: menuTarget.x, top: menuTarget.y }}
-        role="menu"
-      >
-        <button type="button" onClick={() => handleCreateEntry(menuTarget.path, false, menuTarget.isDir)}>
-          New File
-        </button>
-        <button type="button" onClick={() => handleCreateEntry(menuTarget.path, true, menuTarget.isDir)}>
-          New Folder
-        </button>
-        <hr />
-        <button type="button" onClick={() => handleRename(menuTarget.path)}>
-          Rename
-        </button>
-        <button type="button" onClick={handleDeleteSelected}>
-          Delete
-        </button>
-        <hr />
-        <button type="button" onClick={() => handleCopyCut('copy')}>
-          Copy
-        </button>
-        <button type="button" onClick={() => handleCopyCut('cut')}>
-          Cut
-        </button>
-        <button type="button" disabled={!clipboard} onClick={() => handlePaste(menuTarget.path)}>
-          Paste
-        </button>
-        <hr />
-        <button type="button" onClick={() => handleCopyPath(menuTarget.path, true)}>
-          Copy Path
-        </button>
-        <button type="button" onClick={() => handleCopyPath(menuTarget.path, false)}>
-          Copy Relative Path
-        </button>
-        <button type="button" onClick={() => handleRevealInFinder(menuTarget.path)}>
-          Reveal in Finder
-        </button>
-      </div>
-    );
-  };
+	const renderContextMenu = () => {
+		if (!contextMenu) return null;
+		const menuTarget = contextMenu;
+		return (
+			<div
+				className="file-context-menu"
+				style={{ left: menuTarget.x, top: menuTarget.y }}
+				role="menu"
+			>
+				<button
+					type="button"
+					onClick={() => handleCreateEntry(menuTarget.path, false, menuTarget.isDir)}
+				>
+					New File
+				</button>
+				<button
+					type="button"
+					onClick={() => handleCreateEntry(menuTarget.path, true, menuTarget.isDir)}
+				>
+					New Folder
+				</button>
+				<hr />
+				<button type="button" onClick={() => handleRename(menuTarget.path)}>
+					Rename
+				</button>
+				<button type="button" onClick={handleDeleteSelected}>
+					Delete
+				</button>
+				<hr />
+				<button type="button" onClick={() => handleCopyCut("copy")}>
+					Copy
+				</button>
+				<button type="button" onClick={() => handleCopyCut("cut")}>
+					Cut
+				</button>
+				<button type="button" disabled={!clipboard} onClick={() => handlePaste(menuTarget.path)}>
+					Paste
+				</button>
+				<hr />
+				<button type="button" onClick={() => handleCopyPath(menuTarget.path, true)}>
+					Copy Path
+				</button>
+				<button type="button" onClick={() => handleCopyPath(menuTarget.path, false)}>
+					Copy Relative Path
+				</button>
+				<button type="button" onClick={() => handleRevealInFinder(menuTarget.path)}>
+					Reveal in Finder
+				</button>
+			</div>
+		);
+	};
 
-  const renderNode = (node: TreeNode) => {
-    const isSelected = selectedFiles.has(node.path);
-    const isFocused = focusedPath === node.path;
-    const ext = getExtension(node.name);
-    const color =
-      ext && extensionColors[ext] ? extensionColors[ext] : node.is_dir ? '#60A5FA' : '#CBD5F5';
+	const renderNode = (node: TreeNode) => {
+		const isSelected = selectedFiles.has(node.path);
+		const isFocused = focusedPath === node.path;
+		const ext = getExtension(node.name);
+		const color =
+			ext && extensionColors[ext] ? extensionColors[ext] : node.is_dir ? "#60A5FA" : "#CBD5F5";
 
-    return (
-      <div
-        key={node.path}
-        className={[
-          'file-tree-node',
-          node.is_dir ? 'is-directory' : 'is-file',
-          isSelected ? 'is-selected' : '',
-          isFocused ? 'is-focused' : '',
-          dragOverPath === node.path ? 'is-drag-target' : '',
-        ].join(' ')}
-        style={{ paddingLeft: `${node.depth * 16 + 12}px` }}
-        onClick={(event) => handleNodeClick(event, node)}
-        onDoubleClick={() => handleNodeDoubleClick(node)}
-        onContextMenu={(event) => handleContextMenu(event, node)}
-        draggable
-        onDragStart={(event) => handleNodeDragStart(event, node)}
-        onDragOver={(event) => handleNodeDragOver(event, node)}
-        onDrop={(event) => handleNodeDrop(event, node)}
-        onDragLeave={() => {
-          if (dragOverPath === node.path) {
-            setDragOverPath(null);
-          }
-        }}
-        onDragEnd={handleDragEnd}
-      >
-        <button
-          type="button"
-          className="file-tree-expander"
-          onClick={(event) => {
-            event.stopPropagation();
-            if (node.is_dir) {
-              toggleFolder(node.path);
-            }
-          }}
-          aria-label={expandedFolders.has(node.path) ? 'Collapse folder' : 'Expand folder'}
-        >
-          {node.is_dir ? (
-            expandedFolders.has(node.path) ? (
-              <IconChevronDown width={12} height={12} />
-            ) : (
-              <IconChevronRight width={12} height={12} />
-            )
-          ) : (
-            <span className="file-tree-placeholder" />
-          )}
-        </button>
-        <span
-          className="file-type-icon"
-          style={{ backgroundColor: node.is_dir ? 'transparent' : color }}
-        >
-          {node.is_dir ? (
-            <IconFolder width={14} height={14} />
-          ) : (
-            (ext ?? 'file').slice(0, 3).toUpperCase()
-          )}
-        </span>
-        <span className="file-tree-label">{node.name}</span>
-        {node.pending && <span className="file-tree-pending">Loading…</span>}
-      </div>
-    );
-  };
+		return (
+			<div
+				key={node.path}
+				className={[
+					"file-tree-node",
+					node.is_dir ? "is-directory" : "is-file",
+					isSelected ? "is-selected" : "",
+					isFocused ? "is-focused" : "",
+					dragOverPath === node.path ? "is-drag-target" : "",
+				].join(" ")}
+				style={{ paddingLeft: `${node.depth * 16 + 12}px` }}
+				onClick={(event) => handleNodeClick(event, node)}
+				onDoubleClick={() => handleNodeDoubleClick(node)}
+				onContextMenu={(event) => handleContextMenu(event, node)}
+				draggable
+				onDragStart={(event) => handleNodeDragStart(event, node)}
+				onDragOver={(event) => handleNodeDragOver(event, node)}
+				onDrop={(event) => handleNodeDrop(event, node)}
+				onDragLeave={() => {
+					if (dragOverPath === node.path) {
+						setDragOverPath(null);
+					}
+				}}
+				onDragEnd={handleDragEnd}
+			>
+				<button
+					type="button"
+					className="file-tree-expander"
+					onClick={(event) => {
+						event.stopPropagation();
+						if (node.is_dir) {
+							toggleFolder(node.path);
+						}
+					}}
+					aria-label={expandedFolders.has(node.path) ? "Collapse folder" : "Expand folder"}
+				>
+					{node.is_dir ? (
+						expandedFolders.has(node.path) ? (
+							<IconChevronDown width={12} height={12} />
+						) : (
+							<IconChevronRight width={12} height={12} />
+						)
+					) : (
+						<span className="file-tree-placeholder" />
+					)}
+				</button>
+				<span
+					className="file-type-icon"
+					style={{ backgroundColor: node.is_dir ? "transparent" : color }}
+				>
+					{node.is_dir ? (
+						<IconFolder width={14} height={14} />
+					) : (
+						(ext ?? "file").slice(0, 3).toUpperCase()
+					)}
+				</span>
+				<span className="file-tree-label">{node.name}</span>
+				{node.pending && <span className="file-tree-pending">Loading…</span>}
+			</div>
+		);
+	};
 
-  return (
-    <div className="panel file-browser">
-      <div className="panel-header file-browser-header">
-        <div className="panel-title">{ROOT_LABEL}</div>
-        <div className="panel-actions">
-          <button
-            type="button"
-            className="btn btn-icon"
-            title="New File"
-            onClick={() => handleCreateEntry(ROOT_PATH, false, true)}
-          >
-            <IconPlus width={14} height={14} />
-          </button>
-          <button
-            type="button"
-            className="btn btn-icon"
-            title="New Folder"
-            onClick={() => handleCreateEntry(ROOT_PATH, true, true)}
-          >
-            <IconFolder width={14} height={14} />
-          </button>
-        </div>
-      </div>
-      <div
-        className={[
-          'panel-content',
-          'file-browser-content',
-          dragOverPath === ROOT_PATH ? 'is-drag-target' : '',
-        ].join(' ')}
-        tabIndex={0}
-        onKeyDown={handleKeyDown}
-        onClick={() => {
-          clearSelection();
-          setFocusedPath(null);
-          setAnchorPath(null);
-          setActivePath(null);
-        }}
-        onDragOver={handleRootDragOver}
-        onDrop={handleRootDrop}
-        onDragLeave={(event) => {
-          if (event.currentTarget === event.target) {
-            setDragOverPath(null);
-          }
-        }}
-      >
-        {loading && (
-          <div className="file-browser-empty">
-            <span className="spinner" aria-hidden />
-            Loading workspace…
-          </div>
-        )}
-        {!loading && !nodes.length && (
-          <div className="file-browser-empty">
-            <p>No files found</p>
-            <p className="description">
-              Use the + buttons to create files or folders, or toggle this pane from View → Show/Hide
-              Files Pane (Cmd/Ctrl+Shift+E).
-            </p>
-          </div>
-        )}
-        {error && (
-          <div className="file-browser-error">
-            <p>File system error</p>
-            <pre>{error}</pre>
-          </div>
-        )}
-        <div className="file-tree">{nodes.map((node) => renderNode(node))}</div>
-      </div>
-      {renderContextMenu()}
-    </div>
-  );
+	return (
+		<div className="panel file-browser">
+			<div className="panel-header file-browser-header">
+				<div className="panel-title">{ROOT_LABEL}</div>
+				<div className="panel-actions">
+					<button
+						type="button"
+						className="btn btn-icon"
+						title="New File"
+						onClick={() => handleCreateEntry(ROOT_PATH, false, true)}
+					>
+						<IconPlus width={14} height={14} />
+					</button>
+					<button
+						type="button"
+						className="btn btn-icon"
+						title="New Folder"
+						onClick={() => handleCreateEntry(ROOT_PATH, true, true)}
+					>
+						<IconFolder width={14} height={14} />
+					</button>
+				</div>
+			</div>
+			<div
+				className={[
+					"panel-content",
+					"file-browser-content",
+					dragOverPath === ROOT_PATH ? "is-drag-target" : "",
+				].join(" ")}
+				tabIndex={0}
+				onKeyDown={handleKeyDown}
+				onClick={() => {
+					clearSelection();
+					setFocusedPath(null);
+					setAnchorPath(null);
+					setActivePath(null);
+				}}
+				onDragOver={handleRootDragOver}
+				onDrop={handleRootDrop}
+				onDragLeave={(event) => {
+					if (event.currentTarget === event.target) {
+						setDragOverPath(null);
+					}
+				}}
+			>
+				{loading && (
+					<div className="file-browser-empty">
+						<span className="spinner" aria-hidden />
+						Loading workspace…
+					</div>
+				)}
+				{!loading && !nodes.length && (
+					<div className="file-browser-empty">
+						<p>No files found</p>
+						<p className="description">
+							Use the + buttons to create files or folders, or toggle this pane from View →
+							Show/Hide Files Pane (Cmd/Ctrl+Shift+E).
+						</p>
+					</div>
+				)}
+				{error && (
+					<div className="file-browser-error">
+						<p>File system error</p>
+						<pre>{error}</pre>
+					</div>
+				)}
+				<div className="file-tree">{nodes.map((node) => renderNode(node))}</div>
+			</div>
+			{renderContextMenu()}
+		</div>
+	);
 }

--- a/client/src/components/menu/MenuBar.tsx
+++ b/client/src/components/menu/MenuBar.tsx
@@ -4,262 +4,264 @@
  * Main menu bar with 6 sections: File, Edit, Code, Session, View, Help
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
-import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
-import { useStore } from '@/core/state/store';
-import { useMenuSections } from '@/hooks/useMenuSections';
-import {
-  type MenuItem,
-  type MenuSectionComponentProps,
-  type ConnectionIndicatorProps,
-} from '@/types/menu';
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useStore } from "@/core/state/store";
+import { useMenuSections } from "@/hooks/useMenuSections";
+import type { ConnectionIndicatorProps, MenuItem, MenuSectionComponentProps } from "@/types/menu";
 
 export function MenuBar(): JSX.Element {
-  const isConnected = useStore((state) => state.isConnected);
-  const menuSections = useMenuSections();
-  const [openSection, setOpenSection] = useState<string | null>(null);
-  const menubarRef = useRef<HTMLDivElement>(null);
+	const isConnected = useStore((state) => state.isConnected);
+	const menuSections = useMenuSections();
+	const [openSection, setOpenSection] = useState<string | null>(null);
+	const menubarRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
-      if (!menubarRef.current?.contains(event.target as Node)) {
-        setOpenSection(null);
-      }
-    };
+	useEffect(() => {
+		const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+			if (!menubarRef.current?.contains(event.target as Node)) {
+				setOpenSection(null);
+			}
+		};
 
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setOpenSection(null);
-      }
-    };
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				setOpenSection(null);
+			}
+		};
 
-    document.addEventListener('mousedown', handlePointerDown);
-    document.addEventListener('touchstart', handlePointerDown);
-    document.addEventListener('keydown', handleKeyDown);
+		document.addEventListener("mousedown", handlePointerDown);
+		document.addEventListener("touchstart", handlePointerDown);
+		document.addEventListener("keydown", handleKeyDown);
 
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
-      document.removeEventListener('touchstart', handlePointerDown);
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, []);
+		return () => {
+			document.removeEventListener("mousedown", handlePointerDown);
+			document.removeEventListener("touchstart", handlePointerDown);
+			document.removeEventListener("keydown", handleKeyDown);
+		};
+	}, []);
 
-  const handleOpenSection = (label: string) => {
-    setOpenSection(label);
-  };
+	const handleOpenSection = (label: string) => {
+		setOpenSection(label);
+	};
 
-  const handleCloseMenus = () => setOpenSection(null);
+	const handleCloseMenus = () => setOpenSection(null);
 
-  const isAnyMenuOpen = useMemo(() => openSection !== null, [openSection]);
+	const isAnyMenuOpen = useMemo(() => openSection !== null, [openSection]);
 
-  return (
-    <div className="menubar" ref={menubarRef}>
-      <div className="menubar-left">
-        <span className="menubar-brand">Re-prod</span>
-        <div className="menubar-menu">
-          {menuSections.map((section) => (
-            <MenuSectionComponent
-              key={section.label}
-              section={section}
-              isOpen={openSection === section.label}
-              anyMenuOpen={isAnyMenuOpen}
-              onOpenExplicit={handleOpenSection}
-              onClose={handleCloseMenus}
-            />
-          ))}
-        </div>
-      </div>
-      <div className="menubar-right">
-        <ConnectionIndicator isConnected={isConnected} />
-      </div>
-    </div>
-  );
+	return (
+		<div className="menubar" ref={menubarRef}>
+			<div className="menubar-left">
+				<span className="menubar-brand">Re-prod</span>
+				<div className="menubar-menu">
+					{menuSections.map((section) => (
+						<MenuSectionComponent
+							key={section.label}
+							section={section}
+							isOpen={openSection === section.label}
+							anyMenuOpen={isAnyMenuOpen}
+							onOpenExplicit={handleOpenSection}
+							onClose={handleCloseMenus}
+						/>
+					))}
+				</div>
+			</div>
+			<div className="menubar-right">
+				<ConnectionIndicator isConnected={isConnected} />
+			</div>
+		</div>
+	);
 }
 
 // Individual menu section component
 function MenuSectionComponent({
-  section,
-  isOpen,
-  anyMenuOpen,
-  onOpenExplicit,
-  onClose,
+	section,
+	isOpen,
+	anyMenuOpen,
+	onOpenExplicit,
+	onClose,
 }: MenuSectionComponentProps) {
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
+	const buttonRef = useRef<HTMLButtonElement>(null);
+	const menuRef = useRef<HTMLDivElement>(null);
 
-  const closeMenu = (focusButton = false) => {
-    onClose();
-    if (focusButton) {
-      requestAnimationFrame(() => buttonRef.current?.focus());
-    }
-  };
+	const closeMenu = (focusButton = false) => {
+		onClose();
+		if (focusButton) {
+			requestAnimationFrame(() => buttonRef.current?.focus());
+		}
+	};
 
-  const getFocusableItems = (): HTMLButtonElement[] => {
-    if (!menuRef.current) return [];
-    return Array.from(
-      menuRef.current.querySelectorAll<HTMLButtonElement>('button[role="menuitem"]:not([disabled])')
-    );
-  };
+	const getFocusableItems = (): HTMLButtonElement[] => {
+		if (!menuRef.current) return [];
+		return Array.from(
+			menuRef.current.querySelectorAll<HTMLButtonElement>(
+				'button[role="menuitem"]:not([disabled])',
+			),
+		);
+	};
 
-  const focusFirstItem = () => {
-    const items = getFocusableItems();
-    items[0]?.focus();
-  };
+	const focusFirstItem = () => {
+		const items = getFocusableItems();
+		items[0]?.focus();
+	};
 
-  const focusLastItem = () => {
-    const items = getFocusableItems();
-    items[items.length - 1]?.focus();
-  };
+	const focusLastItem = () => {
+		const items = getFocusableItems();
+		items[items.length - 1]?.focus();
+	};
 
-  const handleButtonClick = (event: ReactMouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    if (isOpen) {
-      closeMenu(true);
-    } else {
-      onOpenExplicit(section.label);
-      requestAnimationFrame(focusFirstItem);
-    }
-  };
+	const handleButtonClick = (event: ReactMouseEvent<HTMLButtonElement>) => {
+		event.preventDefault();
+		if (isOpen) {
+			closeMenu(true);
+		} else {
+			onOpenExplicit(section.label);
+			requestAnimationFrame(focusFirstItem);
+		}
+	};
 
-  const handleButtonKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      if (!isOpen) {
-        onOpenExplicit(section.label);
-        requestAnimationFrame(focusFirstItem);
-      } else {
-        focusFirstItem();
-      }
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      if (!isOpen) {
-        onOpenExplicit(section.label);
-        requestAnimationFrame(focusLastItem);
-      } else {
-        focusLastItem();
-      }
-    } else if (event.key === 'Escape' && isOpen) {
-      event.preventDefault();
-      closeMenu(true);
-    }
-  };
+	const handleButtonKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+		if (event.key === "ArrowDown" || event.key === "Enter" || event.key === " ") {
+			event.preventDefault();
+			if (!isOpen) {
+				onOpenExplicit(section.label);
+				requestAnimationFrame(focusFirstItem);
+			} else {
+				focusFirstItem();
+			}
+		} else if (event.key === "ArrowUp") {
+			event.preventDefault();
+			if (!isOpen) {
+				onOpenExplicit(section.label);
+				requestAnimationFrame(focusLastItem);
+			} else {
+				focusLastItem();
+			}
+		} else if (event.key === "Escape" && isOpen) {
+			event.preventDefault();
+			closeMenu(true);
+		}
+	};
 
-  const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    const items = getFocusableItems();
-    if (items.length === 0) {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        closeMenu(true);
-      }
-      return;
-    }
+	const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+		const items = getFocusableItems();
+		if (items.length === 0) {
+			if (event.key === "Escape") {
+				event.preventDefault();
+				closeMenu(true);
+			}
+			return;
+		}
 
-    const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+		const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
 
-    switch (event.key) {
-      case 'ArrowDown': {
-        event.preventDefault();
-        const nextIndex = (currentIndex + 1) % items.length;
-        items[nextIndex]?.focus();
-        break;
-      }
-      case 'ArrowUp': {
-        event.preventDefault();
-        const nextIndex = (currentIndex - 1 + items.length) % items.length;
-        items[nextIndex]?.focus();
-        break;
-      }
-      case 'Home':
-        event.preventDefault();
-        items[0]?.focus();
-        break;
-      case 'End':
-        event.preventDefault();
-        items[items.length - 1]?.focus();
-        break;
-      case 'Escape':
-        event.preventDefault();
-        closeMenu(true);
-        break;
-      case 'Tab':
-        closeMenu();
-        break;
-      default:
-        break;
-    }
-  };
+		switch (event.key) {
+			case "ArrowDown": {
+				event.preventDefault();
+				const nextIndex = (currentIndex + 1) % items.length;
+				items[nextIndex]?.focus();
+				break;
+			}
+			case "ArrowUp": {
+				event.preventDefault();
+				const nextIndex = (currentIndex - 1 + items.length) % items.length;
+				items[nextIndex]?.focus();
+				break;
+			}
+			case "Home":
+				event.preventDefault();
+				items[0]?.focus();
+				break;
+			case "End":
+				event.preventDefault();
+				items[items.length - 1]?.focus();
+				break;
+			case "Escape":
+				event.preventDefault();
+				closeMenu(true);
+				break;
+			case "Tab":
+				closeMenu();
+				break;
+			default:
+				break;
+		}
+	};
 
-  const handleMouseEnter = () => {
-    if (anyMenuOpen && !isOpen) {
-      onOpenExplicit(section.label);
-    }
-  };
+	const handleMouseEnter = () => {
+		if (anyMenuOpen && !isOpen) {
+			onOpenExplicit(section.label);
+		}
+	};
 
-  return (
-    <div className="menu-section" onMouseEnter={handleMouseEnter}>
-      <button
-        ref={buttonRef}
-        type="button"
-        className={`menu-item ${isOpen ? 'active' : ''}`}
-        aria-haspopup="menu"
-        aria-expanded={isOpen}
-        onClick={handleButtonClick}
-        onKeyDown={handleButtonKeyDown}
-      >
-        {section.label}
-      </button>
-      <div
-        ref={menuRef}
-        className={`menu-dropdown ${isOpen ? '' : 'hidden'}`}
-        role="menu"
-        aria-label={section.label}
-        aria-hidden={!isOpen}
-        onKeyDown={handleMenuKeyDown}
-      >
-        {section.items.map((item, index) => {
-          if ('type' in item && item.type === 'separator') {
-            return <div key={`sep-${index}`} className="menu-dropdown-separator" role="separator" />;
-          }
+	return (
+		<div className="menu-section" onMouseEnter={handleMouseEnter}>
+			<button
+				ref={buttonRef}
+				type="button"
+				className={`menu-item ${isOpen ? "active" : ""}`}
+				aria-haspopup="menu"
+				aria-expanded={isOpen}
+				onClick={handleButtonClick}
+				onKeyDown={handleButtonKeyDown}
+			>
+				{section.label}
+			</button>
+			<div
+				ref={menuRef}
+				className={`menu-dropdown ${isOpen ? "" : "hidden"}`}
+				role="menu"
+				aria-label={section.label}
+				aria-hidden={!isOpen}
+				onKeyDown={handleMenuKeyDown}
+			>
+				{section.items.map((item, index) => {
+					if ("type" in item && item.type === "separator") {
+						return (
+							<div key={`sep-${index}`} className="menu-dropdown-separator" role="separator" />
+						);
+					}
 
-          const menuItem = item as MenuItem;
-          const isEnabled = menuItem.enabled ? menuItem.enabled() : true;
-          const isToggleItem = 'checked' in menuItem;
-          const isChecked = isToggleItem ? menuItem.checked() : false;
+					const menuItem = item as MenuItem;
+					const isEnabled = menuItem.enabled ? menuItem.enabled() : true;
+					const isToggleItem = "checked" in menuItem;
+					const isChecked = isToggleItem ? menuItem.checked() : false;
 
-          return (
-            <button
-              key={menuItem.id}
-              type="button"
-              role="menuitem"
-              className="menu-dropdown-item"
-              data-id={menuItem.id}
-              data-disabled={!isEnabled}
-              data-checked={isToggleItem ? isChecked : undefined}
-              disabled={!isEnabled}
-              onClick={() => {
-                menuItem.action();
-                closeMenu();
-              }}
-            >
-              <span className="menu-item-label">
-                {isToggleItem ? <span className="menu-item-check">{isChecked ? '✓' : ''}</span> : null}
-                {menuItem.label}
-              </span>
-              {menuItem.shortcut && <span className="menu-item-shortcut">{menuItem.shortcut}</span>}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
+					return (
+						<button
+							key={menuItem.id}
+							type="button"
+							role="menuitem"
+							className="menu-dropdown-item"
+							data-id={menuItem.id}
+							data-disabled={!isEnabled}
+							data-checked={isToggleItem ? isChecked : undefined}
+							disabled={!isEnabled}
+							onClick={() => {
+								menuItem.action();
+								closeMenu();
+							}}
+						>
+							<span className="menu-item-label">
+								{isToggleItem ? (
+									<span className="menu-item-check">{isChecked ? "✓" : ""}</span>
+								) : null}
+								{menuItem.label}
+							</span>
+							{menuItem.shortcut && <span className="menu-item-shortcut">{menuItem.shortcut}</span>}
+						</button>
+					);
+				})}
+			</div>
+		</div>
+	);
 }
 
 // Connection indicator component
 function ConnectionIndicator({ isConnected }: ConnectionIndicatorProps) {
-  return (
-    <div className={`connection-indicator ${isConnected ? 'connected' : 'disconnected'}`}>
-      <span className="connection-dot"></span>
-      <span className="connection-text">{isConnected ? 'Connected' : 'Disconnected'}</span>
-    </div>
-  );
+	return (
+		<div className={`connection-indicator ${isConnected ? "connected" : "disconnected"}`}>
+			<span className="connection-dot"></span>
+			<span className="connection-text">{isConnected ? "Connected" : "Disconnected"}</span>
+		</div>
+	);
 }

--- a/client/src/components/menu/StatusBar.tsx
+++ b/client/src/components/menu/StatusBar.tsx
@@ -1,40 +1,30 @@
-import { useStore } from '@/core';
+import { useStore } from "@/core";
 
 export function StatusBar(): JSX.Element {
-  const editor = useStore((state) => state.editor);
-  const settings = useStore((state) => state.settings);
-  const execution = useStore((state) => state.execution);
-  const project = useStore((state) => state.project);
+	const editor = useStore((state) => state.editor);
+	const settings = useStore((state) => state.settings);
+	const execution = useStore((state) => state.execution);
+	const project = useStore((state) => state.project);
 
-  return (
-    <div className="statusbar">
-      <div className="statusbar-left">
-        {project && (
-          <span className="statusbar-item">
-            Project: {project.name}
-          </span>
-        )}
-        <span className="statusbar-item">
-          {editor.filepath || 'Untitled'}
-        </span>
-        {editor.isDirty && (
-          <span className="statusbar-item statusbar-modified">Modified</span>
-        )}
-        <span className="statusbar-item">
-          Ln {editor.cursorPosition.line}, Col {editor.cursorPosition.column}
-        </span>
-      </div>
-      <div className="statusbar-right">
-        {execution.isRunning && (
-          <span className="statusbar-item statusbar-running">
-            <div className="spinner"></div>
-            Running R...
-          </span>
-        )}
-        <span className="statusbar-item">
-          R: {settings.rPath}
-        </span>
-      </div>
-    </div>
-  );
+	return (
+		<div className="statusbar">
+			<div className="statusbar-left">
+				{project && <span className="statusbar-item">Project: {project.name}</span>}
+				<span className="statusbar-item">{editor.filepath || "Untitled"}</span>
+				{editor.isDirty && <span className="statusbar-item statusbar-modified">Modified</span>}
+				<span className="statusbar-item">
+					Ln {editor.cursorPosition.line}, Col {editor.cursorPosition.column}
+				</span>
+			</div>
+			<div className="statusbar-right">
+				{execution.isRunning && (
+					<span className="statusbar-item statusbar-running">
+						<div className="spinner"></div>
+						Running R...
+					</span>
+				)}
+				<span className="statusbar-item">R: {settings.rPath}</span>
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/menu/index.ts
+++ b/client/src/components/menu/index.ts
@@ -1,2 +1,2 @@
-export { MenuBar } from './MenuBar';
-export { StatusBar } from './StatusBar';
+export { MenuBar } from "./MenuBar";
+export { StatusBar } from "./StatusBar";

--- a/client/src/components/modals/AboutModal.tsx
+++ b/client/src/components/modals/AboutModal.tsx
@@ -1,71 +1,71 @@
-import packageJson from '../../../package.json';
-import { IconInfo } from '@/components/shared';
-import { useStore } from '@/core';
-import { LINKS, TECH_STACK } from '@/constants/appInfo';
-import { ModalShell } from './ModalShell';
+import { IconInfo } from "@/components/shared";
+import { LINKS, TECH_STACK } from "@/constants/appInfo";
+import { useStore } from "@/core";
+import packageJson from "../../../package.json";
+import { ModalShell } from "./ModalShell";
 
 interface AboutModalProps {
-  open: boolean;
-  onClose: () => void;
+	open: boolean;
+	onClose: () => void;
 }
 
 export function AboutModal({ open, onClose }: AboutModalProps): JSX.Element | null {
-  const settings = useStore((state) => state.settings);
-  const version = packageJson.version ?? 'dev';
-  const mode = import.meta.env.MODE;
-  const build = import.meta.env.VITE_GIT_SHA || 'local-build';
-  const platform = typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown';
+	const settings = useStore((state) => state.settings);
+	const version = packageJson.version ?? "dev";
+	const mode = import.meta.env.MODE;
+	const build = import.meta.env.VITE_GIT_SHA || "local-build";
+	const platform = typeof navigator !== "undefined" ? navigator.userAgent : "unknown";
 
-  return (
-    <ModalShell
-      open={open}
-      onClose={onClose}
-      title="About Re-prod"
-      subtitle="AI-powered R analysis workspace"
-      icon={<IconInfo width={24} height={24} aria-hidden />}
-    >
-      <div className="about-grid">
-        <div className="about-card">
-          <h3>Version</h3>
-          <p className="about-metric">v{version}</p>
-          <dl>
-            <div>
-              <dt>Build channel</dt>
-              <dd>{mode}</dd>
-            </div>
-            <div>
-              <dt>Commit</dt>
-              <dd>{build}</dd>
-            </div>
-            <div>
-              <dt>R Path</dt>
-              <dd>{settings.rPath}</dd>
-            </div>
-          </dl>
-        </div>
-        <div className="about-card">
-          <h3>Runtime</h3>
-          <p className="about-metric">{platform}</p>
-          <p className="about-note">
-            Electron-free desktop shell powered by Tauri and Axum server bridge.
-          </p>
-          <ul className="about-tech-list">
-            {TECH_STACK.map((tech) => (
-              <li key={tech.title}>
-                <strong>{tech.title}</strong>
-                <span>{tech.description}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
-      <div className="about-links">
-        {LINKS.map((link) => (
-          <a key={link.href} href={link.href} target="_blank" rel="noreferrer">
-            {link.label}
-          </a>
-        ))}
-      </div>
-    </ModalShell>
-  );
+	return (
+		<ModalShell
+			open={open}
+			onClose={onClose}
+			title="About Re-prod"
+			subtitle="AI-powered R analysis workspace"
+			icon={<IconInfo width={24} height={24} aria-hidden />}
+		>
+			<div className="about-grid">
+				<div className="about-card">
+					<h3>Version</h3>
+					<p className="about-metric">v{version}</p>
+					<dl>
+						<div>
+							<dt>Build channel</dt>
+							<dd>{mode}</dd>
+						</div>
+						<div>
+							<dt>Commit</dt>
+							<dd>{build}</dd>
+						</div>
+						<div>
+							<dt>R Path</dt>
+							<dd>{settings.rPath}</dd>
+						</div>
+					</dl>
+				</div>
+				<div className="about-card">
+					<h3>Runtime</h3>
+					<p className="about-metric">{platform}</p>
+					<p className="about-note">
+						Electron-free desktop shell powered by Tauri and Axum server bridge.
+					</p>
+					<ul className="about-tech-list">
+						{TECH_STACK.map((tech) => (
+							<li key={tech.title}>
+								<strong>{tech.title}</strong>
+								<span>{tech.description}</span>
+							</li>
+						))}
+					</ul>
+				</div>
+			</div>
+			<div className="about-links">
+				{LINKS.map((link) => (
+					<a key={link.href} href={link.href} target="_blank" rel="noreferrer">
+						{link.label}
+					</a>
+				))}
+			</div>
+		</ModalShell>
+	);
 }

--- a/client/src/components/modals/KeyboardShortcutsModal.tsx
+++ b/client/src/components/modals/KeyboardShortcutsModal.tsx
@@ -1,78 +1,81 @@
-import { useMemo, useState } from 'react';
-import { IconKeyboard } from '@/components/shared';
-import { SHORTCUT_GROUPS } from '@/constants/shortcuts';
-import { ModalShell } from './ModalShell';
+import { useMemo, useState } from "react";
+import { IconKeyboard } from "@/components/shared";
+import { SHORTCUT_GROUPS } from "@/constants/shortcuts";
+import { ModalShell } from "./ModalShell";
 
 interface KeyboardShortcutsModalProps {
-  open: boolean;
-  onClose: () => void;
+	open: boolean;
+	onClose: () => void;
 }
 
-export function KeyboardShortcutsModal({ open, onClose }: KeyboardShortcutsModalProps): JSX.Element | null {
-  const [query, setQuery] = useState('');
+export function KeyboardShortcutsModal({
+	open,
+	onClose,
+}: KeyboardShortcutsModalProps): JSX.Element | null {
+	const [query, setQuery] = useState("");
 
-  const normalizedQuery = query.trim().toLowerCase();
-  const filteredGroups = useMemo(() => {
-    if (!normalizedQuery) {
-      return SHORTCUT_GROUPS;
-    }
+	const normalizedQuery = query.trim().toLowerCase();
+	const filteredGroups = useMemo(() => {
+		if (!normalizedQuery) {
+			return SHORTCUT_GROUPS;
+		}
 
-    return SHORTCUT_GROUPS.map((group) => ({
-      ...group,
-      items: group.items.filter((item) =>
-        `${item.keys.join(' ')} ${item.description}`.toLowerCase().includes(normalizedQuery)
-      ),
-    })).filter((group) => group.items.length > 0);
-  }, [normalizedQuery]);
+		return SHORTCUT_GROUPS.map((group) => ({
+			...group,
+			items: group.items.filter((item) =>
+				`${item.keys.join(" ")} ${item.description}`.toLowerCase().includes(normalizedQuery),
+			),
+		})).filter((group) => group.items.length > 0);
+	}, [normalizedQuery]);
 
-  return (
-    <ModalShell
-      open={open}
-      onClose={() => {
-        setQuery('');
-        onClose();
-      }}
-      title="Keyboard Shortcuts"
-      subtitle="Stay in flow with quick commands"
-      icon={<IconKeyboard width={24} height={24} aria-hidden />}
-      maxWidth={760}
-    >
-      <div className="shortcuts-search">
-        <input
-          type="search"
-          placeholder="Filter shortcuts"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          aria-label="Filter shortcuts"
-        />
-      </div>
-      <div className="shortcuts-grid">
-        {filteredGroups.map((group) => (
-          <div key={group.title} className="shortcut-group">
-            <div className="shortcut-group-header">{group.title}</div>
-            {group.items.map((item) => (
-              <div key={item.id} className="shortcut-card">
-                <div className="shortcut-keys">
-                  {item.keys.map((combo) => (
-                    <span key={`${item.id}-${combo}`} className="keycap">
-                      {combo}
-                    </span>
-                  ))}
-                </div>
-                <div className="shortcut-details">
-                  <span className="shortcut-description">{item.description}</span>
-                  {item.scope && <span className="shortcut-scope">{item.scope}</span>}
-                </div>
-              </div>
-            ))}
-          </div>
-        ))}
-        {filteredGroups.length === 0 && (
-          <div className="shortcuts-empty">
-            No shortcuts match “{query}”. Try a different search.
-          </div>
-        )}
-      </div>
-    </ModalShell>
-  );
+	return (
+		<ModalShell
+			open={open}
+			onClose={() => {
+				setQuery("");
+				onClose();
+			}}
+			title="Keyboard Shortcuts"
+			subtitle="Stay in flow with quick commands"
+			icon={<IconKeyboard width={24} height={24} aria-hidden />}
+			maxWidth={760}
+		>
+			<div className="shortcuts-search">
+				<input
+					type="search"
+					placeholder="Filter shortcuts"
+					value={query}
+					onChange={(event) => setQuery(event.target.value)}
+					aria-label="Filter shortcuts"
+				/>
+			</div>
+			<div className="shortcuts-grid">
+				{filteredGroups.map((group) => (
+					<div key={group.title} className="shortcut-group">
+						<div className="shortcut-group-header">{group.title}</div>
+						{group.items.map((item) => (
+							<div key={item.id} className="shortcut-card">
+								<div className="shortcut-keys">
+									{item.keys.map((combo) => (
+										<span key={`${item.id}-${combo}`} className="keycap">
+											{combo}
+										</span>
+									))}
+								</div>
+								<div className="shortcut-details">
+									<span className="shortcut-description">{item.description}</span>
+									{item.scope && <span className="shortcut-scope">{item.scope}</span>}
+								</div>
+							</div>
+						))}
+					</div>
+				))}
+				{filteredGroups.length === 0 && (
+					<div className="shortcuts-empty">
+						No shortcuts match “{query}”. Try a different search.
+					</div>
+				)}
+			</div>
+		</ModalShell>
+	);
 }

--- a/client/src/components/modals/ModalShell.tsx
+++ b/client/src/components/modals/ModalShell.tsx
@@ -1,71 +1,71 @@
-import { type ReactNode, useEffect, useId } from 'react';
+import { type ReactNode, useEffect, useId } from "react";
 
 interface ModalShellProps {
-  open: boolean;
-  onClose: () => void;
-  title: string;
-  icon?: ReactNode;
-  subtitle?: string;
-  maxWidth?: number;
-  footer?: ReactNode;
-  children: ReactNode;
+	open: boolean;
+	onClose: () => void;
+	title: string;
+	icon?: ReactNode;
+	subtitle?: string;
+	maxWidth?: number;
+	footer?: ReactNode;
+	children: ReactNode;
 }
 
 export function ModalShell({
-  open,
-  onClose,
-  title,
-  icon,
-  subtitle,
-  maxWidth = 640,
-  footer,
-  children,
+	open,
+	onClose,
+	title,
+	icon,
+	subtitle,
+	maxWidth = 640,
+	footer,
+	children,
 }: ModalShellProps): JSX.Element | null {
-  const labelId = useId();
+	const labelId = useId();
 
-  useEffect(() => {
-    if (!open) return;
+	useEffect(() => {
+		if (!open) return;
 
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.stopPropagation();
-        onClose();
-      }
-    };
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				event.stopPropagation();
+				onClose();
+			}
+		};
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [open, onClose]);
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [open, onClose]);
 
-  if (!open) {
-    return null;
-  }
+	if (!open) {
+		return null;
+	}
 
-  return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div
-        className="modal-dialog"
-        style={{ maxWidth }}
-        onClick={(event) => event.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={`${labelId}-title`}
-      >
-        <div className="modal-header">
-          <div className="modal-title">
-            {icon && <span className="modal-title-icon">{icon}</span>}
-            <div>
-              <h2 id={`${labelId}-title`}>{title}</h2>
-              {subtitle && <p className="modal-subtitle">{subtitle}</p>}
-            </div>
-          </div>
-          <button className="btn btn-icon" onClick={onClose} aria-label="Close dialog">
-            ×
-          </button>
-        </div>
-        <div className="modal-body">{children}</div>
-        {footer && <div className="modal-footer">{footer}</div>}
-      </div>
-    </div>
-  );
+	return (
+		<div className="modal-overlay" onClick={onClose}>
+			<div
+				className="modal-dialog"
+				style={{ maxWidth }}
+				onClick={(event) => event.stopPropagation()}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={`${labelId}-title`}
+			>
+				<div className="modal-header">
+					<div className="modal-title">
+						{icon && <span className="modal-title-icon">{icon}</span>}
+						<div>
+							<h2 id={`${labelId}-title`}>{title}</h2>
+							{subtitle && <p className="modal-subtitle">{subtitle}</p>}
+						</div>
+					</div>
+					<button className="btn btn-icon" onClick={onClose} aria-label="Close dialog">
+						×
+					</button>
+				</div>
+				<div className="modal-body">{children}</div>
+				{footer && <div className="modal-footer">{footer}</div>}
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/modals/ProjectManagerModal.tsx
+++ b/client/src/components/modals/ProjectManagerModal.tsx
@@ -1,148 +1,158 @@
-import { useState } from 'react';
+import { useState } from "react";
 
-import { useStore } from '@/core';
-import { persistCurrentProjectState } from '@/hooks/useProjectSession';
-import { projectService } from '@/services/projectService';
-import { ModalShell } from './ModalShell';
+import { useStore } from "@/core";
+import { persistCurrentProjectState } from "@/hooks/useProjectSession";
+import { projectService } from "@/services/projectService";
+import { ModalShell } from "./ModalShell";
 
 interface ProjectManagerModalProps {
-  open: boolean;
-  onClose: () => void;
+	open: boolean;
+	onClose: () => void;
 }
 
-export function ProjectManagerModal({ open, onClose }: ProjectManagerModalProps): JSX.Element | null {
-  const currentProject = useStore((state) => state.project);
-  const [newProjectName, setNewProjectName] = useState('New Project');
-  const [newProjectPath, setNewProjectPath] = useState('');
-  const [cloneRemote, setCloneRemote] = useState('');
-  const [clonePath, setClonePath] = useState('');
-  const [cloneName, setCloneName] = useState('');
-  const [error, setError] = useState<string | null>(null);
+export function ProjectManagerModal({
+	open,
+	onClose,
+}: ProjectManagerModalProps): JSX.Element | null {
+	const currentProject = useStore((state) => state.project);
+	const [newProjectName, setNewProjectName] = useState("New Project");
+	const [newProjectPath, setNewProjectPath] = useState("");
+	const [cloneRemote, setCloneRemote] = useState("");
+	const [clonePath, setClonePath] = useState("");
+	const [cloneName, setCloneName] = useState("");
+	const [error, setError] = useState<string | null>(null);
 
-  if (!open) {
-    return null;
-  }
+	if (!open) {
+		return null;
+	}
 
-  const handleProjectOpen = (projectId: string) => {
-    setError(null);
-    persistCurrentProjectState();
-    projectService.open(projectId);
-    onClose();
-  };
+	const handleProjectOpen = (projectId: string) => {
+		setError(null);
+		persistCurrentProjectState();
+		projectService.open(projectId);
+		onClose();
+	};
 
-  const handleCreate = () => {
-    if (!newProjectName.trim() || !newProjectPath.trim()) {
-      setError('Project name and path are required.');
-      return;
-    }
-    setError(null);
-    persistCurrentProjectState();
-    projectService.create({ name: newProjectName.trim(), path: newProjectPath.trim() });
-  };
+	const handleCreate = () => {
+		if (!newProjectName.trim() || !newProjectPath.trim()) {
+			setError("Project name and path are required.");
+			return;
+		}
+		setError(null);
+		persistCurrentProjectState();
+		projectService.create({
+			name: newProjectName.trim(),
+			path: newProjectPath.trim(),
+		});
+	};
 
-  const handleClone = () => {
-    if (!cloneRemote.trim() || !clonePath.trim()) {
-      setError('Remote URL and destination path are required.');
-      return;
-    }
-    setError(null);
-    persistCurrentProjectState();
-    projectService.clone({
-      remote: cloneRemote.trim(),
-      path: clonePath.trim(),
-      name: cloneName.trim() || undefined,
-    });
-  };
+	const handleClone = () => {
+		if (!cloneRemote.trim() || !clonePath.trim()) {
+			setError("Remote URL and destination path are required.");
+			return;
+		}
+		setError(null);
+		persistCurrentProjectState();
+		projectService.clone({
+			remote: cloneRemote.trim(),
+			path: clonePath.trim(),
+			name: cloneName.trim() || undefined,
+		});
+	};
 
-  return (
-    <ModalShell
-      open={open}
-      onClose={onClose}
-      title="Projects"
-      subtitle="Create new isolated workspaces or clone from version control."
-      maxWidth={800}
-    >
-      <div className="project-manager">
-        {error && <div className="alert alert-error">{error}</div>}
-        <section className="project-manager-section">
-          <h3>Current Project</h3>
-          {currentProject ? (
-            <div className="project-card">
-              <div>
-                <strong>{currentProject.name}</strong>
-                <p className="muted">{currentProject.path}</p>
-              </div>
-              <button type="button" className="btn btn-secondary" onClick={() => handleProjectOpen(currentProject.id)}>
-                Reload
-              </button>
-            </div>
-          ) : (
-            <p>No project selected.</p>
-          )}
-        </section>
+	return (
+		<ModalShell
+			open={open}
+			onClose={onClose}
+			title="Projects"
+			subtitle="Create new isolated workspaces or clone from version control."
+			maxWidth={800}
+		>
+			<div className="project-manager">
+				{error && <div className="alert alert-error">{error}</div>}
+				<section className="project-manager-section">
+					<h3>Current Project</h3>
+					{currentProject ? (
+						<div className="project-card">
+							<div>
+								<strong>{currentProject.name}</strong>
+								<p className="muted">{currentProject.path}</p>
+							</div>
+							<button
+								type="button"
+								className="btn btn-secondary"
+								onClick={() => handleProjectOpen(currentProject.id)}
+							>
+								Reload
+							</button>
+						</div>
+					) : (
+						<p>No project selected.</p>
+					)}
+				</section>
 
-        <section className="project-manager-section">
-          <h3>Create New Project</h3>
-          <div className="form-grid">
-            <label>
-              Name
-              <input
-                type="text"
-                value={newProjectName}
-                onChange={(event) => setNewProjectName(event.target.value)}
-              />
-            </label>
-            <label>
-              Directory Path
-              <input
-                type="text"
-                placeholder="/path/to/project"
-                value={newProjectPath}
-                onChange={(event) => setNewProjectPath(event.target.value)}
-              />
-            </label>
-          </div>
-          <button type="button" className="btn btn-primary" onClick={handleCreate}>
-            Create Project
-          </button>
-        </section>
+				<section className="project-manager-section">
+					<h3>Create New Project</h3>
+					<div className="form-grid">
+						<label>
+							Name
+							<input
+								type="text"
+								value={newProjectName}
+								onChange={(event) => setNewProjectName(event.target.value)}
+							/>
+						</label>
+						<label>
+							Directory Path
+							<input
+								type="text"
+								placeholder="/path/to/project"
+								value={newProjectPath}
+								onChange={(event) => setNewProjectPath(event.target.value)}
+							/>
+						</label>
+					</div>
+					<button type="button" className="btn btn-primary" onClick={handleCreate}>
+						Create Project
+					</button>
+				</section>
 
-        <section className="project-manager-section">
-          <h3>Clone from Version Control</h3>
-          <div className="form-grid">
-            <label>
-              Remote URL
-              <input
-                type="text"
-                placeholder="https://github.com/org/repo.git"
-                value={cloneRemote}
-                onChange={(event) => setCloneRemote(event.target.value)}
-              />
-            </label>
-            <label>
-              Destination Path
-              <input
-                type="text"
-                placeholder="/path/to/clone"
-                value={clonePath}
-                onChange={(event) => setClonePath(event.target.value)}
-              />
-            </label>
-            <label>
-              Project Name (optional)
-              <input
-                type="text"
-                placeholder="Friendly name"
-                value={cloneName}
-                onChange={(event) => setCloneName(event.target.value)}
-              />
-            </label>
-          </div>
-          <button type="button" className="btn btn-secondary" onClick={handleClone}>
-            Clone Repository
-          </button>
-        </section>
-      </div>
-    </ModalShell>
-  );
+				<section className="project-manager-section">
+					<h3>Clone from Version Control</h3>
+					<div className="form-grid">
+						<label>
+							Remote URL
+							<input
+								type="text"
+								placeholder="https://github.com/org/repo.git"
+								value={cloneRemote}
+								onChange={(event) => setCloneRemote(event.target.value)}
+							/>
+						</label>
+						<label>
+							Destination Path
+							<input
+								type="text"
+								placeholder="/path/to/clone"
+								value={clonePath}
+								onChange={(event) => setClonePath(event.target.value)}
+							/>
+						</label>
+						<label>
+							Project Name (optional)
+							<input
+								type="text"
+								placeholder="Friendly name"
+								value={cloneName}
+								onChange={(event) => setCloneName(event.target.value)}
+							/>
+						</label>
+					</div>
+					<button type="button" className="btn btn-secondary" onClick={handleClone}>
+						Clone Repository
+					</button>
+				</section>
+			</div>
+		</ModalShell>
+	);
 }

--- a/client/src/components/modals/SessionInfoModal.tsx
+++ b/client/src/components/modals/SessionInfoModal.tsx
@@ -1,200 +1,198 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { IconInfo, IconRefresh } from '@/components/shared';
-import { useStore, buildExecutionRequest } from '@/core';
-import { executeRequest, ExecutionServiceError } from '@/services/executionService';
-import { ModalShell } from './ModalShell';
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { IconInfo, IconRefresh } from "@/components/shared";
+import { buildExecutionRequest, useStore } from "@/core";
+import { ExecutionServiceError, executeRequest } from "@/services/executionService";
+import { ModalShell } from "./ModalShell";
 
 interface SessionInfoModalProps {
-  open: boolean;
-  onClose: () => void;
+	open: boolean;
+	onClose: () => void;
 }
 
 interface ParsedSessionInfo {
-  rVersion?: string;
-  packages: Array<{ name: string; version?: string }>;
-  rawOutput: string;
+	rVersion?: string;
+	packages: Array<{ name: string; version?: string }>;
+	rawOutput: string;
 }
 
-const SESSION_INFO_COMMAND = 'sessionInfo()';
+const SESSION_INFO_COMMAND = "sessionInfo()";
 
 function parseSessionInfoOutput(output: string): ParsedSessionInfo {
-  const trimmed = output.trim();
-  const versionMatch = trimmed.match(/R version\s+([^\n]+)/i);
-  const packages: ParsedSessionInfo['packages'] = [];
+	const trimmed = output.trim();
+	const versionMatch = trimmed.match(/R version\s+([^\n]+)/i);
+	const packages: ParsedSessionInfo["packages"] = [];
 
-  const packagesMatch = trimmed.match(/other attached packages:\s*([\s\S]*?)(?:\n\n|\nloaded via|$)/i);
-  if (packagesMatch) {
-    const normalized = packagesMatch[1]
-      .split('\n')
-      .map((line) => line.replace(/\[[^\]]+\]/g, '').trim())
-      .join(' ')
-      .replace(/,+/g, ' ');
+	const packagesMatch = trimmed.match(
+		/other attached packages:\s*([\s\S]*?)(?:\n\n|\nloaded via|$)/i,
+	);
+	if (packagesMatch) {
+		const normalized = packagesMatch[1]
+			.split("\n")
+			.map((line) => line.replace(/\[[^\]]+\]/g, "").trim())
+			.join(" ")
+			.replace(/,+/g, " ");
 
-    normalized
-      .split(/\s+/)
-      .filter(Boolean)
-      .forEach((token) => {
-        const separatorIndex = token.lastIndexOf('_');
-        if (separatorIndex <= 0 || separatorIndex === token.length - 1) {
-          return;
-        }
-        const name = token.slice(0, separatorIndex);
-        const version = token.slice(separatorIndex + 1).replace(/[,;]+$/, '');
-        packages.push({ name, version });
-      });
-  }
+		normalized
+			.split(/\s+/)
+			.filter(Boolean)
+			.forEach((token) => {
+				const separatorIndex = token.lastIndexOf("_");
+				if (separatorIndex <= 0 || separatorIndex === token.length - 1) {
+					return;
+				}
+				const name = token.slice(0, separatorIndex);
+				const version = token.slice(separatorIndex + 1).replace(/[,;]+$/, "");
+				packages.push({ name, version });
+			});
+	}
 
-  return {
-    rVersion: versionMatch?.[1]?.trim(),
-    packages,
-    rawOutput: trimmed,
-  };
+	return {
+		rVersion: versionMatch?.[1]?.trim(),
+		packages,
+		rawOutput: trimmed,
+	};
 }
 
 export function SessionInfoModal({ open, onClose }: SessionInfoModalProps): JSX.Element | null {
-  const settings = useStore((state) => state.settings);
-  const execution = useStore((state) => state.execution);
-  const isConnected = useStore((state) => state.isConnected);
-  const [sessionInfo, setSessionInfo] = useState<ParsedSessionInfo | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+	const settings = useStore((state) => state.settings);
+	const execution = useStore((state) => state.execution);
+	const isConnected = useStore((state) => state.isConnected);
+	const [sessionInfo, setSessionInfo] = useState<ParsedSessionInfo | null>(null);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [lastUpdated, setLastUpdated] = useState<number | null>(null);
 
-  const totalRuns = execution.history.length;
-  const totalErrors = useMemo(
-    () => execution.history.filter((result) => !result.success).length,
-    [execution.history]
-  );
-  const lastRunEntry = execution.history.length
-    ? execution.history[execution.history.length - 1]
-    : null;
-  const lastRunTimestamp = lastRunEntry?.timestamp ?? null;
+	const totalRuns = execution.history.length;
+	const totalErrors = useMemo(
+		() => execution.history.filter((result) => !result.success).length,
+		[execution.history],
+	);
+	const lastRunEntry = execution.history.length
+		? execution.history[execution.history.length - 1]
+		: null;
+	const lastRunTimestamp = lastRunEntry?.timestamp ?? null;
 
-  const fetchSessionInfo = useCallback(async () => {
-    const request = buildExecutionRequest({
-      target: {
-        code: SESSION_INFO_COMMAND,
-        source: 'selection',
-        range: { startLine: 1, endLine: 1 },
-      },
-      cells: [],
-      documentContent: SESSION_INFO_COMMAND,
-      filepath: undefined,
-    });
+	const fetchSessionInfo = useCallback(async () => {
+		const request = buildExecutionRequest({
+			target: {
+				code: SESSION_INFO_COMMAND,
+				source: "selection",
+				range: { startLine: 1, endLine: 1 },
+			},
+			cells: [],
+			documentContent: SESSION_INFO_COMMAND,
+			filepath: undefined,
+		});
 
-    setLoading(true);
-    setError(null);
+		setLoading(true);
+		setError(null);
 
-    try {
-      const { result } = await executeRequest(request);
-      setSessionInfo(parseSessionInfoOutput(result.output || ''));
-      setLastUpdated(Date.now());
-      if (result.error) {
-        setError(result.error);
-      }
-    } catch (err) {
-      const message =
-        err instanceof ExecutionServiceError
-          ? err.message
-          : 'Unable to fetch session information.';
-      setError(message);
-      setSessionInfo(null);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+		try {
+			const { result } = await executeRequest(request);
+			setSessionInfo(parseSessionInfoOutput(result.output || ""));
+			setLastUpdated(Date.now());
+			if (result.error) {
+				setError(result.error);
+			}
+		} catch (err) {
+			const message =
+				err instanceof ExecutionServiceError ? err.message : "Unable to fetch session information.";
+			setError(message);
+			setSessionInfo(null);
+		} finally {
+			setLoading(false);
+		}
+	}, []);
 
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    void fetchSessionInfo();
-  }, [open, fetchSessionInfo]);
+	useEffect(() => {
+		if (!open) {
+			return;
+		}
+		void fetchSessionInfo();
+	}, [open, fetchSessionInfo]);
 
-  return (
-    <ModalShell
-      open={open}
-      onClose={onClose}
-      title="Session Info"
-      subtitle="Snapshot of the active R runtime"
-      icon={<IconInfo width={22} height={22} aria-hidden />}
-      maxWidth={780}
-      footer={
-        <div className="modal-footer-actions">
-          <button className="btn" onClick={fetchSessionInfo} disabled={loading}>
-            <IconRefresh width={16} height={16} aria-hidden />
-            {loading ? 'Refreshing…' : 'Refresh'}
-          </button>
-          <button className="btn btn-primary" onClick={onClose}>
-            Close
-          </button>
-        </div>
-      }
-    >
-      <div className="session-info-grid">
-        <div className="session-info-card">
-          <h3>Status</h3>
-          <dl>
-            <div>
-              <dt>Connection</dt>
-              <dd>{isConnected ? 'Connected' : 'Disconnected'}</dd>
-            </div>
-            <div>
-              <dt>R executable</dt>
-              <dd>{settings.rPath}</dd>
-            </div>
-            <div>
-              <dt>R version</dt>
-              <dd>{sessionInfo?.rVersion || 'Pending data'}</dd>
-            </div>
-            <div>
-              <dt>Total runs</dt>
-              <dd>{totalRuns}</dd>
-            </div>
-            <div>
-              <dt>Errors</dt>
-              <dd>{totalErrors}</dd>
-            </div>
-            <div>
-              <dt>Last run</dt>
-              <dd>{lastRunTimestamp ? new Date(lastRunTimestamp).toLocaleString() : 'Never'}</dd>
-            </div>
-            <div>
-              <dt>Last refreshed</dt>
-              <dd>{lastUpdated ? new Date(lastUpdated).toLocaleTimeString() : 'Now'}</dd>
-            </div>
-          </dl>
-        </div>
-        <div className="session-info-card">
-          <h3>Packages</h3>
-          {sessionInfo?.packages.length ? (
-            <ul className="package-list">
-              {sessionInfo.packages.slice(0, 20).map((pkg) => (
-                <li key={`${pkg.name}-${pkg.version || 'unknown'}`}>
-                  <span className="package-name">{pkg.name}</span>
-                  {pkg.version && <span className="package-version">v{pkg.version}</span>}
-                </li>
-              ))}
-              {sessionInfo.packages.length > 20 && (
-                <li className="package-more">+{sessionInfo.packages.length - 20} more</li>
-              )}
-            </ul>
-          ) : (
-            <p className="session-info-empty">
-              {loading ? 'Requesting sessionInfo() from R…' : 'No attached packages reported yet.'}
-            </p>
-          )}
-        </div>
-      </div>
-      {error && <div className="session-info-error">{error}</div>}
-      {sessionInfo?.rawOutput && (
-        <div className="session-info-output">
-          <div className="session-info-output-header">
-            Raw sessionInfo() output
-          </div>
-          <pre>{sessionInfo.rawOutput}</pre>
-        </div>
-      )}
-    </ModalShell>
-  );
+	return (
+		<ModalShell
+			open={open}
+			onClose={onClose}
+			title="Session Info"
+			subtitle="Snapshot of the active R runtime"
+			icon={<IconInfo width={22} height={22} aria-hidden />}
+			maxWidth={780}
+			footer={
+				<div className="modal-footer-actions">
+					<button className="btn" onClick={fetchSessionInfo} disabled={loading}>
+						<IconRefresh width={16} height={16} aria-hidden />
+						{loading ? "Refreshing…" : "Refresh"}
+					</button>
+					<button className="btn btn-primary" onClick={onClose}>
+						Close
+					</button>
+				</div>
+			}
+		>
+			<div className="session-info-grid">
+				<div className="session-info-card">
+					<h3>Status</h3>
+					<dl>
+						<div>
+							<dt>Connection</dt>
+							<dd>{isConnected ? "Connected" : "Disconnected"}</dd>
+						</div>
+						<div>
+							<dt>R executable</dt>
+							<dd>{settings.rPath}</dd>
+						</div>
+						<div>
+							<dt>R version</dt>
+							<dd>{sessionInfo?.rVersion || "Pending data"}</dd>
+						</div>
+						<div>
+							<dt>Total runs</dt>
+							<dd>{totalRuns}</dd>
+						</div>
+						<div>
+							<dt>Errors</dt>
+							<dd>{totalErrors}</dd>
+						</div>
+						<div>
+							<dt>Last run</dt>
+							<dd>{lastRunTimestamp ? new Date(lastRunTimestamp).toLocaleString() : "Never"}</dd>
+						</div>
+						<div>
+							<dt>Last refreshed</dt>
+							<dd>{lastUpdated ? new Date(lastUpdated).toLocaleTimeString() : "Now"}</dd>
+						</div>
+					</dl>
+				</div>
+				<div className="session-info-card">
+					<h3>Packages</h3>
+					{sessionInfo?.packages.length ? (
+						<ul className="package-list">
+							{sessionInfo.packages.slice(0, 20).map((pkg) => (
+								<li key={`${pkg.name}-${pkg.version || "unknown"}`}>
+									<span className="package-name">{pkg.name}</span>
+									{pkg.version && <span className="package-version">v{pkg.version}</span>}
+								</li>
+							))}
+							{sessionInfo.packages.length > 20 && (
+								<li className="package-more">+{sessionInfo.packages.length - 20} more</li>
+							)}
+						</ul>
+					) : (
+						<p className="session-info-empty">
+							{loading ? "Requesting sessionInfo() from R…" : "No attached packages reported yet."}
+						</p>
+					)}
+				</div>
+			</div>
+			{error && <div className="session-info-error">{error}</div>}
+			{sessionInfo?.rawOutput && (
+				<div className="session-info-output">
+					<div className="session-info-output-header">Raw sessionInfo() output</div>
+					<pre>{sessionInfo.rawOutput}</pre>
+				</div>
+			)}
+		</ModalShell>
+	);
 }

--- a/client/src/components/modals/SettingsModal.tsx
+++ b/client/src/components/modals/SettingsModal.tsx
@@ -1,155 +1,160 @@
-import { useEffect, useState } from 'react';
-import type { AppSettings } from '@shared/types';
-import { IconSettings } from '@/components/shared';
-import { useStore } from '@/core';
-import { DEFAULT_SETTINGS } from '@/constants/defaultSettings';
-import { ModalShell } from './ModalShell';
-import { SettingsPanel } from '../settings/SettingsPanel';
+import type { AppSettings } from "@shared/types";
+import { useEffect, useState } from "react";
+import { IconSettings } from "@/components/shared";
+import { DEFAULT_SETTINGS } from "@/constants/defaultSettings";
+import { useStore } from "@/core";
+import { SettingsPanel } from "../settings/SettingsPanel";
+import { ModalShell } from "./ModalShell";
 
 interface SettingsModalProps {
-  open: boolean;
-  onClose: () => void;
+	open: boolean;
+	onClose: () => void;
 }
 
 type SettingKey = keyof AppSettings;
 
 export function SettingsModal({ open, onClose }: SettingsModalProps): JSX.Element | null {
-  const settings = useStore((state) => state.settings);
-  const updateSettings = useStore((state) => state.updateSettings);
-  const [draft, setDraft] = useState<AppSettings>(settings);
+	const settings = useStore((state) => state.settings);
+	const updateSettings = useStore((state) => state.updateSettings);
+	const [draft, setDraft] = useState<AppSettings>(settings);
 
-  useEffect(() => {
-    if (open) {
-      setDraft(settings);
-    }
-  }, [open, settings]);
+	useEffect(() => {
+		if (open) {
+			setDraft(settings);
+		}
+	}, [open, settings]);
 
-  const handleChange = <K extends SettingKey>(key: K, value: AppSettings[K]) => {
-    setDraft((prev) => ({ ...prev, [key]: value }));
-  };
+	const handleChange = <K extends SettingKey>(key: K, value: AppSettings[K]) => {
+		setDraft((prev) => ({ ...prev, [key]: value }));
+	};
 
-  const handleSubmit = (event: React.FormEvent) => {
-    event.preventDefault();
-    updateSettings(draft);
-    onClose();
-  };
+	const handleSubmit = (event: React.FormEvent) => {
+		event.preventDefault();
+		updateSettings(draft);
+		onClose();
+	};
 
-  const handleReset = () => {
-    setDraft({ ...DEFAULT_SETTINGS });
-  };
+	const handleReset = () => {
+		setDraft({ ...DEFAULT_SETTINGS });
+	};
 
-  return (
-    <ModalShell
-      open={open}
-      onClose={onClose}
-      title="Settings"
-      subtitle="Personalize the editor and runtime"
-      icon={<IconSettings width={22} height={22} aria-hidden />}
-      maxWidth={720}
-      footer={
-        <div className="modal-footer-actions">
-          <button className="btn" type="button" onClick={handleReset}>
-            Reset defaults
-          </button>
-          <div className="settings-footer-spacer" />
-          <button className="btn" type="button" onClick={onClose}>
-            Cancel
-          </button>
-          <button className="btn btn-primary" type="submit" form="settings-form">
-            Save changes
-          </button>
-        </div>
-      }
-    >
-      <form id="settings-form" className="settings-form" onSubmit={handleSubmit}>
-        <section>
-          <h3>General</h3>
-          <label className="settings-row">
-            <span>
-              Auto-run new code blocks
-              <small>Automatically execute when AI inserts snippets.</small>
-            </span>
-            <input
-              type="checkbox"
-              checked={draft.autoRun}
-              onChange={(event) => handleChange('autoRun', event.target.checked)}
-            />
-          </label>
-          <label className="settings-row">
-            <span>
-              Theme
-              <small>Experimental. Applies to supported components.</small>
-            </span>
-            <select value={draft.theme} onChange={(event) => handleChange('theme', event.target.value as AppSettings['theme'])}>
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-            </select>
-          </label>
-        </section>
+	return (
+		<ModalShell
+			open={open}
+			onClose={onClose}
+			title="Settings"
+			subtitle="Personalize the editor and runtime"
+			icon={<IconSettings width={22} height={22} aria-hidden />}
+			maxWidth={720}
+			footer={
+				<div className="modal-footer-actions">
+					<button className="btn" type="button" onClick={handleReset}>
+						Reset defaults
+					</button>
+					<div className="settings-footer-spacer" />
+					<button className="btn" type="button" onClick={onClose}>
+						Cancel
+					</button>
+					<button className="btn btn-primary" type="submit" form="settings-form">
+						Save changes
+					</button>
+				</div>
+			}
+		>
+			<form id="settings-form" className="settings-form" onSubmit={handleSubmit}>
+				<section>
+					<h3>General</h3>
+					<label className="settings-row">
+						<span>
+							Auto-run new code blocks
+							<small>Automatically execute when AI inserts snippets.</small>
+						</span>
+						<input
+							type="checkbox"
+							checked={draft.autoRun}
+							onChange={(event) => handleChange("autoRun", event.target.checked)}
+						/>
+					</label>
+					<label className="settings-row">
+						<span>
+							Theme
+							<small>Experimental. Applies to supported components.</small>
+						</span>
+						<select
+							value={draft.theme}
+							onChange={(event) =>
+								handleChange("theme", event.target.value as AppSettings["theme"])
+							}
+						>
+							<option value="light">Light</option>
+							<option value="dark">Dark</option>
+						</select>
+					</label>
+				</section>
 
-        <section>
-          <h3>Editor</h3>
-          <label className="settings-row">
-            <span>
-              Font size
-              <small>Applies to instantly Monaco editor.</small>
-            </span>
-            <div className="settings-number-input">
-              <input
-                type="range"
-                min={11}
-                max={22}
-                value={draft.fontSize}
-                onChange={(event) => handleChange('fontSize', Number(event.target.value))}
-              />
-              <span>{draft.fontSize}px</span>
-            </div>
-          </label>
-          <label className="settings-row">
-            <span>
-              Show cell decorations
-              <small>Draw section markers for `# ----` blocks.</small>
-            </span>
-            <input
-              type="checkbox"
-              checked={draft.showCellDecorations}
-              onChange={(event) => handleChange('showCellDecorations', event.target.checked)}
-            />
-          </label>
-          <label className="settings-row">
-            <span>
-              Highlight executing cell
-              <small>Shade the currently running block.</small>
-            </span>
-            <input
-              type="checkbox"
-              checked={draft.highlightExecutingCell}
-              onChange={(event) => handleChange('highlightExecutingCell', event.target.checked)}
-            />
-          </label>
-        </section>
+				<section>
+					<h3>Editor</h3>
+					<label className="settings-row">
+						<span>
+							Font size
+							<small>Applies to instantly Monaco editor.</small>
+						</span>
+						<div className="settings-number-input">
+							<input
+								type="range"
+								min={11}
+								max={22}
+								value={draft.fontSize}
+								onChange={(event) => handleChange("fontSize", Number(event.target.value))}
+							/>
+							<span>{draft.fontSize}px</span>
+						</div>
+					</label>
+					<label className="settings-row">
+						<span>
+							Show cell decorations
+							<small>Draw section markers for `# ----` blocks.</small>
+						</span>
+						<input
+							type="checkbox"
+							checked={draft.showCellDecorations}
+							onChange={(event) => handleChange("showCellDecorations", event.target.checked)}
+						/>
+					</label>
+					<label className="settings-row">
+						<span>
+							Highlight executing cell
+							<small>Shade the currently running block.</small>
+						</span>
+						<input
+							type="checkbox"
+							checked={draft.highlightExecutingCell}
+							onChange={(event) => handleChange("highlightExecutingCell", event.target.checked)}
+						/>
+					</label>
+				</section>
 
-        <section>
-          <h3>R Runtime</h3>
-          <label className="settings-row">
-            <span>
-              R executable path
-              <small>Used by the backend when launching scripts.</small>
-            </span>
-            <input
-              type="text"
-              value={draft.rPath}
-              onChange={(event) => handleChange('rPath', event.target.value)}
-              placeholder="Rscript"
-            />
-          </label>
-        </section>
+				<section>
+					<h3>R Runtime</h3>
+					<label className="settings-row">
+						<span>
+							R executable path
+							<small>Used by the backend when launching scripts.</small>
+						</span>
+						<input
+							type="text"
+							value={draft.rPath}
+							onChange={(event) => handleChange("rPath", event.target.value)}
+							placeholder="Rscript"
+						/>
+					</label>
+				</section>
 
-        <section>
-          <h3>LLM Providers</h3>
-          <SettingsPanel />
-        </section>
-      </form>
-    </ModalShell>
-  );
+				<section>
+					<h3>LLM Providers</h3>
+					<SettingsPanel />
+				</section>
+			</form>
+		</ModalShell>
+	);
 }

--- a/client/src/components/modals/index.ts
+++ b/client/src/components/modals/index.ts
@@ -1,5 +1,5 @@
-export { KeyboardShortcutsModal } from './KeyboardShortcutsModal';
-export { AboutModal } from './AboutModal';
-export { SessionInfoModal } from './SessionInfoModal';
-export { SettingsModal } from './SettingsModal';
-export { ProjectManagerModal } from './ProjectManagerModal';
+export { AboutModal } from "./AboutModal";
+export { KeyboardShortcutsModal } from "./KeyboardShortcutsModal";
+export { ProjectManagerModal } from "./ProjectManagerModal";
+export { SessionInfoModal } from "./SessionInfoModal";
+export { SettingsModal } from "./SettingsModal";

--- a/client/src/components/settings/LLMProviderConfig.css
+++ b/client/src/components/settings/LLMProviderConfig.css
@@ -1,105 +1,106 @@
 .llm-provider-config {
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  padding: 12px;
-  margin-bottom: 12px;
-  background: var(--bg-secondary);
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	padding: 12px;
+	margin-bottom: 12px;
+	background: var(--bg-secondary);
 }
 
 .provider-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 8px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 8px;
 }
 
 .provider-name {
-  font-weight: 600;
-  font-size: 14px;
+	font-weight: 600;
+	font-size: 14px;
 }
 
 .status-badge {
-  font-size: 10px;
-  padding: 2px 6px;
-  border-radius: 4px;
-  background: var(--success-bg);
-  color: var(--success-text);
+	font-size: 10px;
+	padding: 2px 6px;
+	border-radius: 4px;
+	background: var(--success-bg);
+	color: var(--success-text);
 }
 
 .config-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 8px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 8px;
 }
 
 .config-row label {
-  width: 60px;
-  font-size: 12px;
-  color: var(--text-secondary);
+	width: 60px;
+	font-size: 12px;
+	color: var(--text-secondary);
 }
 
-.input-group, .display-group {
-  display: flex;
-  flex: 1;
-  gap: 8px;
-  align-items: center;
+.input-group,
+.display-group {
+	display: flex;
+	flex: 1;
+	gap: 8px;
+	align-items: center;
 }
 
 input[type="password"] {
-  flex: 1;
-  padding: 4px 8px;
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  background: var(--bg-primary);
-  color: var(--text-primary);
+	flex: 1;
+	padding: 4px 8px;
+	border: 1px solid var(--border-color);
+	border-radius: 4px;
+	background: var(--bg-primary);
+	color: var(--text-primary);
 }
 
 .masked-key {
-  font-family: monospace;
-  color: var(--text-secondary);
-  flex: 1;
+	font-family: monospace;
+	color: var(--text-secondary);
+	flex: 1;
 }
 
 button {
-  padding: 4px 12px;
-  font-size: 12px;
-  border-radius: 4px;
-  cursor: pointer;
-  background: var(--primary-color);
-  color: white;
-  border: none;
+	padding: 4px 12px;
+	font-size: 12px;
+	border-radius: 4px;
+	cursor: pointer;
+	background: var(--primary-color);
+	color: white;
+	border: none;
 }
 
 button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+	opacity: 0.5;
+	cursor: not-allowed;
 }
 
 button.secondary {
-  background: transparent;
-  border: 1px solid var(--border-color);
-  color: var(--text-primary);
+	background: transparent;
+	border: 1px solid var(--border-color);
+	color: var(--text-primary);
 }
 
 .actions-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-top: 8px;
-  border-top: 1px solid var(--border-color);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding-top: 8px;
+	border-top: 1px solid var(--border-color);
 }
 
 .models-info {
-  color: var(--text-secondary);
+	color: var(--text-secondary);
 }
 
 .test-button.success {
-  background: var(--success-bg);
-  color: var(--success-text);
+	background: var(--success-bg);
+	color: var(--success-text);
 }
 
 .test-button.failed {
-  background: var(--error-bg);
-  color: var(--error-text);
+	background: var(--error-bg);
+	color: var(--error-text);
 }

--- a/client/src/components/settings/LLMProviderConfig.tsx
+++ b/client/src/components/settings/LLMProviderConfig.tsx
@@ -1,83 +1,94 @@
-import React, { useState } from 'react';
-import { useSettingsStore } from '../../core/state/slices/settingsStore';
-import './LLMProviderConfig.css';
+import type React from "react";
+import { useState } from "react";
+import { useSettingsStore } from "../../core/state/slices/settingsStore";
+import "./LLMProviderConfig.css";
 
 interface Props {
-  providerName: string;
-  displayName: string;
-  models: string[];
-  isConfigured: boolean;
-  apiKeyMasked?: string;
+	providerName: string;
+	displayName: string;
+	models: string[];
+	isConfigured: boolean;
+	apiKeyMasked?: string;
 }
 
 export const LLMProviderConfig: React.FC<Props> = ({
-  providerName,
-  displayName,
-  models,
-  isConfigured,
-  apiKeyMasked,
+	providerName,
+	displayName,
+	models,
+	isConfigured,
+	apiKeyMasked,
 }) => {
-  const { setApiKey, testConnection } = useSettingsStore();
-  const [apiKey, setLocalApiKey] = useState('');
-  const [isEditing, setIsEditing] = useState(!isConfigured);
-  const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'failed'>('idle');
+	const { setApiKey, testConnection } = useSettingsStore();
+	const [apiKey, setLocalApiKey] = useState("");
+	const [isEditing, setIsEditing] = useState(!isConfigured);
+	const [testStatus, setTestStatus] = useState<"idle" | "testing" | "success" | "failed">("idle");
 
-  const handleSave = async () => {
-    if (!apiKey) return;
-    await setApiKey(providerName, apiKey);
-    setIsEditing(false);
-    setLocalApiKey('');
-  };
+	const handleSave = async () => {
+		if (!apiKey) return;
+		await setApiKey(providerName, apiKey);
+		setIsEditing(false);
+		setLocalApiKey("");
+	};
 
-  const handleTest = async () => {
-    setTestStatus('testing');
-    const success = await testConnection(providerName);
-    setTestStatus(success ? 'success' : 'failed');
-    setTimeout(() => setTestStatus('idle'), 3000);
-  };
+	const handleTest = async () => {
+		setTestStatus("testing");
+		const success = await testConnection(providerName);
+		setTestStatus(success ? "success" : "failed");
+		setTimeout(() => setTestStatus("idle"), 3000);
+	};
 
-  return (
-    <div className="llm-provider-config">
-      <div className="provider-header">
-        <span className="provider-name">{displayName}</span>
-        {isConfigured && <span className="status-badge success">Configured</span>}
-      </div>
-      
-      <div className="config-row">
-        <label>API Key:</label>
-        {isEditing ? (
-          <div className="input-group">
-            <input
-              type="password"
-              value={apiKey}
-              onChange={(e) => setLocalApiKey(e.target.value)}
-              placeholder="sk-..."
-            />
-            <button onClick={handleSave} disabled={!apiKey}>Save</button>
-            <button onClick={() => setIsEditing(false)} className="secondary">Cancel</button>
-          </div>
-        ) : (
-          <div className="display-group">
-            <span className="masked-key">{apiKeyMasked || 'Not configured'}</span>
-            <button onClick={() => setIsEditing(true)} className="secondary">Update</button>
-          </div>
-        )}
-      </div>
+	return (
+		<div className="llm-provider-config">
+			<div className="provider-header">
+				<span className="provider-name">{displayName}</span>
+				{isConfigured && <span className="status-badge success">Configured</span>}
+			</div>
 
-      <div className="actions-row">
-        <div className="models-info">
-          <small>Models: {models.join(', ')}</small>
-        </div>
-        <button 
-          className={`test-button ${testStatus}`} 
-          onClick={handleTest}
-          disabled={!isConfigured || isEditing || testStatus === 'testing'}
-        >
-          {testStatus === 'testing' ? 'Testing...' : 
-           testStatus === 'success' ? '✓ Working' : 
-           testStatus === 'failed' ? '✗ Failed' : 'Test Connection'}
-        </button>
-      </div>
-    </div>
-  );
+			<div className="config-row">
+				<label>API Key:</label>
+				{isEditing ? (
+					<div className="input-group">
+						<input
+							type="password"
+							value={apiKey}
+							onChange={(e) => setLocalApiKey(e.target.value)}
+							placeholder="sk-..."
+						/>
+						<button onClick={handleSave} disabled={!apiKey}>
+							Save
+						</button>
+						<button onClick={() => setIsEditing(false)} className="secondary">
+							Cancel
+						</button>
+					</div>
+				) : (
+					<div className="display-group">
+						<span className="masked-key">{apiKeyMasked || "Not configured"}</span>
+						<button onClick={() => setIsEditing(true)} className="secondary">
+							Update
+						</button>
+					</div>
+				)}
+			</div>
+
+			<div className="actions-row">
+				<div className="models-info">
+					<small>Models: {models.join(", ")}</small>
+				</div>
+				<button
+					className={`test-button ${testStatus}`}
+					onClick={handleTest}
+					disabled={!isConfigured || isEditing || testStatus === "testing"}
+				>
+					{testStatus === "testing"
+						? "Testing..."
+						: testStatus === "success"
+							? "✓ Working"
+							: testStatus === "failed"
+								? "✗ Failed"
+								: "Test Connection"}
+				</button>
+			</div>
+		</div>
+	);
 };

--- a/client/src/components/settings/SettingsPanel.css
+++ b/client/src/components/settings/SettingsPanel.css
@@ -1,35 +1,35 @@
 .settings-panel {
-  padding: 20px;
-  height: 100%;
-  overflow-y: auto;
-  color: var(--text-primary);
+	padding: 20px;
+	height: 100%;
+	overflow-y: auto;
+	color: var(--text-primary);
 }
 
 .settings-section {
-  margin-bottom: 24px;
+	margin-bottom: 24px;
 }
 
 .settings-section h3 {
-  font-size: 14px;
-  font-weight: 600;
-  margin-bottom: 12px;
-  color: var(--text-primary);
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 12px;
+	color: var(--text-primary);
 }
 
 .provider-select {
-  width: 100%;
-  padding: 8px;
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  font-size: 14px;
+	width: 100%;
+	padding: 8px;
+	border: 1px solid var(--border-color);
+	border-radius: 4px;
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	font-size: 14px;
 }
 
 .settings-loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 200px;
-  color: var(--text-secondary);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 200px;
+	color: var(--text-secondary);
 }

--- a/client/src/components/settings/SettingsPanel.tsx
+++ b/client/src/components/settings/SettingsPanel.tsx
@@ -1,49 +1,51 @@
-import React, { useEffect } from 'react';
-import { useSettingsStore } from '../../core/state/slices/settingsStore';
-import { LLMProviderConfig } from './LLMProviderConfig';
-import './SettingsPanel.css';
+import type React from "react";
+import { useEffect } from "react";
+import { useSettingsStore } from "../../core/state/slices/settingsStore";
+import { LLMProviderConfig } from "./LLMProviderConfig";
+import "./SettingsPanel.css";
 
 export const SettingsPanel: React.FC = () => {
-  const { providers, activeProvider, setActiveProvider, fetchSettings, isLoading } = useSettingsStore();
+	const { providers, activeProvider, setActiveProvider, fetchSettings, isLoading } =
+		useSettingsStore();
 
-  useEffect(() => {
-    fetchSettings();
-  }, []);
+	useEffect(() => {
+		fetchSettings();
+	}, []);
 
-  if (isLoading && providers.length === 0) {
-    return <div className="settings-loading">Loading settings...</div>;
-  }
+	if (isLoading && providers.length === 0) {
+		return <div className="settings-loading">Loading settings...</div>;
+	}
 
-  return (
-    <div className="settings-panel">
-      <div className="settings-section">
-        <h3>Active Provider</h3>
-        <select 
-          value={activeProvider} 
-          onChange={(e) => setActiveProvider(e.target.value)}
-          className="provider-select"
-        >
-          {providers.map(p => (
-            <option key={p.name} value={p.name}>
-              {p.displayName} {p.isConfigured ? '(Configured)' : '(Not Configured)'}
-            </option>
-          ))}
-        </select>
-      </div>
+	return (
+		<div className="settings-panel">
+			<div className="settings-section">
+				<h3>Active Provider</h3>
+				<select
+					value={activeProvider}
+					onChange={(e) => setActiveProvider(e.target.value)}
+					className="provider-select"
+				>
+					{providers.map((p) => (
+						<option key={p.name} value={p.name}>
+							{p.displayName} {p.isConfigured ? "(Configured)" : "(Not Configured)"}
+						</option>
+					))}
+				</select>
+			</div>
 
-      <div className="settings-section">
-        <h3>Provider Configuration</h3>
-        {providers.map(provider => (
-          <LLMProviderConfig
-            key={provider.name}
-            providerName={provider.name}
-            displayName={provider.displayName}
-            models={provider.models}
-            isConfigured={provider.isConfigured}
-            apiKeyMasked={provider.apiKeyMasked}
-          />
-        ))}
-      </div>
-    </div>
-  );
+			<div className="settings-section">
+				<h3>Provider Configuration</h3>
+				{providers.map((provider) => (
+					<LLMProviderConfig
+						key={provider.name}
+						providerName={provider.name}
+						displayName={provider.displayName}
+						models={provider.models}
+						isConfigured={provider.isConfigured}
+						apiKeyMasked={provider.apiKeyMasked}
+					/>
+				))}
+			</div>
+		</div>
+	);
 };

--- a/client/src/components/shared/Checkbox.tsx
+++ b/client/src/components/shared/Checkbox.tsx
@@ -1,45 +1,43 @@
-import React from "react";
+import type React from "react";
 
 export interface CheckboxProps {
-  label: string;
+	label: string;
 
-  checked: boolean;
+	checked: boolean;
 
-  onChange: (checked: boolean) => void;
+	onChange: (checked: boolean) => void;
 
-  id?: string;
+	id?: string;
 
-  disabled?: boolean;
+	disabled?: boolean;
 
-  className?: string;
+	className?: string;
 }
 
 export const Checkbox: React.FC<CheckboxProps> = ({
-  label,
-  checked,
-  onChange,
-  id,
-  disabled = false,
-  className = "",
+	label,
+	checked,
+	onChange,
+	id,
+	disabled = false,
+	className = "",
 }) => {
-  const inputId = id || `checkbox-${label.replace(/\s+/g, "-").toLowerCase()}`;
+	const inputId = id || `checkbox-${label.replace(/\s+/g, "-").toLowerCase()}`;
 
-  return (
-    <label
-      htmlFor={inputId}
-      className={`checkbox ${
-        disabled ? "checkbox--disabled" : ""
-      } ${className}`}
-    >
-      <input
-        id={inputId}
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        disabled={disabled}
-        aria-label={label}
-      />
-      <span className="checkbox-label">{label}</span>
-    </label>
-  );
+	return (
+		<label
+			htmlFor={inputId}
+			className={`checkbox ${disabled ? "checkbox--disabled" : ""} ${className}`}
+		>
+			<input
+				id={inputId}
+				type="checkbox"
+				checked={checked}
+				onChange={(e) => onChange(e.target.checked)}
+				disabled={disabled}
+				aria-label={label}
+			/>
+			<span className="checkbox-label">{label}</span>
+		</label>
+	);
 };

--- a/client/src/components/shared/PanelTabs.tsx
+++ b/client/src/components/shared/PanelTabs.tsx
@@ -1,43 +1,43 @@
-import type { ReactNode } from 'react';
+import type { ReactNode } from "react";
 
 export interface PanelTabItem<T extends string> {
-  id: T;
-  label: ReactNode;
-  disabled?: boolean;
+	id: T;
+	label: ReactNode;
+	disabled?: boolean;
 }
 
 interface PanelTabsProps<T extends string> {
-  items: PanelTabItem<T>[];
-  activeId: T;
-  onSelect: (id: T) => void;
-  className?: string;
+	items: PanelTabItem<T>[];
+	activeId: T;
+	onSelect: (id: T) => void;
+	className?: string;
 }
 
 export function PanelTabs<T extends string>({
-  items,
-  activeId,
-  onSelect,
-  className,
+	items,
+	activeId,
+	onSelect,
+	className,
 }: PanelTabsProps<T>): JSX.Element {
-  const containerClass = ['tabs', className].filter(Boolean).join(' ');
+	const containerClass = ["tabs", className].filter(Boolean).join(" ");
 
-  return (
-    <div className={containerClass}>
-      {items.map((item) => {
-        const isActive = item.id === activeId;
+	return (
+		<div className={containerClass}>
+			{items.map((item) => {
+				const isActive = item.id === activeId;
 
-        return (
-          <button
-            key={item.id}
-            type="button"
-            className={`tab${isActive ? ' active' : ''}`}
-            onClick={() => onSelect(item.id)}
-            disabled={item.disabled}
-          >
-            {item.label}
-          </button>
-        );
-      })}
-    </div>
-  );
+				return (
+					<button
+						key={item.id}
+						type="button"
+						className={`tab${isActive ? " active" : ""}`}
+						onClick={() => onSelect(item.id)}
+						disabled={item.disabled}
+					>
+						{item.label}
+					</button>
+				);
+			})}
+		</div>
+	);
 }

--- a/client/src/components/shared/dialog/ConfirmDialog.tsx
+++ b/client/src/components/shared/dialog/ConfirmDialog.tsx
@@ -1,78 +1,70 @@
 interface ConfirmDialogProps {
-  open: boolean;
-  title: string;
-  message: string;
-  confirmLabel?: string;
-  cancelLabel?: string;
-  onConfirm: () => void;
-  onCancel: () => void;
+	open: boolean;
+	title: string;
+	message: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	onConfirm: () => void;
+	onCancel: () => void;
 }
 
 export function ConfirmDialog({
-  open,
-  title,
-  message,
-  confirmLabel = "Confirm",
-  cancelLabel = "Cancel",
-  onConfirm,
-  onCancel,
+	open,
+	title,
+	message,
+	confirmLabel = "Confirm",
+	cancelLabel = "Cancel",
+	onConfirm,
+	onCancel,
 }: ConfirmDialogProps): JSX.Element | null {
-  if (!open) return null;
+	if (!open) return null;
 
-  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>): void => {
-    if (e.target === e.currentTarget) {
-      onCancel();
-    }
-  };
+	const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>): void => {
+		if (e.target === e.currentTarget) {
+			onCancel();
+		}
+	};
 
-  const handleConfirm = (): void => {
-    onConfirm();
-  };
+	const handleConfirm = (): void => {
+		onConfirm();
+	};
 
-  const handleCancel = (): void => {
-    onCancel();
-  };
+	const handleCancel = (): void => {
+		onCancel();
+	};
 
-  return (
-    <div
-      className="confirm-dialog-overlay"
-      onClick={handleOverlayClick}
-      role="presentation"
-    >
-      <div
-        className="confirm-dialog"
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="confirm-dialog-title"
-        aria-describedby="confirm-dialog-message"
-      >
-        <div className="confirm-dialog-header">
-          <h2 id="confirm-dialog-title">{title}</h2>
-          <button
-            className="btn btn-icon"
-            onClick={handleCancel}
-            aria-label="Close dialog"
-          >
-            ×
-          </button>
-        </div>
+	return (
+		<div className="confirm-dialog-overlay" onClick={handleOverlayClick} role="presentation">
+			<div
+				className="confirm-dialog"
+				onClick={(e) => e.stopPropagation()}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="confirm-dialog-title"
+				aria-describedby="confirm-dialog-message"
+			>
+				<div className="confirm-dialog-header">
+					<h2 id="confirm-dialog-title">{title}</h2>
+					<button className="btn btn-icon" onClick={handleCancel} aria-label="Close dialog">
+						×
+					</button>
+				</div>
 
-        <div className="confirm-dialog-content">
-          <p id="confirm-dialog-message" className="confirm-dialog-message">
-            {message}
-          </p>
-        </div>
+				<div className="confirm-dialog-content">
+					<p id="confirm-dialog-message" className="confirm-dialog-message">
+						{message}
+					</p>
+				</div>
 
-        <div className="confirm-dialog-footer">
-          <button className="btn" onClick={handleCancel}>
-            {cancelLabel}
-          </button>
-          <button className="btn btn-primary" onClick={handleConfirm}>
-            {confirmLabel}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+				<div className="confirm-dialog-footer">
+					<button className="btn" onClick={handleCancel}>
+						{cancelLabel}
+					</button>
+					<button className="btn btn-primary" onClick={handleConfirm}>
+						{confirmLabel}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/shared/dialog/index.ts
+++ b/client/src/components/shared/dialog/index.ts
@@ -1,1 +1,1 @@
-export { ConfirmDialog } from './ConfirmDialog';
+export { ConfirmDialog } from "./ConfirmDialog";

--- a/client/src/components/shared/icons.tsx
+++ b/client/src/components/shared/icons.tsx
@@ -1,72 +1,72 @@
-import type { SVGProps } from 'react';
-import { iconDefinitions } from '@/assets/icons/definitions';
+import type { SVGProps } from "react";
+import { iconDefinitions } from "@/assets/icons/definitions";
 
 type IconProps = SVGProps<SVGSVGElement>;
 
 const base = {
-  fill: 'none',
-  stroke: 'currentColor',
-  strokeWidth: 1.8,
-  strokeLinecap: 'round' as const,
-  strokeLinejoin: 'round' as const
+	fill: "none",
+	stroke: "currentColor",
+	strokeWidth: 1.8,
+	strokeLinecap: "round" as const,
+	strokeLinejoin: "round" as const,
 };
 
 type PathDef = {
-  type: string;
-  [key: string]: string | number | undefined;
+	type: string;
+	[key: string]: string | number | undefined;
 };
 
 function renderPath(path: PathDef, index: number) {
-  const { type, ...attrs } = path;
-  const props = { key: index, ...attrs };
+	const { type, ...attrs } = path;
+	const props = { key: index, ...attrs };
 
-  switch (type) {
-    case 'path':
-      return <path {...props} />;
-    case 'circle':
-      return <circle {...props} />;
-    case 'rect':
-      return <rect {...props} />;
-    case 'line':
-      return <line {...props} />;
-    case 'polyline':
-      return <polyline {...props} />;
-    case 'polygon':
-      return <polygon {...props} />;
-    default:
-      return null;
-  }
+	switch (type) {
+		case "path":
+			return <path {...props} />;
+		case "circle":
+			return <circle {...props} />;
+		case "rect":
+			return <rect {...props} />;
+		case "line":
+			return <line {...props} />;
+		case "polyline":
+			return <polyline {...props} />;
+		case "polygon":
+			return <polygon {...props} />;
+		default:
+			return null;
+	}
 }
 
 function createIcon(name: keyof typeof iconDefinitions) {
-  return function Icon(props: IconProps): JSX.Element {
-    const def = iconDefinitions[name];
-    return (
-      <svg viewBox={def.viewBox} {...base} {...props}>
-        {def.paths.map((path, index) => renderPath(path as PathDef, index))}
-      </svg>
-    );
-  };
+	return function Icon(props: IconProps): JSX.Element {
+		const def = iconDefinitions[name];
+		return (
+			<svg viewBox={def.viewBox} {...base} {...props}>
+				{def.paths.map((path, index) => renderPath(path as PathDef, index))}
+			</svg>
+		);
+	};
 }
 
-export const IconPlay = createIcon('play');
-export const IconPlayCircle = createIcon('playCircle');
-export const IconPlus = createIcon('plus');
-export const IconRobot = createIcon('robot');
-export const IconSend = createIcon('send');
-export const IconSquare = createIcon('square');
-export const IconClipboard = createIcon('clipboard');
-export const IconCheck = createIcon('check');
-export const IconTrash = createIcon('trash');
-export const IconBarChart = createIcon('barChart');
-export const IconCheckCircle = createIcon('checkCircle');
-export const IconXCircle = createIcon('xCircle');
-export const IconChevronLeft = createIcon('chevronLeft');
-export const IconChevronRight = createIcon('chevronRight');
-export const IconChevronDown = createIcon('chevronDown');
-export const IconLightbulb = createIcon('lightbulb');
-export const IconInfo = createIcon('info');
-export const IconSettings = createIcon('settings');
-export const IconKeyboard = createIcon('keyboard');
-export const IconRefresh = createIcon('refresh');
-export const IconFolder = createIcon('folder');
+export const IconPlay = createIcon("play");
+export const IconPlayCircle = createIcon("playCircle");
+export const IconPlus = createIcon("plus");
+export const IconRobot = createIcon("robot");
+export const IconSend = createIcon("send");
+export const IconSquare = createIcon("square");
+export const IconClipboard = createIcon("clipboard");
+export const IconCheck = createIcon("check");
+export const IconTrash = createIcon("trash");
+export const IconBarChart = createIcon("barChart");
+export const IconCheckCircle = createIcon("checkCircle");
+export const IconXCircle = createIcon("xCircle");
+export const IconChevronLeft = createIcon("chevronLeft");
+export const IconChevronRight = createIcon("chevronRight");
+export const IconChevronDown = createIcon("chevronDown");
+export const IconLightbulb = createIcon("lightbulb");
+export const IconInfo = createIcon("info");
+export const IconSettings = createIcon("settings");
+export const IconKeyboard = createIcon("keyboard");
+export const IconRefresh = createIcon("refresh");
+export const IconFolder = createIcon("folder");

--- a/client/src/components/shared/index.ts
+++ b/client/src/components/shared/index.ts
@@ -1,3 +1,3 @@
-export * from './icons';
-export { PanelTabs, type PanelTabItem } from './PanelTabs';
-export { ConfirmDialog } from './dialog';
+export { ConfirmDialog } from "./dialog";
+export * from "./icons";
+export { type PanelTabItem, PanelTabs } from "./PanelTabs";

--- a/client/src/components/timeline/Timeline.tsx
+++ b/client/src/components/timeline/Timeline.tsx
@@ -1,51 +1,49 @@
-import { TimelineEvent } from './TimelineEvent';
-import type { TimelineListProps } from '@/types/timeline';
+import type { TimelineListProps } from "@/types/timeline";
+import { TimelineEvent } from "./TimelineEvent";
 
 export function Timeline({
-  events,
-  total,
-  hasMore,
-  loading,
-  onLoadMore,
-  onNavigate,
+	events,
+	total,
+	hasMore,
+	loading,
+	onLoadMore,
+	onNavigate,
 }: TimelineListProps): JSX.Element {
-  if (events.length === 0 && !loading) {
-    return (
-      <div className="timeline-empty">
-        <div className="timeline-empty-message">No execution events yet</div>
-        <div className="timeline-empty-hint">
-          Execute some R code to see the timeline
-        </div>
-      </div>
-    );
-  }
+	if (events.length === 0 && !loading) {
+		return (
+			<div className="timeline-empty">
+				<div className="timeline-empty-message">No execution events yet</div>
+				<div className="timeline-empty-hint">Execute some R code to see the timeline</div>
+			</div>
+		);
+	}
 
-  return (
-    <div className="timeline">
-      <div className="timeline-list">
-        {events.map((event) => (
-          <TimelineEvent key={event.event_id} event={event} onNavigate={onNavigate} />
-        ))}
-      </div>
+	return (
+		<div className="timeline">
+			<div className="timeline-list">
+				{events.map((event) => (
+					<TimelineEvent key={event.event_id} event={event} onNavigate={onNavigate} />
+				))}
+			</div>
 
-      {loading && (
-        <div className="timeline-loading">
-          <div className="timeline-spinner" />
-          <span>Loading events...</span>
-        </div>
-      )}
+			{loading && (
+				<div className="timeline-loading">
+					<div className="timeline-spinner" />
+					<span>Loading events...</span>
+				</div>
+			)}
 
-      {hasMore && !loading && (
-        <button className="timeline-load-more" onClick={onLoadMore}>
-          Load More ({total - events.length} remaining)
-        </button>
-      )}
+			{hasMore && !loading && (
+				<button className="timeline-load-more" onClick={onLoadMore}>
+					Load More ({total - events.length} remaining)
+				</button>
+			)}
 
-      {!hasMore && events.length > 0 && (
-        <div className="timeline-end">
-          Showing all {total} event{total !== 1 ? 's' : ''}
-        </div>
-      )}
-    </div>
-  );
+			{!hasMore && events.length > 0 && (
+				<div className="timeline-end">
+					Showing all {total} event{total !== 1 ? "s" : ""}
+				</div>
+			)}
+		</div>
+	);
 }

--- a/client/src/components/timeline/TimelineDialog.tsx
+++ b/client/src/components/timeline/TimelineDialog.tsx
@@ -1,128 +1,120 @@
-import { useCallback, useEffect } from 'react';
-import type { ExecutionEventPayload } from 'shared';
+import { useCallback, useEffect } from "react";
+import type { ExecutionEventPayload } from "shared";
 
-import { useStore } from '@/core';
-import { useTimelineData } from '@/hooks/useTimelineData';
-import { Timeline } from './Timeline';
-import { TimelineStats } from './TimelineStats';
-import { TimelineFilters } from './TimelineFilters';
-import { TimelineSort } from './TimelineSort';
+import { useStore } from "@/core";
+import { useTimelineData } from "@/hooks/useTimelineData";
+import { Timeline } from "./Timeline";
+import { TimelineFilters } from "./TimelineFilters";
+import { TimelineSort } from "./TimelineSort";
+import { TimelineStats } from "./TimelineStats";
 
 interface TimelineDialogProps {
-  open: boolean;
-  onClose: () => void;
+	open: boolean;
+	onClose: () => void;
 }
 
 export function TimelineDialog({ open, onClose }: TimelineDialogProps): JSX.Element | null {
-  const {
-    events,
-    total,
-    hasMore,
-    loading,
-    error,
-    filters,
-    sort,
-    setFilters,
-    setSort,
-    loadMore,
-    stats,
-    statsLoading,
-  } = useTimelineData();
+	const {
+		events,
+		total,
+		hasMore,
+		loading,
+		error,
+		filters,
+		sort,
+		setFilters,
+		setSort,
+		loadMore,
+		stats,
+		statsLoading,
+	} = useTimelineData();
 
-  const editorRef = useStore((state) => state.editorRef);
+	const editorRef = useStore((state) => state.editorRef);
 
-  const handleNavigate = useCallback(
-    (event: ExecutionEventPayload) => {
-      const targetEditor = editorRef?.current;
-      if (!targetEditor) {
-        return;
-      }
+	const handleNavigate = useCallback(
+		(event: ExecutionEventPayload) => {
+			const targetEditor = editorRef?.current;
+			if (!targetEditor) {
+				return;
+			}
 
-      const line = event.blocks?.[0]?.start_line;
-      if (line === undefined) {
-        return;
-      }
+			const line = event.blocks?.[0]?.start_line;
+			if (line === undefined) {
+				return;
+			}
 
-      targetEditor.navigateToLine(line);
-      // Close dialog after navigation
-      onClose();
-    },
-    [editorRef, onClose],
-  );
+			targetEditor.navigateToLine(line);
+			// Close dialog after navigation
+			onClose();
+		},
+		[editorRef, onClose],
+	);
 
-  // Handle ESC key to close dialog
-  useEffect(() => {
-    if (!open) return;
+	// Handle ESC key to close dialog
+	useEffect(() => {
+		if (!open) return;
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    };
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				onClose();
+			}
+		};
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [open, onClose]);
+		document.addEventListener("keydown", handleKeyDown);
+		return () => {
+			document.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [open, onClose]);
 
-  if (!open) return null;
+	if (!open) return null;
 
-  return (
-    <div
-      className="timeline-dialog-overlay"
-      onClick={onClose}
-      tabIndex={-1}
-    >
-      <div
-        className="timeline-dialog"
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="timeline-dialog-title"
-      >
-        <div className="timeline-dialog-header">
-          <h2 id="timeline-dialog-title">Timeline</h2>
-          <button
-            className="btn btn-icon"
-            onClick={onClose}
-            aria-label="Close dialog"
-          >
-            ×
-          </button>
-        </div>
+	return (
+		<div className="timeline-dialog-overlay" onClick={onClose} tabIndex={-1}>
+			<div
+				className="timeline-dialog"
+				onClick={(e) => e.stopPropagation()}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="timeline-dialog-title"
+			>
+				<div className="timeline-dialog-header">
+					<h2 id="timeline-dialog-title">Timeline</h2>
+					<button className="btn btn-icon" onClick={onClose} aria-label="Close dialog">
+						×
+					</button>
+				</div>
 
-        <div className="timeline-dialog-content">
-          {/* Filter section - 20-25% height */}
-          <div className="timeline-dialog-filters">
-            <TimelineStats stats={stats} loading={statsLoading} />
+				<div className="timeline-dialog-content">
+					{/* Filter section - 20-25% height */}
+					<div className="timeline-dialog-filters">
+						<TimelineStats stats={stats} loading={statsLoading} />
 
-            <div className="timeline-panel-controls">
-              <TimelineFilters filters={filters} onChange={setFilters} />
-              <TimelineSort sort={sort} onChange={setSort} />
-            </div>
+						<div className="timeline-panel-controls">
+							<TimelineFilters filters={filters} onChange={setFilters} />
+							<TimelineSort sort={sort} onChange={setSort} />
+						</div>
 
-            {error && (
-              <div className="timeline-error">
-                <span className="timeline-error-icon">⚠️</span>
-                <span className="timeline-error-message">{error}</span>
-              </div>
-            )}
-          </div>
+						{error && (
+							<div className="timeline-error">
+								<span className="timeline-error-icon">⚠️</span>
+								<span className="timeline-error-message">{error}</span>
+							</div>
+						)}
+					</div>
 
-          {/* History list - 75-80% height */}
-          <div className="timeline-dialog-history">
-            <Timeline
-              events={events}
-              total={total}
-              hasMore={hasMore}
-              loading={loading}
-              onLoadMore={loadMore}
-              onNavigate={handleNavigate}
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+					{/* History list - 75-80% height */}
+					<div className="timeline-dialog-history">
+						<Timeline
+							events={events}
+							total={total}
+							hasMore={hasMore}
+							loading={loading}
+							onLoadMore={loadMore}
+							onNavigate={handleNavigate}
+						/>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/timeline/TimelineEvent.tsx
+++ b/client/src/components/timeline/TimelineEvent.tsx
@@ -1,79 +1,79 @@
-import type { TimelineEventProps } from '@/types/timeline';
+import type { TimelineEventProps } from "@/types/timeline";
 
 export function TimelineEvent({ event, onNavigate }: TimelineEventProps): JSX.Element {
-  const { context, blocks, result } = event;
+	const { context, blocks, result } = event;
 
-  // Format timestamp
-  const timestamp = new Date(event.created_at_ms);
-  const timeStr = timestamp.toLocaleTimeString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
+	// Format timestamp
+	const timestamp = new Date(event.created_at_ms);
+	const timeStr = timestamp.toLocaleTimeString("en-US", {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+	});
 
-  // Get actor label
-  const actorLabel = context.actor === 'user' ? 'User' : 'AI';
+	// Get actor label
+	const actorLabel = context.actor === "user" ? "User" : "AI";
 
-  // Get source label
-  const sourceLabels: Record<string, string> = {
-    selection: 'Selection',
-    cell: `Cell #${context.cell_index ?? '?'}`,
-    whole_document: 'Document',
-    unknown: 'Unknown',
-  };
-  const sourceLabel = sourceLabels[context.source] || context.source;
+	// Get source label
+	const sourceLabels: Record<string, string> = {
+		selection: "Selection",
+		cell: `Cell #${context.cell_index ?? "?"}`,
+		whole_document: "Document",
+		unknown: "Unknown",
+	};
+	const sourceLabel = sourceLabels[context.source] || context.source;
 
-  // Get first block for preview
-  const firstBlock = blocks[0];
-  const codePreview = firstBlock?.code || '';
-  const codeLines = codePreview.split('\n');
-  const displayCode = codeLines.slice(0, 3).join('\n');
-  const hasMoreLines = codeLines.length > 3;
+	// Get first block for preview
+	const firstBlock = blocks[0];
+	const codePreview = firstBlock?.code || "";
+	const codeLines = codePreview.split("\n");
+	const displayCode = codeLines.slice(0, 3).join("\n");
+	const hasMoreLines = codeLines.length > 3;
 
-  // Get result status
-  const statusLabel = result.success ? 'Success' : 'Error';
-  const executionTime = result.execution_time_ms;
-  const plotCount = result.plots.length;
+	// Get result status
+	const statusLabel = result.success ? "Success" : "Error";
+	const executionTime = result.execution_time_ms;
+	const plotCount = result.plots.length;
 
-  const handleClick = () => {
-    if (onNavigate) {
-      onNavigate(event);
-    }
-  };
+	const handleClick = () => {
+		if (onNavigate) {
+			onNavigate(event);
+		}
+	};
 
-  return (
-    <div className="timeline-event" onClick={handleClick}>
-      <div className="timeline-event-header">
-        <span className="timeline-event-actor">{actorLabel}</span>
-        <span className="timeline-event-time">{timeStr}</span>
-        <span className="timeline-event-source">{sourceLabel}</span>
-      </div>
+	return (
+		<div className="timeline-event" onClick={handleClick}>
+			<div className="timeline-event-header">
+				<span className="timeline-event-actor">{actorLabel}</span>
+				<span className="timeline-event-time">{timeStr}</span>
+				<span className="timeline-event-source">{sourceLabel}</span>
+			</div>
 
-      <div className="timeline-event-divider" />
+			<div className="timeline-event-divider" />
 
-      <div className="timeline-event-code">
-        <pre>
-          <code>{displayCode}</code>
-        </pre>
-        {hasMoreLines && <span className="timeline-event-more">...</span>}
-      </div>
+			<div className="timeline-event-code">
+				<pre>
+					<code>{displayCode}</code>
+				</pre>
+				{hasMoreLines && <span className="timeline-event-more">...</span>}
+			</div>
 
-      <div className="timeline-event-footer">
-        <span className="timeline-event-status">{statusLabel}</span>
-        <span className="timeline-event-duration">{executionTime}ms</span>
-        {plotCount > 0 && (
-          <span className="timeline-event-plots">
-            {plotCount} plot{plotCount > 1 ? 's' : ''}
-          </span>
-        )}
-      </div>
+			<div className="timeline-event-footer">
+				<span className="timeline-event-status">{statusLabel}</span>
+				<span className="timeline-event-duration">{executionTime}ms</span>
+				{plotCount > 0 && (
+					<span className="timeline-event-plots">
+						{plotCount} plot{plotCount > 1 ? "s" : ""}
+					</span>
+				)}
+			</div>
 
-      {result.error && (
-        <div className="timeline-event-error">
-          <span className="timeline-event-error-label">Error:</span>
-          <span className="timeline-event-error-message">{result.error}</span>
-        </div>
-      )}
-    </div>
-  );
+			{result.error && (
+				<div className="timeline-event-error">
+					<span className="timeline-event-error-label">Error:</span>
+					<span className="timeline-event-error-message">{result.error}</span>
+				</div>
+			)}
+		</div>
+	);
 }

--- a/client/src/components/timeline/TimelineFilters.tsx
+++ b/client/src/components/timeline/TimelineFilters.tsx
@@ -1,113 +1,92 @@
 import type { TimelineFiltersProps } from "@/types/timeline";
 import { Checkbox } from "../shared/Checkbox";
 
-export function TimelineFilters({
-  filters = {},
-  onChange,
-}: TimelineFiltersProps): JSX.Element {
-  const handleActorChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
-    onChange({
-      ...filters,
-      actor: value === "all" ? undefined : (value as "user" | "ai"),
-    });
-  };
+export function TimelineFilters({ filters = {}, onChange }: TimelineFiltersProps): JSX.Element {
+	const handleActorChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+		const value = e.target.value;
+		onChange({
+			...filters,
+			actor: value === "all" ? undefined : (value as "user" | "ai"),
+		});
+	};
 
-  const handleSourceChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
-    onChange({
-      ...filters,
-      source:
-        value === "all"
-          ? undefined
-          : (value as "selection" | "cell" | "whole_document"),
-    });
-  };
+	const handleSourceChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+		const value = e.target.value;
+		onChange({
+			...filters,
+			source: value === "all" ? undefined : (value as "selection" | "cell" | "whole_document"),
+		});
+	};
 
-  const handleCodeSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    onChange({
-      ...filters,
-      codeContains: value ? value : undefined,
-    });
-  };
+	const handleCodeSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const value = e.target.value;
+		onChange({
+			...filters,
+			codeContains: value ? value : undefined,
+		});
+	};
 
-  const handleClearFilters = () => {
-    onChange({});
-  };
+	const handleClearFilters = () => {
+		onChange({});
+	};
 
-  const hasActiveFilters = Object.keys(filters).length > 0;
+	const hasActiveFilters = Object.keys(filters).length > 0;
 
-  return (
-    <div className="timeline-filters">
-      <div className="timeline-filters-row">
-        <div className="timeline-filter">
-          <label htmlFor="filter-actor">Actor:</label>
-          <select
-            id="filter-actor"
-            value={filters.actor || "all"}
-            onChange={handleActorChange}
-          >
-            <option value="all">All</option>
-            <option value="user">User</option>
-            <option value="ai">AI</option>
-          </select>
-        </div>
+	return (
+		<div className="timeline-filters">
+			<div className="timeline-filters-row">
+				<div className="timeline-filter">
+					<label htmlFor="filter-actor">Actor:</label>
+					<select id="filter-actor" value={filters.actor || "all"} onChange={handleActorChange}>
+						<option value="all">All</option>
+						<option value="user">User</option>
+						<option value="ai">AI</option>
+					</select>
+				</div>
 
-        <div className="timeline-filter">
-          <label htmlFor="filter-source">Source:</label>
-          <select
-            id="filter-source"
-            value={filters.source || "all"}
-            onChange={handleSourceChange}
-          >
-            <option value="all">All</option>
-            <option value="selection">Selection</option>
-            <option value="cell">Cell</option>
-            <option value="whole_document">Document</option>
-          </select>
-        </div>
+				<div className="timeline-filter">
+					<label htmlFor="filter-source">Source:</label>
+					<select id="filter-source" value={filters.source || "all"} onChange={handleSourceChange}>
+						<option value="all">All</option>
+						<option value="selection">Selection</option>
+						<option value="cell">Cell</option>
+						<option value="whole_document">Document</option>
+					</select>
+				</div>
 
-        <Checkbox
-          className="timeline-filter timeline-filter-checkbox"
-          label="With Plots"
-          checked={filters.hasPlots || false}
-          onChange={(checked) =>
-            onChange({ ...filters, hasPlots: checked ? true : undefined })
-          }
-        />
+				<Checkbox
+					className="timeline-filter timeline-filter-checkbox"
+					label="With Plots"
+					checked={filters.hasPlots || false}
+					onChange={(checked) => onChange({ ...filters, hasPlots: checked ? true : undefined })}
+				/>
 
-        <Checkbox
-          className="timeline-filter timeline-filter-checkbox"
-          label="With Errors"
-          checked={filters.hasErrors || false}
-          onChange={(checked) =>
-            onChange({ ...filters, hasErrors: checked ? true : undefined })
-          }
-        />
-      </div>
+				<Checkbox
+					className="timeline-filter timeline-filter-checkbox"
+					label="With Errors"
+					checked={filters.hasErrors || false}
+					onChange={(checked) => onChange({ ...filters, hasErrors: checked ? true : undefined })}
+				/>
+			</div>
 
-      <div className="timeline-filters-row">
-        <div className="timeline-filter timeline-filter-search">
-          <label htmlFor="filter-code">Code contains:</label>
-          <input
-            type="text"
-            id="filter-code"
-            placeholder="Search code..."
-            value={filters.codeContains || ""}
-            onChange={handleCodeSearchChange}
-          />
-        </div>
+			<div className="timeline-filters-row">
+				<div className="timeline-filter timeline-filter-search">
+					<label htmlFor="filter-code">Code contains:</label>
+					<input
+						type="text"
+						id="filter-code"
+						placeholder="Search code..."
+						value={filters.codeContains || ""}
+						onChange={handleCodeSearchChange}
+					/>
+				</div>
 
-        {hasActiveFilters && (
-          <button
-            className="timeline-filter-clear"
-            onClick={handleClearFilters}
-          >
-            Clear Filters
-          </button>
-        )}
-      </div>
-    </div>
-  );
+				{hasActiveFilters && (
+					<button className="timeline-filter-clear" onClick={handleClearFilters}>
+						Clear Filters
+					</button>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/timeline/TimelineSort.tsx
+++ b/client/src/components/timeline/TimelineSort.tsx
@@ -1,17 +1,17 @@
-import type { TimelineSortProps } from '@/types/timeline';
+import type { TimelineSortProps } from "@/types/timeline";
 
 export function TimelineSort({ sort, onChange }: TimelineSortProps): JSX.Element {
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    onChange(e.target.value as 'asc' | 'desc');
-  };
+	const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+		onChange(e.target.value as "asc" | "desc");
+	};
 
-  return (
-    <div className="timeline-sort">
-      <label htmlFor="timeline-sort-select">Sort by time:</label>
-      <select id="timeline-sort-select" value={sort} onChange={handleChange}>
-        <option value="desc">Newest First</option>
-        <option value="asc">Oldest First</option>
-      </select>
-    </div>
-  );
+	return (
+		<div className="timeline-sort">
+			<label htmlFor="timeline-sort-select">Sort by time:</label>
+			<select id="timeline-sort-select" value={sort} onChange={handleChange}>
+				<option value="desc">Newest First</option>
+				<option value="asc">Oldest First</option>
+			</select>
+		</div>
+	);
 }

--- a/client/src/components/timeline/TimelineStats.tsx
+++ b/client/src/components/timeline/TimelineStats.tsx
@@ -1,64 +1,64 @@
-import type { TimelineStatsProps } from '@/types/timeline';
+import type { TimelineStatsProps } from "@/types/timeline";
 
 export function TimelineStats({ stats, loading }: TimelineStatsProps): JSX.Element {
-  if (loading || !stats) {
-    return (
-      <div className="timeline-stats">
-        <div className="timeline-stats-loading">Loading stats...</div>
-      </div>
-    );
-  }
+	if (loading || !stats) {
+		return (
+			<div className="timeline-stats">
+				<div className="timeline-stats-loading">Loading stats...</div>
+			</div>
+		);
+	}
 
-  // Format session duration
-  const formatDuration = (ms: number): string => {
-    const seconds = Math.floor(ms / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
+	// Format session duration
+	const formatDuration = (ms: number): string => {
+		const seconds = Math.floor(ms / 1000);
+		const minutes = Math.floor(seconds / 60);
+		const hours = Math.floor(minutes / 60);
 
-    if (hours > 0) {
-      return `${hours}h ${minutes % 60}m`;
-    } else if (minutes > 0) {
-      return `${minutes}m ${seconds % 60}s`;
-    } else {
-      return `${seconds}s`;
-    }
-  };
+		if (hours > 0) {
+			return `${hours}h ${minutes % 60}m`;
+		} else if (minutes > 0) {
+			return `${minutes}m ${seconds % 60}s`;
+		} else {
+			return `${seconds}s`;
+		}
+	};
 
-  const duration = formatDuration(stats.sessionDuration);
+	const duration = formatDuration(stats.sessionDuration);
 
-  return (
-    <div className="timeline-stats">
-      <div className="timeline-stats-grid">
-        <div className="timeline-stat">
-          <div className="timeline-stat-value">{stats.totalEvents}</div>
-          <div className="timeline-stat-label">Total Events</div>
-        </div>
+	return (
+		<div className="timeline-stats">
+			<div className="timeline-stats-grid">
+				<div className="timeline-stat">
+					<div className="timeline-stat-value">{stats.totalEvents}</div>
+					<div className="timeline-stat-label">Total Events</div>
+				</div>
 
-        <div className="timeline-stat">
-          <div className="timeline-stat-value">{stats.userActions}</div>
-          <div className="timeline-stat-label">User</div>
-        </div>
+				<div className="timeline-stat">
+					<div className="timeline-stat-value">{stats.userActions}</div>
+					<div className="timeline-stat-label">User</div>
+				</div>
 
-        <div className="timeline-stat">
-          <div className="timeline-stat-value">{stats.aiActions}</div>
-          <div className="timeline-stat-label">AI</div>
-        </div>
+				<div className="timeline-stat">
+					<div className="timeline-stat-value">{stats.aiActions}</div>
+					<div className="timeline-stat-label">AI</div>
+				</div>
 
-        <div className="timeline-stat">
-          <div className="timeline-stat-value">{stats.totalPlots}</div>
-          <div className="timeline-stat-label">Plots</div>
-        </div>
+				<div className="timeline-stat">
+					<div className="timeline-stat-value">{stats.totalPlots}</div>
+					<div className="timeline-stat-label">Plots</div>
+				</div>
 
-        <div className="timeline-stat">
-          <div className="timeline-stat-value">{stats.totalErrors}</div>
-          <div className="timeline-stat-label">Errors</div>
-        </div>
+				<div className="timeline-stat">
+					<div className="timeline-stat-value">{stats.totalErrors}</div>
+					<div className="timeline-stat-label">Errors</div>
+				</div>
 
-        <div className="timeline-stat">
-          <div className="timeline-stat-value">{duration}</div>
-          <div className="timeline-stat-label">Duration</div>
-        </div>
-      </div>
-    </div>
-  );
+				<div className="timeline-stat">
+					<div className="timeline-stat-value">{duration}</div>
+					<div className="timeline-stat-label">Duration</div>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/client/src/components/timeline/index.ts
+++ b/client/src/components/timeline/index.ts
@@ -1,6 +1,6 @@
-export { TimelineDialog } from './TimelineDialog';
-export { Timeline } from './Timeline';
-export { TimelineEvent } from './TimelineEvent';
-export { TimelineFilters } from './TimelineFilters';
-export { TimelineSort } from './TimelineSort';
-export { TimelineStats } from './TimelineStats';
+export { Timeline } from "./Timeline";
+export { TimelineDialog } from "./TimelineDialog";
+export { TimelineEvent } from "./TimelineEvent";
+export { TimelineFilters } from "./TimelineFilters";
+export { TimelineSort } from "./TimelineSort";
+export { TimelineStats } from "./TimelineStats";

--- a/client/src/constants/appInfo.ts
+++ b/client/src/constants/appInfo.ts
@@ -3,35 +3,35 @@
  * Centralized definitions for app metadata, links, and tech stack
  */
 
-import { DOCS_URL, GITHUB_URL, GITHUB_ISSUE_URL } from './urls';
+import { DOCS_URL, GITHUB_ISSUE_URL, GITHUB_URL } from "./urls";
 
 export interface AppLink {
-  label: string;
-  href: string;
+	label: string;
+	href: string;
 }
 
 export interface TechStackItem {
-  title: string;
-  description: string;
+	title: string;
+	description: string;
 }
 
 export const LINKS: AppLink[] = [
-  { label: 'Documentation', href: DOCS_URL },
-  { label: 'GitHub', href: GITHUB_URL },
-  { label: 'Report Issue', href: GITHUB_ISSUE_URL },
+	{ label: "Documentation", href: DOCS_URL },
+	{ label: "GitHub", href: GITHUB_URL },
+	{ label: "Report Issue", href: GITHUB_ISSUE_URL },
 ];
 
 export const TECH_STACK: TechStackItem[] = [
-  {
-    title: 'Rust Core',
-    description: 'Tokio + Axum orchestrate the execution engine and WebSocket shell.',
-  },
-  {
-    title: 'Tauri Desktop',
-    description: 'Native desktop wrapper with secure command bridge.',
-  },
-  {
-    title: 'React + Monaco',
-    description: 'TypeScript UI with Monaco editor, Zustand state, and AI tooling.',
-  },
+	{
+		title: "Rust Core",
+		description: "Tokio + Axum orchestrate the execution engine and WebSocket shell.",
+	},
+	{
+		title: "Tauri Desktop",
+		description: "Native desktop wrapper with secure command bridge.",
+	},
+	{
+		title: "React + Monaco",
+		description: "TypeScript UI with Monaco editor, Zustand state, and AI tooling.",
+	},
 ];

--- a/client/src/constants/defaultSettings.ts
+++ b/client/src/constants/defaultSettings.ts
@@ -3,13 +3,13 @@
  * Centralized default values for app configuration
  */
 
-import type { AppSettings } from '@shared/types';
+import type { AppSettings } from "@shared/types";
 
 export const DEFAULT_SETTINGS: AppSettings = {
-  autoRun: false,
-  theme: 'phylo',
-  rPath: 'Rscript',
-  fontSize: 13,
-  showCellDecorations: true,
-  highlightExecutingCell: true,
+	autoRun: false,
+	theme: "phylo",
+	rPath: "Rscript",
+	fontSize: 13,
+	showCellDecorations: true,
+	highlightExecutingCell: true,
 };

--- a/client/src/constants/shortcuts.ts
+++ b/client/src/constants/shortcuts.ts
@@ -4,84 +4,125 @@
  */
 
 export interface ShortcutItem {
-  id: string;
-  keys: string[];
-  description: string;
-  scope?: string;
+	id: string;
+	keys: string[];
+	description: string;
+	scope?: string;
 }
 
 export interface ShortcutGroup {
-  title: string;
-  items: ShortcutItem[];
+	title: string;
+	items: ShortcutItem[];
 }
 
 export const SHORTCUT_GROUPS: ShortcutGroup[] = [
-  {
-    title: 'General',
-    items: [
-      { id: 'file-new', keys: ['⌘N', 'Ctrl+N'], description: 'New R script' },
-      { id: 'file-open', keys: ['⌘O', 'Ctrl+O'], description: 'Open existing file' },
-      { id: 'file-save', keys: ['⌘S', 'Ctrl+S'], description: 'Save current file' },
-      { id: 'file-save-as', keys: ['⌘⇧S', 'Ctrl+Shift+S'], description: 'Save as new file' },
-      { id: 'settings', keys: ['⌘,', 'Ctrl+,'], description: 'Open settings' },
-      { id: 'ai', keys: ['⌘K', 'Ctrl+K'], description: 'Focus AI Assistant' },
-    ],
-  },
-  {
-    title: 'Code Execution',
-    items: [
-      {
-        id: 'run-selection',
-        keys: ['⌘↵', 'Ctrl+Enter'],
-        description: 'Run current line or selection',
-        scope: 'Editor',
-      },
-      {
-        id: 'run-next',
-        keys: ['Shift+Enter'],
-        description: 'Run cell and move to next',
-        scope: 'Editor',
-      },
-      {
-        id: 'run-all',
-        keys: ['⌘⇧↵', 'Ctrl+Shift+Enter'],
-        description: 'Run entire document',
-        scope: 'Editor',
-      },
-      { id: 'interrupt', keys: ['Esc'], description: 'Interrupt running code' },
-      { id: 'restart', keys: ['⌘⇧0', 'Ctrl+Shift+0'], description: 'Restart R session' },
-    ],
-  },
-  {
-    title: 'Session & Navigation',
-    items: [
-      { id: 'timeline', keys: ['⌘T', 'Ctrl+T'], description: 'Open timeline' },
-      { id: 'new-session', keys: ['⌘⇧N', 'Ctrl+Shift+N'], description: 'Start new session' },
-      { id: 'toggle-editor', keys: ['⌘1', 'Ctrl+1'], description: 'Show or hide editor' },
-      { id: 'toggle-console', keys: ['⌘2', 'Ctrl+2'], description: 'Show or hide console' },
-      { id: 'toggle-plots', keys: ['⌘3', 'Ctrl+3'], description: 'Show or hide plots' },
-      { id: 'toggle-timeline', keys: ['⌘4', 'Ctrl+4'], description: 'Toggle timeline tab' },
-    ],
-  },
-  {
-    title: 'View & Editing',
-    items: [
-      {
-        id: 'comment',
-        keys: ['⌘/', 'Ctrl+/'],
-        description: 'Comment or uncomment selection',
-        scope: 'Editor',
-      },
-      { id: 'find', keys: ['⌘F', 'Ctrl+F'], description: 'Find in editor', scope: 'Editor' },
-      {
-        id: 'replace',
-        keys: ['⌘H', 'Ctrl+H'],
-        description: 'Find and replace',
-        scope: 'Editor',
-      },
-      { id: 'zoom-in', keys: ['⌘+', 'Ctrl++'], description: 'Zoom in' },
-      { id: 'zoom-out', keys: ['⌘-', 'Ctrl+-'], description: 'Zoom out' },
-      { id: 'zoom-reset', keys: ['⌘0', 'Ctrl+0'], description: 'Reset zoom' },
-    ],
-  },
+	{
+		title: "General",
+		items: [
+			{ id: "file-new", keys: ["⌘N", "Ctrl+N"], description: "New R script" },
+			{
+				id: "file-open",
+				keys: ["⌘O", "Ctrl+O"],
+				description: "Open existing file",
+			},
+			{
+				id: "file-save",
+				keys: ["⌘S", "Ctrl+S"],
+				description: "Save current file",
+			},
+			{
+				id: "file-save-as",
+				keys: ["⌘⇧S", "Ctrl+Shift+S"],
+				description: "Save as new file",
+			},
+			{ id: "settings", keys: ["⌘,", "Ctrl+,"], description: "Open settings" },
+			{ id: "ai", keys: ["⌘K", "Ctrl+K"], description: "Focus AI Assistant" },
+		],
+	},
+	{
+		title: "Code Execution",
+		items: [
+			{
+				id: "run-selection",
+				keys: ["⌘↵", "Ctrl+Enter"],
+				description: "Run current line or selection",
+				scope: "Editor",
+			},
+			{
+				id: "run-next",
+				keys: ["Shift+Enter"],
+				description: "Run cell and move to next",
+				scope: "Editor",
+			},
+			{
+				id: "run-all",
+				keys: ["⌘⇧↵", "Ctrl+Shift+Enter"],
+				description: "Run entire document",
+				scope: "Editor",
+			},
+			{ id: "interrupt", keys: ["Esc"], description: "Interrupt running code" },
+			{
+				id: "restart",
+				keys: ["⌘⇧0", "Ctrl+Shift+0"],
+				description: "Restart R session",
+			},
+		],
+	},
+	{
+		title: "Session & Navigation",
+		items: [
+			{ id: "timeline", keys: ["⌘T", "Ctrl+T"], description: "Open timeline" },
+			{
+				id: "new-session",
+				keys: ["⌘⇧N", "Ctrl+Shift+N"],
+				description: "Start new session",
+			},
+			{
+				id: "toggle-editor",
+				keys: ["⌘1", "Ctrl+1"],
+				description: "Show or hide editor",
+			},
+			{
+				id: "toggle-console",
+				keys: ["⌘2", "Ctrl+2"],
+				description: "Show or hide console",
+			},
+			{
+				id: "toggle-plots",
+				keys: ["⌘3", "Ctrl+3"],
+				description: "Show or hide plots",
+			},
+			{
+				id: "toggle-timeline",
+				keys: ["⌘4", "Ctrl+4"],
+				description: "Toggle timeline tab",
+			},
+		],
+	},
+	{
+		title: "View & Editing",
+		items: [
+			{
+				id: "comment",
+				keys: ["⌘/", "Ctrl+/"],
+				description: "Comment or uncomment selection",
+				scope: "Editor",
+			},
+			{
+				id: "find",
+				keys: ["⌘F", "Ctrl+F"],
+				description: "Find in editor",
+				scope: "Editor",
+			},
+			{
+				id: "replace",
+				keys: ["⌘H", "Ctrl+H"],
+				description: "Find and replace",
+				scope: "Editor",
+			},
+			{ id: "zoom-in", keys: ["⌘+", "Ctrl++"], description: "Zoom in" },
+			{ id: "zoom-out", keys: ["⌘-", "Ctrl+-"], description: "Zoom out" },
+			{ id: "zoom-reset", keys: ["⌘0", "Ctrl+0"], description: "Reset zoom" },
+		],
+	},
 ];

--- a/client/src/constants/terminalEvents.ts
+++ b/client/src/constants/terminalEvents.ts
@@ -1,2 +1,2 @@
-export const TERMINAL_TAB_FOCUS_EVENT = 'terminal-panel:focus';
-export const TERMINAL_TAB_CREATE_EVENT = 'terminal-panel:new-session';
+export const TERMINAL_TAB_FOCUS_EVENT = "terminal-panel:focus";
+export const TERMINAL_TAB_CREATE_EVENT = "terminal-panel:new-session";

--- a/client/src/constants/urls.ts
+++ b/client/src/constants/urls.ts
@@ -8,24 +8,24 @@
 /**
  * Documentation website URL
  */
-export const DOCS_URL = 'https://reprod.dev/docs';
+export const DOCS_URL = "https://reprod.dev/docs";
 
 /**
  * GitHub repository URL
  */
-export const GITHUB_URL = 'https://github.com/reprod';
+export const GITHUB_URL = "https://github.com/reprod";
 
 /**
  * GitHub new issue URL
  */
-export const GITHUB_ISSUE_URL = 'https://github.com/reprod/issues/new';
+export const GITHUB_ISSUE_URL = "https://github.com/reprod/issues/new";
 
 // ===== API URLs =====
 
 /**
  * Base URL for the backend API server
  */
-export const API_BASE_URL = 'http://localhost:3001/api';
+export const API_BASE_URL = "http://localhost:3001/api";
 
 /**
  * API endpoint for provider configuration

--- a/client/src/core/ai/__tests__/codeBlockUtils.test.ts
+++ b/client/src/core/ai/__tests__/codeBlockUtils.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { extractCodeBlocks } from '../codeBlockUtils';
+import { describe, expect, it } from "vitest";
+import { extractCodeBlocks } from "../codeBlockUtils";
 
-describe('extractCodeBlocks', () => {
-  it('parses structured JSON metadata blocks', () => {
-    const structured = `
+describe("extractCodeBlocks", () => {
+	it("parses structured JSON metadata blocks", () => {
+		const structured = `
 Here is the patch:
 
 \`\`\`json
@@ -23,38 +23,38 @@ Here is the patch:
 \`\`\`
 `;
 
-    const [block] = extractCodeBlocks(structured);
+		const [block] = extractCodeBlocks(structured);
 
-    expect(block).toMatchObject({
-      id: 'fix-target',
-      action: 'replace-range',
-      filepath: 'analysis.R',
-      code: "print('fixed')",
-      explanation: 'Fixes edge case',
-    });
-    expect(block.targetRange).toEqual({
-      startLine: 5,
-      startColumn: 1,
-      endLine: 7,
-      endColumn: 1,
-    });
-  });
+		expect(block).toMatchObject({
+			id: "fix-target",
+			action: "replace-range",
+			filepath: "analysis.R",
+			code: "print('fixed')",
+			explanation: "Fixes edge case",
+		});
+		expect(block.targetRange).toEqual({
+			startLine: 5,
+			startColumn: 1,
+			endLine: 7,
+			endColumn: 1,
+		});
+	});
 
-  it('falls back to insert for plain R code fences', () => {
-    const script = `
+	it("falls back to insert for plain R code fences", () => {
+		const script = `
 \`\`\`r
 cat('hello world')
 \`\`\`
 `;
 
-    const [block] = extractCodeBlocks(script);
+		const [block] = extractCodeBlocks(script);
 
-    expect(block.action).toBe('insert');
-    expect(block.code.trim()).toBe("cat('hello world')");
-  });
- 
-  it('extracts original/new snippets from diff-style code blocks', () => {
-    const diffBlock = `
+		expect(block.action).toBe("insert");
+		expect(block.code.trim()).toBe("cat('hello world')");
+	});
+
+	it("extracts original/new snippets from diff-style code blocks", () => {
+		const diffBlock = `
 \`\`\`json
 {
   "id": "diff-example",
@@ -65,68 +65,64 @@ cat('hello world')
 \`\`\`
 `;
 
-    const [block] = extractCodeBlocks(diffBlock);
+		const [block] = extractCodeBlocks(diffBlock);
 
-    expect(block.code).toContain('new_value <- 2');
-    expect(block.originalCode).toContain('old_value <- 1');
-  });
+		expect(block.code).toContain("new_value <- 2");
+		expect(block.originalCode).toContain("old_value <- 1");
+	});
 
-  it('attaches simple changes to patch-based code blocks', () => {
-    const response = [
-      'numbers <- compute()',
-      '- result <- slow_run()',
-      '+ result <- fast_run()',
-      'return(result)',
-      '',
-      '*** Begin Patch',
-      '*** Update File: analysis.R',
-      '@@',
-      ' numbers <- compute()',
-      '-result <- slow_run()',
-      '+result <- fast_run()',
-      ' return(result)',
-      '*** End Patch',
-    ].join('\n');
+	it("attaches simple changes to patch-based code blocks", () => {
+		const response = [
+			"numbers <- compute()",
+			"- result <- slow_run()",
+			"+ result <- fast_run()",
+			"return(result)",
+			"",
+			"*** Begin Patch",
+			"*** Update File: analysis.R",
+			"@@",
+			" numbers <- compute()",
+			"-result <- slow_run()",
+			"+result <- fast_run()",
+			" return(result)",
+			"*** End Patch",
+		].join("\n");
 
-    const [block] = extractCodeBlocks(response);
-    expect(block.patchChunks).toHaveLength(1);
-    expect(block.simpleChanges).toHaveLength(2);
-    expect(block.simpleChanges?.[0].oldLines).toContain(' result <- slow_run()');
-  });
+		const [block] = extractCodeBlocks(response);
+		expect(block.patchChunks).toHaveLength(1);
+		expect(block.simpleChanges).toHaveLength(2);
+		expect(block.simpleChanges?.[0].oldLines).toContain(" result <- slow_run()");
+	});
 
-  it('keeps all simple changes even when patch has a single chunk', () => {
-    const response = [
-      '*** Begin Patch',
-      '*** Update File: analysis.R',
-      '@@',
-      '- summary(mtcars)',
-      '+ summary(iris)',
-      '- str(mtcars)',
-      '+ str(iris)',
-      '',
-      '- plot(mtcars$mpg, mtcars$hp)',
-      '+ plot(iris$Sepal.Length, iris$Sepal.Width)',
-      '*** End Patch',
-    ].join('\n');
+	it("keeps all simple changes even when patch has a single chunk", () => {
+		const response = [
+			"*** Begin Patch",
+			"*** Update File: analysis.R",
+			"@@",
+			"- summary(mtcars)",
+			"+ summary(iris)",
+			"- str(mtcars)",
+			"+ str(iris)",
+			"",
+			"- plot(mtcars$mpg, mtcars$hp)",
+			"+ plot(iris$Sepal.Length, iris$Sepal.Width)",
+			"*** End Patch",
+		].join("\n");
 
-    const [block] = extractCodeBlocks(response);
-    expect(block.patchChunks).toHaveLength(1);
-    expect(block.simpleChanges).toHaveLength(2);
-    expect(block.simpleChanges?.[0].oldLines.join(' ')).toContain('summary(mtcars)');
-    expect(block.simpleChanges?.[1].oldLines.join(' ')).toContain('plot(mtcars$mpg');
-  });
+		const [block] = extractCodeBlocks(response);
+		expect(block.patchChunks).toHaveLength(1);
+		expect(block.simpleChanges).toHaveLength(2);
+		expect(block.simpleChanges?.[0].oldLines.join(" ")).toContain("summary(mtcars)");
+		expect(block.simpleChanges?.[1].oldLines.join(" ")).toContain("plot(mtcars$mpg");
+	});
 
-  it('extracts code blocks consistently across multiple calls', () => {
-    const script = [
-      '```r',
-      "cat('hello world')",
-      '```',
-    ].join('\n');
+	it("extracts code blocks consistently across multiple calls", () => {
+		const script = ["```r", "cat('hello world')", "```"].join("\n");
 
-    const first = extractCodeBlocks(script);
-    const second = extractCodeBlocks(script);
+		const first = extractCodeBlocks(script);
+		const second = extractCodeBlocks(script);
 
-    expect(first[0].code.trim()).toBe("cat('hello world')");
-    expect(second[0].code.trim()).toBe("cat('hello world')");
-  });
+		expect(first[0].code.trim()).toBe("cat('hello world')");
+		expect(second[0].code.trim()).toBe("cat('hello world')");
+	});
 });

--- a/client/src/core/ai/__tests__/contextMatcher.test.ts
+++ b/client/src/core/ai/__tests__/contextMatcher.test.ts
@@ -1,74 +1,74 @@
-import { describe, expect, it } from 'vitest';
-import { findCodeInEditor } from '../contextMatcher';
+import { describe, expect, it } from "vitest";
+import { findCodeInEditor } from "../contextMatcher";
 
 const sampleContent = [
-  'alpha <- 1',
-  'beta <- 2',
-  'target <- beta * 2',
-  'gamma <- beta + 1',
-  'delta <- 3',
-  'epsilon <- 4',
-  'target <- alpha + delta',
-  'zeta <- target',
-].join('\n');
+	"alpha <- 1",
+	"beta <- 2",
+	"target <- beta * 2",
+	"gamma <- beta + 1",
+	"delta <- 3",
+	"epsilon <- 4",
+	"target <- alpha + delta",
+	"zeta <- target",
+].join("\n");
 
-describe('findCodeInEditor', () => {
-  it('locates exact old snippet', () => {
-    const range = findCodeInEditor(
-      sampleContent,
-      ['target <- beta * 2', 'gamma <- beta + 1'],
-      ['beta <- 2'],
-      ['delta <- 3'],
-    );
+describe("findCodeInEditor", () => {
+	it("locates exact old snippet", () => {
+		const range = findCodeInEditor(
+			sampleContent,
+			["target <- beta * 2", "gamma <- beta + 1"],
+			["beta <- 2"],
+			["delta <- 3"],
+		);
 
-    expect(range).toMatchObject({ startLine: 3, endLine: 4 });
-  });
+		expect(range).toMatchObject({ startLine: 3, endLine: 4 });
+	});
 
-  it('uses before context to disambiguate matches', () => {
-    const range = findCodeInEditor(
-      sampleContent,
-      ['target <- alpha + delta'],
-      ['delta <- 3', 'epsilon <- 4'],
-      [],
-    );
+	it("uses before context to disambiguate matches", () => {
+		const range = findCodeInEditor(
+			sampleContent,
+			["target <- alpha + delta"],
+			["delta <- 3", "epsilon <- 4"],
+			[],
+		);
 
-    expect(range).toMatchObject({ startLine: 7, endLine: 7 });
-  });
+		expect(range).toMatchObject({ startLine: 7, endLine: 7 });
+	});
 
-  it('falls back to after context when needed', () => {
-    const content = ['foo()', 'bar()', 'foo()', 'keep()', 'bar()', 'done()'].join('\n');
-    const range = findCodeInEditor(content, ['foo()'], [], ['done()']);
+	it("falls back to after context when needed", () => {
+		const content = ["foo()", "bar()", "foo()", "keep()", "bar()", "done()"].join("\n");
+		const range = findCodeInEditor(content, ["foo()"], [], ["done()"]);
 
-    expect(range).toMatchObject({ startLine: 3, endLine: 3 });
-  });
+		expect(range).toMatchObject({ startLine: 3, endLine: 3 });
+	});
 
-  it('returns insertion range when only context exists', () => {
-    const content = ['first()', 'second()', 'third()'].join('\n');
-    const range = findCodeInEditor(content, [], ['first()'], ['third()']);
+	it("returns insertion range when only context exists", () => {
+		const content = ["first()", "second()", "third()"].join("\n");
+		const range = findCodeInEditor(content, [], ["first()"], ["third()"]);
 
-    expect(range).toMatchObject({ startLine: 2, endLine: 2 });
-  });
+		expect(range).toMatchObject({ startLine: 2, endLine: 2 });
+	});
 
-  it('matches snippets that include blank lines', () => {
-    const content = [
-      'summary(mtcars)',
-      'str(mtcars)',
-      '',
-      'plot(mtcars$mpg, mtcars$hp)',
-      'abline(lm(hp ~ mpg, data = mtcars))',
-    ].join('\n');
+	it("matches snippets that include blank lines", () => {
+		const content = [
+			"summary(mtcars)",
+			"str(mtcars)",
+			"",
+			"plot(mtcars$mpg, mtcars$hp)",
+			"abline(lm(hp ~ mpg, data = mtcars))",
+		].join("\n");
 
-    const range = findCodeInEditor(content, [
-      'summary(mtcars)',
-      'str(mtcars)',
-      '',
-      'plot(mtcars$mpg, mtcars$hp)',
-    ]);
+		const range = findCodeInEditor(content, [
+			"summary(mtcars)",
+			"str(mtcars)",
+			"",
+			"plot(mtcars$mpg, mtcars$hp)",
+		]);
 
-    expect(range).toMatchObject({ startLine: 1, endLine: 4 });
-  });
+		expect(range).toMatchObject({ startLine: 1, endLine: 4 });
+	});
 
-  it('returns null when nothing matches', () => {
-    expect(findCodeInEditor(sampleContent, ['missing <- 0'], [], [])).toBeNull();
-  });
+	it("returns null when nothing matches", () => {
+		expect(findCodeInEditor(sampleContent, ["missing <- 0"], [], [])).toBeNull();
+	});
 });

--- a/client/src/core/ai/__tests__/patchParser.test.ts
+++ b/client/src/core/ai/__tests__/patchParser.test.ts
@@ -1,29 +1,29 @@
-import { describe, expect, it } from 'vitest';
-import { parsePatchFormat } from '../patchParser';
+import { describe, expect, it } from "vitest";
+import { parsePatchFormat } from "../patchParser";
 
-describe('parsePatchFormat', () => {
-  const patch = [
-    '*** Begin Patch',
-    '*** Update File: analysis.R',
-    '@@',
-    '- summary(mtcars)',
-    '+ summary(iris)',
-    '*** End Patch',
-  ].join('\n');
+describe("parsePatchFormat", () => {
+	const patch = [
+		"*** Begin Patch",
+		"*** Update File: analysis.R",
+		"@@",
+		"- summary(mtcars)",
+		"+ summary(iris)",
+		"*** End Patch",
+	].join("\n");
 
-  it('parses patch hunks', () => {
-    const [hunk] = parsePatchFormat(patch);
+	it("parses patch hunks", () => {
+		const [hunk] = parsePatchFormat(patch);
 
-    expect(hunk.filepath).toBe('analysis.R');
-    expect(hunk.type).toBe('update');
-    expect(hunk.chunks).toHaveLength(1);
-  });
+		expect(hunk.filepath).toBe("analysis.R");
+		expect(hunk.type).toBe("update");
+		expect(hunk.chunks).toHaveLength(1);
+	});
 
-  it('resets regex state across calls', () => {
-    const first = parsePatchFormat(patch);
-    const second = parsePatchFormat(patch);
+	it("resets regex state across calls", () => {
+		const first = parsePatchFormat(patch);
+		const second = parsePatchFormat(patch);
 
-    expect(first).toHaveLength(1);
-    expect(second).toHaveLength(1);
-  });
+		expect(first).toHaveLength(1);
+		expect(second).toHaveLength(1);
+	});
 });

--- a/client/src/core/ai/__tests__/simpleChangeParser.test.ts
+++ b/client/src/core/ai/__tests__/simpleChangeParser.test.ts
@@ -1,92 +1,87 @@
-import { describe, expect, it } from 'vitest';
-import { parseSimpleChanges } from '../simpleChangeParser';
+import { describe, expect, it } from "vitest";
+import { parseSimpleChanges } from "../simpleChangeParser";
 
-describe('parseSimpleChanges', () => {
-  it('parses diff content inside fenced blocks', () => {
-    const input = [
-      'Response with diff block:',
-      '```diff',
-      'before_line_1()',
-      'before_line_2()',
-      '- old_call()',
-      '+ new_call()',
-      'after_line_1()',
-      'after_line_2()',
-      '```',
-    ].join('\n');
+describe("parseSimpleChanges", () => {
+	it("parses diff content inside fenced blocks", () => {
+		const input = [
+			"Response with diff block:",
+			"```diff",
+			"before_line_1()",
+			"before_line_2()",
+			"- old_call()",
+			"+ new_call()",
+			"after_line_1()",
+			"after_line_2()",
+			"```",
+		].join("\n");
 
-    const [change] = parseSimpleChanges(input);
-    expect(change).toBeDefined();
-    expect(change.beforeContext).toEqual(['before_line_1()', 'before_line_2()']);
-    expect(change.afterContext).toEqual(['after_line_1()', 'after_line_2()']);
-    expect(change.oldLines).toEqual([' old_call()']);
-    expect(change.newLines).toEqual([' new_call()']);
-  });
+		const [change] = parseSimpleChanges(input);
+		expect(change).toBeDefined();
+		expect(change.beforeContext).toEqual(["before_line_1()", "before_line_2()"]);
+		expect(change.afterContext).toEqual(["after_line_1()", "after_line_2()"]);
+		expect(change.oldLines).toEqual([" old_call()"]);
+		expect(change.newLines).toEqual([" new_call()"]);
+	});
 
-  it('detects multiple change sections outside fenced blocks', () => {
-    const input = [
-      'context_before_a()',
-      '- remove_a()',
-      '+ add_a()',
-      'context_after_a()',
-      '',
-      'leading_text',
-      'second_before()',
-      '- erase_line()',
-      '+ insert_line()',
-      'second_after()',
-    ].join('\n');
+	it("detects multiple change sections outside fenced blocks", () => {
+		const input = [
+			"context_before_a()",
+			"- remove_a()",
+			"+ add_a()",
+			"context_after_a()",
+			"",
+			"leading_text",
+			"second_before()",
+			"- erase_line()",
+			"+ insert_line()",
+			"second_after()",
+		].join("\n");
 
-    const changes = parseSimpleChanges(input);
-    expect(changes).toHaveLength(2);
+		const changes = parseSimpleChanges(input);
+		expect(changes).toHaveLength(2);
 
-    expect(changes[0]).toMatchObject({
-      beforeContext: ['context_before_a()'],
-      afterContext: ['context_after_a()'],
-      oldLines: [' remove_a()'],
-      newLines: [' add_a()'],
-    });
+		expect(changes[0]).toMatchObject({
+			beforeContext: ["context_before_a()"],
+			afterContext: ["context_after_a()"],
+			oldLines: [" remove_a()"],
+			newLines: [" add_a()"],
+		});
 
-    expect(changes[1]).toMatchObject({
-      beforeContext: ['leading_text', 'second_before()'],
-      afterContext: ['second_after()'],
-    });
-  });
+		expect(changes[1]).toMatchObject({
+			beforeContext: ["leading_text", "second_before()"],
+			afterContext: ["second_after()"],
+		});
+	});
 
-  it('retains blank lines inside fenced diff blocks', () => {
-    const input = [
-      '```diff',
-      '- summary(mtcars)',
-      '+ summary(iris)',
-      '',
-      '- plot(mtcars$mpg)',
-      '+ plot(iris$Sepal.Length)',
-      '```',
-    ].join('\n');
+	it("retains blank lines inside fenced diff blocks", () => {
+		const input = [
+			"```diff",
+			"- summary(mtcars)",
+			"+ summary(iris)",
+			"",
+			"- plot(mtcars$mpg)",
+			"+ plot(iris$Sepal.Length)",
+			"```",
+		].join("\n");
 
-    const [change] = parseSimpleChanges(input);
-    expect(change).toBeDefined();
-    expect(change.oldLines).toEqual([' summary(mtcars)', '', ' plot(mtcars$mpg)']);
-    expect(change.newLines).toEqual([' summary(iris)', '', ' plot(iris$Sepal.Length)']);
-  });
+		const [change] = parseSimpleChanges(input);
+		expect(change).toBeDefined();
+		expect(change.oldLines).toEqual([" summary(mtcars)", "", " plot(mtcars$mpg)"]);
+		expect(change.newLines).toEqual([" summary(iris)", "", " plot(iris$Sepal.Length)"]);
+	});
 
-  it('resets regex state between calls', () => {
-    const input = [
-      '```diff',
-      '- a()',
-      '+ b()',
-      '```',
-    ].join('\n');
+	it("resets regex state between calls", () => {
+		const input = ["```diff", "- a()", "+ b()", "```"].join("\n");
 
-    const first = parseSimpleChanges(input);
-    const second = parseSimpleChanges(input);
+		const first = parseSimpleChanges(input);
+		const second = parseSimpleChanges(input);
 
-    expect(first).toHaveLength(1);
-    expect(second).toHaveLength(1);
-  });
+		expect(first).toHaveLength(1);
+		expect(second).toHaveLength(1);
+	});
 
-  it('ignores text without balanced +/- sections', () => {
-    const input = 'List:\n- item one\n- item two';
-    expect(parseSimpleChanges(input)).toHaveLength(0);
-  });
+	it("ignores text without balanced +/- sections", () => {
+		const input = "List:\n- item one\n- item two";
+		expect(parseSimpleChanges(input)).toHaveLength(0);
+	});
 });

--- a/client/src/core/ai/codeBlockActions.ts
+++ b/client/src/core/ai/codeBlockActions.ts
@@ -1,39 +1,39 @@
-import type { CodeBlock } from '@shared/types';
+import type { CodeBlock } from "@shared/types";
 
 /**
  * Get target file description for a code block
  */
 export function getCodeActionTarget(codeBlock: CodeBlock): string {
-  return codeBlock.filepath || 'active editor';
+	return codeBlock.filepath || "active editor";
 }
 
 /**
  * Get human-readable action label for a code block
  */
 export function getCodeActionLabel(codeBlock: CodeBlock): string {
-  const targetFile = getCodeActionTarget(codeBlock);
+	const targetFile = getCodeActionTarget(codeBlock);
 
-  if (codeBlock.action === 'replace-all') {
-    return `Replace entire ${targetFile}`;
-  }
+	if (codeBlock.action === "replace-all") {
+		return `Replace entire ${targetFile}`;
+	}
 
-  if (codeBlock.action === 'replace-range' && codeBlock.targetRange) {
-    const { startLine, startColumn, endLine, endColumn } = codeBlock.targetRange;
-    return `Replace ${targetFile} ${startLine}:${startColumn}-${endLine}:${endColumn}`;
-  }
+	if (codeBlock.action === "replace-range" && codeBlock.targetRange) {
+		const { startLine, startColumn, endLine, endColumn } = codeBlock.targetRange;
+		return `Replace ${targetFile} ${startLine}:${startColumn}-${endLine}:${endColumn}`;
+	}
 
-  if (codeBlock.action === 'delete-range' && codeBlock.targetRange) {
-    const { startLine, endLine } = codeBlock.targetRange;
-    return `Delete ${targetFile} lines ${startLine}-${endLine}`;
-  }
+	if (codeBlock.action === "delete-range" && codeBlock.targetRange) {
+		const { startLine, endLine } = codeBlock.targetRange;
+		return `Delete ${targetFile} lines ${startLine}-${endLine}`;
+	}
 
-  if (codeBlock.action === 'create-file' && codeBlock.filepath) {
-    return `Create file ${codeBlock.filepath}`;
-  }
+	if (codeBlock.action === "create-file" && codeBlock.filepath) {
+		return `Create file ${codeBlock.filepath}`;
+	}
 
-  if (codeBlock.action === 'insert') {
-    return `Insert code in ${targetFile}`;
-  }
+	if (codeBlock.action === "insert") {
+		return `Insert code in ${targetFile}`;
+	}
 
-  return 'Apply suggested change';
+	return "Apply suggested change";
 }

--- a/client/src/core/ai/codeBlockUtils.ts
+++ b/client/src/core/ai/codeBlockUtils.ts
@@ -1,286 +1,298 @@
-import type { CodeBlock, CodeChangeAction, CodeRange, SimpleCodeChange } from '@shared/types';
-import { parsePatchFormat } from './patchParser';
-import type { PatchHunk } from './patchParser';
-import { parseSimpleChanges } from './simpleChangeParser';
+import type { CodeBlock, CodeChangeAction, CodeRange, SimpleCodeChange } from "@shared/types";
+import type { PatchHunk } from "./patchParser";
+import { parsePatchFormat } from "./patchParser";
+import { parseSimpleChanges } from "./simpleChangeParser";
 
 const R_CODE_BLOCK_REGEX = /```(?:r|R)\n([\s\S]*?)\n```/g;
 const JSON_BLOCK_REGEX = /```json\n([\s\S]*?)\n```/g;
 
 const codeChangeActions: CodeChangeAction[] = [
-  'replace-all',
-  'replace-range',
-  'insert',
-  'create-file',
-  'delete-range',
+	"replace-all",
+	"replace-range",
+	"insert",
+	"create-file",
+	"delete-range",
 ];
 
 const makeCodeRange = (raw?: Partial<CodeRange>): CodeRange | undefined => {
-  if (!raw) {
-    return undefined;
-  }
+	if (!raw) {
+		return undefined;
+	}
 
-  const range: CodeRange = {
-    startLine: Number(raw.startLine) || 0,
-    startColumn: Number(raw.startColumn) || 1,
-    endLine: Number(raw.endLine) || 0,
-    endColumn: Number(raw.endColumn) || 1,
-  };
+	const range: CodeRange = {
+		startLine: Number(raw.startLine) || 0,
+		startColumn: Number(raw.startColumn) || 1,
+		endLine: Number(raw.endLine) || 0,
+		endColumn: Number(raw.endColumn) || 1,
+	};
 
-  if (!range.startLine || !range.endLine) {
-    return undefined;
-  }
+	if (!range.startLine || !range.endLine) {
+		return undefined;
+	}
 
-  return range;
+	return range;
 };
 
 const parsePatchSnippet = (value: string): { originalCode: string; newCode: string } | null => {
-  const lines = value.split(/\r?\n/);
-  const hasDiffMarkers = lines.some((line) => line.startsWith('+') || line.startsWith('-'));
-  if (!hasDiffMarkers) {
-    return null;
-  }
+	const lines = value.split(/\r?\n/);
+	const hasDiffMarkers = lines.some((line) => line.startsWith("+") || line.startsWith("-"));
+	if (!hasDiffMarkers) {
+		return null;
+	}
 
-  const originalLines: string[] = [];
-  const newLines: string[] = [];
+	const originalLines: string[] = [];
+	const newLines: string[] = [];
 
-  for (const line of lines) {
-    if (line.startsWith('@@') || line.startsWith('---') || line.startsWith('+++')) {
-      continue;
-    }
+	for (const line of lines) {
+		if (line.startsWith("@@") || line.startsWith("---") || line.startsWith("+++")) {
+			continue;
+		}
 
-    if (line.startsWith('-')) {
-      originalLines.push(line.slice(1));
-      continue;
-    }
+		if (line.startsWith("-")) {
+			originalLines.push(line.slice(1));
+			continue;
+		}
 
-    if (line.startsWith('+')) {
-      newLines.push(line.slice(1));
-      continue;
-    }
+		if (line.startsWith("+")) {
+			newLines.push(line.slice(1));
+			continue;
+		}
 
-    if (line.startsWith(' ')) {
-      const context = line.slice(1);
-      originalLines.push(context);
-      newLines.push(context);
-      continue;
-    }
+		if (line.startsWith(" ")) {
+			const context = line.slice(1);
+			originalLines.push(context);
+			newLines.push(context);
+			continue;
+		}
 
-    originalLines.push(line);
-    newLines.push(line);
-  }
+		originalLines.push(line);
+		newLines.push(line);
+	}
 
-  if (!originalLines.length && !newLines.length) {
-    return null;
-  }
+	if (!originalLines.length && !newLines.length) {
+		return null;
+	}
 
-  return {
-    originalCode: originalLines.join('\n').trimEnd(),
-    newCode: newLines.join('\n').trimEnd(),
-  };
+	return {
+		originalCode: originalLines.join("\n").trimEnd(),
+		newCode: newLines.join("\n").trimEnd(),
+	};
 };
 
 const formatPatchText = (hunk: PatchHunk): string => {
-  const header = `*** Begin Patch\n*** ${hunk.type === 'add' ? 'Add' : hunk.type === 'delete' ? 'Delete' : 'Update'} File: ${hunk.filepath}\n`;
-  const body = hunk.chunks
-    .map((chunk) => {
-      const context = chunk.context ? `${chunk.context}\n` : '';
-      const oldLines = chunk.oldLines.map((line) => `-${line}`).join('\n');
-      const newLines = chunk.newLines.map((line) => `+${line}`).join('\n');
-      return `${context}${oldLines}\n${newLines}`;
-    })
-    .join('\n\n');
+	const header = `*** Begin Patch\n*** ${hunk.type === "add" ? "Add" : hunk.type === "delete" ? "Delete" : "Update"} File: ${hunk.filepath}\n`;
+	const body = hunk.chunks
+		.map((chunk) => {
+			const context = chunk.context ? `${chunk.context}\n` : "";
+			const oldLines = chunk.oldLines.map((line) => `-${line}`).join("\n");
+			const newLines = chunk.newLines.map((line) => `+${line}`).join("\n");
+			return `${context}${oldLines}\n${newLines}`;
+		})
+		.join("\n\n");
 
-  return `${header}${body}\n*** End Patch`;
+	return `${header}${body}\n*** End Patch`;
 };
 
 const buildCodeBlockFromPatch = (hunk: PatchHunk): CodeBlock | null => {
-  const newCode = hunk.chunks.flatMap((chunk) => chunk.newLines).join('\n').trimEnd();
-  const originalCode = hunk.chunks.flatMap((chunk) => chunk.oldLines).join('\n').trimEnd();
+	const newCode = hunk.chunks
+		.flatMap((chunk) => chunk.newLines)
+		.join("\n")
+		.trimEnd();
+	const originalCode = hunk.chunks
+		.flatMap((chunk) => chunk.oldLines)
+		.join("\n")
+		.trimEnd();
 
-  if (!newCode) {
-    return null;
-  }
+	if (!newCode) {
+		return null;
+	}
 
-  const action: CodeChangeAction =
-    hunk.type === 'add' ? 'create-file' : hunk.type === 'delete' ? 'delete-range' : 'replace-range';
+	const action: CodeChangeAction =
+		hunk.type === "add" ? "create-file" : hunk.type === "delete" ? "delete-range" : "replace-range";
 
-  const codeBlock: CodeBlock = {
-    id: `patch-${Date.now()}-${hunk.filepath}`,
-    code: newCode,
-    language: 'r',
-    action,
-    filepath: hunk.filepath,
-    patchChunks: hunk.chunks,
-    patchText: formatPatchText(hunk),
-  };
+	const codeBlock: CodeBlock = {
+		id: `patch-${Date.now()}-${hunk.filepath}`,
+		code: newCode,
+		language: "r",
+		action,
+		filepath: hunk.filepath,
+		patchChunks: hunk.chunks,
+		patchText: formatPatchText(hunk),
+	};
 
-  if (originalCode) {
-    codeBlock.originalCode = originalCode;
-  }
+	if (originalCode) {
+		codeBlock.originalCode = originalCode;
+	}
 
-  return codeBlock;
+	return codeBlock;
 };
 
 const normalizeCodeBlock = (raw: Record<string, unknown>): CodeBlock | null => {
-  const action = typeof raw.action === 'string' && codeChangeActions.includes(raw.action as CodeChangeAction)
-    ? (raw.action as CodeChangeAction)
-    : 'replace-all';
+	const action =
+		typeof raw.action === "string" && codeChangeActions.includes(raw.action as CodeChangeAction)
+			? (raw.action as CodeChangeAction)
+			: "replace-all";
 
-  const code = typeof raw.code === 'string' ? raw.code : '';
-  if (!code) {
-    return null;
-  }
+	const code = typeof raw.code === "string" ? raw.code : "";
+	if (!code) {
+		return null;
+	}
 
-  const codeBlock: CodeBlock = {
-    id: typeof raw.id === 'string' ? raw.id : `code-${Date.now()}-json`,
-    code,
-    language: 'r',
-    action,
-    filepath: typeof raw.filepath === 'string' ? raw.filepath : undefined,
-    explanation: typeof raw.explanation === 'string' ? raw.explanation : undefined,
-    checksum: typeof raw.checksum === 'string' ? raw.checksum : undefined,
-    originalCode: typeof raw.originalCode === 'string' ? raw.originalCode : undefined,
-  };
+	const codeBlock: CodeBlock = {
+		id: typeof raw.id === "string" ? raw.id : `code-${Date.now()}-json`,
+		code,
+		language: "r",
+		action,
+		filepath: typeof raw.filepath === "string" ? raw.filepath : undefined,
+		explanation: typeof raw.explanation === "string" ? raw.explanation : undefined,
+		checksum: typeof raw.checksum === "string" ? raw.checksum : undefined,
+		originalCode: typeof raw.originalCode === "string" ? raw.originalCode : undefined,
+	};
 
-  const targetRange = makeCodeRange(raw.targetRange as Partial<CodeRange>);
-  if (targetRange) {
-    codeBlock.targetRange = targetRange;
-  }
+	const targetRange = makeCodeRange(raw.targetRange as Partial<CodeRange>);
+	if (targetRange) {
+		codeBlock.targetRange = targetRange;
+	}
 
-  const diff = parsePatchSnippet(code);
-  if (diff) {
-    if (!codeBlock.originalCode && diff.originalCode) {
-      codeBlock.originalCode = diff.originalCode;
-    }
-    codeBlock.code = diff.newCode;
-  }
+	const diff = parsePatchSnippet(code);
+	if (diff) {
+		if (!codeBlock.originalCode && diff.originalCode) {
+			codeBlock.originalCode = diff.originalCode;
+		}
+		codeBlock.code = diff.newCode;
+	}
 
-  return codeBlock;
+	return codeBlock;
 };
 
-const parseJsonBlocks = (text: string): { blocks: CodeBlock[]; ranges: Array<{ start: number; end: number }> } => {
-  const jsonRanges: Array<{ start: number; end: number }> = [];
-  const parsedBlocks: CodeBlock[] = [];
+const parseJsonBlocks = (
+	text: string,
+): { blocks: CodeBlock[]; ranges: Array<{ start: number; end: number }> } => {
+	const jsonRanges: Array<{ start: number; end: number }> = [];
+	const parsedBlocks: CodeBlock[] = [];
 
-  let match: RegExpExecArray | null;
-  while ((match = JSON_BLOCK_REGEX.exec(text)) !== null) {
-    const rawJson = match[1];
-    const start = match.index;
-    const end = match.index + match[0].length;
-    jsonRanges.push({ start, end });
+	let match: RegExpExecArray | null;
+	while ((match = JSON_BLOCK_REGEX.exec(text)) !== null) {
+		const rawJson = match[1];
+		const start = match.index;
+		const end = match.index + match[0].length;
+		jsonRanges.push({ start, end });
 
-    try {
-      const parsed = JSON.parse(rawJson);
+		try {
+			const parsed = JSON.parse(rawJson);
 
-      if (Array.isArray(parsed)) {
-        parsed.forEach((entry: unknown) => {
-          if (entry && typeof entry === 'object') {
-            const block = normalizeCodeBlock(entry as Record<string, unknown>);
-            if (block) {
-              parsedBlocks.push(block);
-            }
-          }
-        });
-      } else if (parsed && typeof parsed === 'object') {
-        if ('codeBlocks' in parsed && Array.isArray((parsed as { codeBlocks: unknown[] }).codeBlocks)) {
-          (parsed as { codeBlocks: unknown[] }).codeBlocks.forEach((entry: unknown) => {
-            if (entry && typeof entry === 'object') {
-              const block = normalizeCodeBlock(entry as Record<string, unknown>);
-              if (block) {
-                parsedBlocks.push(block);
-              }
-            }
-          });
-        } else {
-          const block = normalizeCodeBlock(parsed as Record<string, unknown>);
-          if (block) {
-            parsedBlocks.push(block);
-          }
-        }
-      }
-    } catch (error) {
-      console.warn('Failed to parse JSON code block metadata', error);
-    }
-  }
+			if (Array.isArray(parsed)) {
+				parsed.forEach((entry: unknown) => {
+					if (entry && typeof entry === "object") {
+						const block = normalizeCodeBlock(entry as Record<string, unknown>);
+						if (block) {
+							parsedBlocks.push(block);
+						}
+					}
+				});
+			} else if (parsed && typeof parsed === "object") {
+				if (
+					"codeBlocks" in parsed &&
+					Array.isArray((parsed as { codeBlocks: unknown[] }).codeBlocks)
+				) {
+					(parsed as { codeBlocks: unknown[] }).codeBlocks.forEach((entry: unknown) => {
+						if (entry && typeof entry === "object") {
+							const block = normalizeCodeBlock(entry as Record<string, unknown>);
+							if (block) {
+								parsedBlocks.push(block);
+							}
+						}
+					});
+				} else {
+					const block = normalizeCodeBlock(parsed as Record<string, unknown>);
+					if (block) {
+						parsedBlocks.push(block);
+					}
+				}
+			}
+		} catch (error) {
+			console.warn("Failed to parse JSON code block metadata", error);
+		}
+	}
 
-  return { blocks: parsedBlocks, ranges: jsonRanges };
+	return { blocks: parsedBlocks, ranges: jsonRanges };
 };
 
 const attachSimpleChanges = (blocks: CodeBlock[], simpleChanges: SimpleCodeChange[]): void => {
-  if (!simpleChanges.length || !blocks.length) {
-    return;
-  }
+	if (!simpleChanges.length || !blocks.length) {
+		return;
+	}
 
-  let cursor = 0;
-  const lastIndex = blocks.length - 1;
-  for (const [index, block] of blocks.entries()) {
-    const remaining = simpleChanges.length - cursor;
-    if (remaining <= 0) {
-      break;
-    }
+	let cursor = 0;
+	const lastIndex = blocks.length - 1;
+	for (const [index, block] of blocks.entries()) {
+		const remaining = simpleChanges.length - cursor;
+		if (remaining <= 0) {
+			break;
+		}
 
-    // Prefer spreading simple changes across patch chunks, but let the final block consume leftovers so we don't drop any.
-    const patchBudget = block.patchChunks?.length ?? 0;
-    const isLastBlock = index === lastIndex;
-    const budget =
-      patchBudget > 0
-        ? isLastBlock
-          ? remaining
-          : Math.min(remaining, patchBudget)
-        : isLastBlock
-          ? remaining
-          : Math.max(1, Math.ceil(remaining / (lastIndex - index + 1)));
+		// Prefer spreading simple changes across patch chunks, but let the final block consume leftovers so we don't drop any.
+		const patchBudget = block.patchChunks?.length ?? 0;
+		const isLastBlock = index === lastIndex;
+		const budget =
+			patchBudget > 0
+				? isLastBlock
+					? remaining
+					: Math.min(remaining, patchBudget)
+				: isLastBlock
+					? remaining
+					: Math.max(1, Math.ceil(remaining / (lastIndex - index + 1)));
 
-    const assigned: SimpleCodeChange[] = [];
-    for (let idx = 0; idx < budget && cursor < simpleChanges.length; idx += 1, cursor += 1) {
-      assigned.push(simpleChanges[cursor]);
-    }
-    if (assigned.length) {
-      block.simpleChanges = assigned;
-    }
-  }
+		const assigned: SimpleCodeChange[] = [];
+		for (let idx = 0; idx < budget && cursor < simpleChanges.length; idx += 1, cursor += 1) {
+			assigned.push(simpleChanges[cursor]);
+		}
+		if (assigned.length) {
+			block.simpleChanges = assigned;
+		}
+	}
 };
 
 export function extractCodeBlocks(text: string): CodeBlock[] {
-  R_CODE_BLOCK_REGEX.lastIndex = 0;
-  JSON_BLOCK_REGEX.lastIndex = 0;
-  const simpleChanges = parseSimpleChanges(text);
-  const patchHunks = parsePatchFormat(text);
-  if (patchHunks.length > 0) {
-    const patchBlocks = patchHunks
-      .map(buildCodeBlockFromPatch)
-      .filter((block): block is CodeBlock => block !== null);
-    attachSimpleChanges(patchBlocks, simpleChanges);
-    return patchBlocks;
-  }
+	R_CODE_BLOCK_REGEX.lastIndex = 0;
+	JSON_BLOCK_REGEX.lastIndex = 0;
+	const simpleChanges = parseSimpleChanges(text);
+	const patchHunks = parsePatchFormat(text);
+	if (patchHunks.length > 0) {
+		const patchBlocks = patchHunks
+			.map(buildCodeBlockFromPatch)
+			.filter((block): block is CodeBlock => block !== null);
+		attachSimpleChanges(patchBlocks, simpleChanges);
+		return patchBlocks;
+	}
 
-  if (text.includes('*** Begin Patch')) {
-    console.warn('Patch detected but structured parser could not decode it.');
-  }
+	if (text.includes("*** Begin Patch")) {
+		console.warn("Patch detected but structured parser could not decode it.");
+	}
 
-  const codeBlocks: CodeBlock[] = [];
-  const { blocks: jsonBlocks, ranges: jsonRanges } = parseJsonBlocks(text);
-  codeBlocks.push(...jsonBlocks);
+	const codeBlocks: CodeBlock[] = [];
+	const { blocks: jsonBlocks, ranges: jsonRanges } = parseJsonBlocks(text);
+	codeBlocks.push(...jsonBlocks);
 
-  let match: RegExpExecArray | null;
-  while ((match = R_CODE_BLOCK_REGEX.exec(text)) !== null) {
-    const start = match.index;
-    const overlapsJson = jsonRanges.some(({ start: jsonStart, end: jsonEnd }) =>
-      start >= jsonStart && start < jsonEnd,
-    );
+	let match: RegExpExecArray | null;
+	while ((match = R_CODE_BLOCK_REGEX.exec(text)) !== null) {
+		const start = match.index;
+		const overlapsJson = jsonRanges.some(
+			({ start: jsonStart, end: jsonEnd }) => start >= jsonStart && start < jsonEnd,
+		);
 
-    if (overlapsJson) {
-      continue;
-    }
+		if (overlapsJson) {
+			continue;
+		}
 
-    codeBlocks.push({
-      id: `code-${Date.now()}-${start}`,
-      code: match[1],
-      language: 'r',
-      action: 'insert', // Safer default fallback (primary fix is system prompts in PR #99)
-    });
-  }
+		codeBlocks.push({
+			id: `code-${Date.now()}-${start}`,
+			code: match[1],
+			language: "r",
+			action: "insert", // Safer default fallback (primary fix is system prompts in PR #99)
+		});
+	}
 
-  attachSimpleChanges(codeBlocks, simpleChanges);
-  return codeBlocks;
+	attachSimpleChanges(codeBlocks, simpleChanges);
+	return codeBlocks;
 }

--- a/client/src/core/ai/contextMatcher.ts
+++ b/client/src/core/ai/contextMatcher.ts
@@ -1,205 +1,198 @@
-import type { CodeRange } from '@shared/types';
-import type { PatchChunk } from '@shared/types';
+import type { CodeRange, PatchChunk } from "@shared/types";
 
 const normalizeLine = (line: string): string => line.trim();
 const normalizeSnippet = (lines: string[]): string[] => {
-  const normalized = lines.map(normalizeLine);
-  const hasContent = normalized.some((line) => line.length > 0);
-  return hasContent ? normalized : [];
+	const normalized = lines.map(normalizeLine);
+	const hasContent = normalized.some((line) => line.length > 0);
+	return hasContent ? normalized : [];
 };
 
 export function seekSequence(
-  content: string,
-  snippetLines: string[],
-  startFromLine = 0,
+	content: string,
+	snippetLines: string[],
+	startFromLine = 0,
 ): number | null {
-  if (snippetLines.length === 0) {
-    return null;
-  }
+	if (snippetLines.length === 0) {
+		return null;
+	}
 
-  const contentLines = content.split(/\r?\n/);
+	const contentLines = content.split(/\r?\n/);
 
-  for (let idx = startFromLine; idx <= contentLines.length - snippetLines.length; idx++) {
-    let match = true;
-    for (let offset = 0; offset < snippetLines.length; offset++) {
-      if (normalizeLine(contentLines[idx + offset]) !== normalizeLine(snippetLines[offset])) {
-        match = false;
-        break;
-      }
-    }
-    if (match) {
-      return idx + 1;
-    }
-  }
+	for (let idx = startFromLine; idx <= contentLines.length - snippetLines.length; idx++) {
+		let match = true;
+		for (let offset = 0; offset < snippetLines.length; offset++) {
+			if (normalizeLine(contentLines[idx + offset]) !== normalizeLine(snippetLines[offset])) {
+				match = false;
+				break;
+			}
+		}
+		if (match) {
+			return idx + 1;
+		}
+	}
 
-  return null;
+	return null;
 }
 
-export function computeTargetRange(
-  content: string,
-  snippet: string,
-): CodeRange | null {
-  const snippetLines = normalizeSnippet(snippet.split(/\r?\n/));
-  if (!snippetLines.length) {
-    return null;
-  }
+export function computeTargetRange(content: string, snippet: string): CodeRange | null {
+	const snippetLines = normalizeSnippet(snippet.split(/\r?\n/));
+	if (!snippetLines.length) {
+		return null;
+	}
 
-  const startLine = seekSequence(content, snippetLines);
-  if (startLine === null) {
-    return null;
-  }
+	const startLine = seekSequence(content, snippetLines);
+	if (startLine === null) {
+		return null;
+	}
 
-  return {
-    startLine,
-    startColumn: 1,
-    endLine: startLine + snippetLines.length - 1,
-    endColumn: 999,
-  };
+	return {
+		startLine,
+		startColumn: 1,
+		endLine: startLine + snippetLines.length - 1,
+		endColumn: 999,
+	};
 }
 
 export function matchPatchChunk(content: string, chunk: PatchChunk): CodeRange | null {
-  const snippet = chunk.oldLines.join('\n');
-  const baseRange = computeTargetRange(content, snippet);
-  if (baseRange) {
-    return baseRange;
-  }
+	const snippet = chunk.oldLines.join("\n");
+	const baseRange = computeTargetRange(content, snippet);
+	if (baseRange) {
+		return baseRange;
+	}
 
-  // Try matching with context header if available
-  if (chunk.context) {
-    const contextLines = chunk.context.replace(/^@@.*@@/, '').trim();
-    const contextRange = computeTargetRange(content, contextLines);
-    if (contextRange) {
-      return contextRange;
-    }
-  }
+	// Try matching with context header if available
+	if (chunk.context) {
+		const contextLines = chunk.context.replace(/^@@.*@@/, "").trim();
+		const contextRange = computeTargetRange(content, contextLines);
+		if (contextRange) {
+			return contextRange;
+		}
+	}
 
-  // Only fallback to single-line match if oldLines has just one line
-  // This prevents matching wrong locations when multiple lines should match together
-  if (chunk.oldLines.length === 1) {
-    const singleLine = chunk.oldLines[0];
-    if (singleLine.trim().length > 0) {
-      const fallbackRange = computeTargetRange(content, singleLine);
-      if (fallbackRange) {
-        return fallbackRange;
-      }
-    }
-  }
+	// Only fallback to single-line match if oldLines has just one line
+	// This prevents matching wrong locations when multiple lines should match together
+	if (chunk.oldLines.length === 1) {
+		const singleLine = chunk.oldLines[0];
+		if (singleLine.trim().length > 0) {
+			const fallbackRange = computeTargetRange(content, singleLine);
+			if (fallbackRange) {
+				return fallbackRange;
+			}
+		}
+	}
 
-  return null;
+	return null;
 }
 
 const makeRangeFromMatch = (startLine: number, lineCount: number): CodeRange => ({
-  startLine,
-  startColumn: 1,
-  endLine: startLine + Math.max(lineCount - 1, 0),
-  endColumn: 999,
+	startLine,
+	startColumn: 1,
+	endLine: startLine + Math.max(lineCount - 1, 0),
+	endColumn: 999,
 });
 
 const sliceContentUntilLine = (content: string, line: number): string => {
-  if (line <= 0) {
-    return content;
-  }
-  return content
-    .split(/\r?\n/)
-    .slice(0, line)
-    .join('\n');
+	if (line <= 0) {
+		return content;
+	}
+	return content.split(/\r?\n/).slice(0, line).join("\n");
 };
 
 export function findCodeInEditor(
-  content: string,
-  oldLines: string[],
-  beforeContext: string[] = [],
-  afterContext: string[] = [],
+	content: string,
+	oldLines: string[],
+	beforeContext: string[] = [],
+	afterContext: string[] = [],
 ): CodeRange | null {
-  const normalizedOld = normalizeSnippet(oldLines);
-  const normalizedBefore = normalizeSnippet(beforeContext);
-  const normalizedAfter = normalizeSnippet(afterContext);
+	const normalizedOld = normalizeSnippet(oldLines);
+	const normalizedBefore = normalizeSnippet(beforeContext);
+	const normalizedAfter = normalizeSnippet(afterContext);
 
-  if (normalizedOld.length) {
-    const direct = seekSequence(content, normalizedOld);
-    const hasContext = normalizedBefore.length > 0 || normalizedAfter.length > 0;
-    if (direct !== null) {
-      if (!hasContext) {
-        return makeRangeFromMatch(direct, normalizedOld.length);
-      }
+	if (normalizedOld.length) {
+		const direct = seekSequence(content, normalizedOld);
+		const hasContext = normalizedBefore.length > 0 || normalizedAfter.length > 0;
+		if (direct !== null) {
+			if (!hasContext) {
+				return makeRangeFromMatch(direct, normalizedOld.length);
+			}
 
-      const secondaryMatch = seekSequence(content, normalizedOld, direct);
-      if (secondaryMatch === null) {
-        return makeRangeFromMatch(direct, normalizedOld.length);
-      }
-    }
+			const secondaryMatch = seekSequence(content, normalizedOld, direct);
+			if (secondaryMatch === null) {
+				return makeRangeFromMatch(direct, normalizedOld.length);
+			}
+		}
 
-    if (normalizedBefore.length) {
-      const beforeAnchor = seekSequence(content, normalizedBefore);
-      if (beforeAnchor !== null) {
-        const searchStart = beforeAnchor + normalizedBefore.length - 1;
-        const anchored = seekSequence(content, normalizedOld, Math.max(searchStart, 0));
-        if (anchored !== null) {
-          return makeRangeFromMatch(anchored, normalizedOld.length);
-        }
-      }
-    }
+		if (normalizedBefore.length) {
+			const beforeAnchor = seekSequence(content, normalizedBefore);
+			if (beforeAnchor !== null) {
+				const searchStart = beforeAnchor + normalizedBefore.length - 1;
+				const anchored = seekSequence(content, normalizedOld, Math.max(searchStart, 0));
+				if (anchored !== null) {
+					return makeRangeFromMatch(anchored, normalizedOld.length);
+				}
+			}
+		}
 
-    if (normalizedAfter.length) {
-      const afterAnchor = seekSequence(content, normalizedAfter);
-      if (afterAnchor !== null) {
-        const limitedContent = sliceContentUntilLine(content, Math.max(afterAnchor - 1, 0));
-        const limitedLines = limitedContent.split(/\r?\n/).map((line) => normalizeLine(line));
-        for (let idx = limitedLines.length - normalizedOld.length; idx >= 0; idx--) {
-          let match = true;
-          for (let offset = 0; offset < normalizedOld.length; offset++) {
-            if (limitedLines[idx + offset] !== normalizedOld[offset]) {
-              match = false;
-              break;
-            }
-          }
-          if (match) {
-            return makeRangeFromMatch(idx + 1, normalizedOld.length);
-          }
-        }
-      }
-    }
+		if (normalizedAfter.length) {
+			const afterAnchor = seekSequence(content, normalizedAfter);
+			if (afterAnchor !== null) {
+				const limitedContent = sliceContentUntilLine(content, Math.max(afterAnchor - 1, 0));
+				const limitedLines = limitedContent.split(/\r?\n/).map((line) => normalizeLine(line));
+				for (let idx = limitedLines.length - normalizedOld.length; idx >= 0; idx--) {
+					let match = true;
+					for (let offset = 0; offset < normalizedOld.length; offset++) {
+						if (limitedLines[idx + offset] !== normalizedOld[offset]) {
+							match = false;
+							break;
+						}
+					}
+					if (match) {
+						return makeRangeFromMatch(idx + 1, normalizedOld.length);
+					}
+				}
+			}
+		}
 
-    if (direct !== null) {
-      return makeRangeFromMatch(direct, normalizedOld.length);
-    }
+		if (direct !== null) {
+			return makeRangeFromMatch(direct, normalizedOld.length);
+		}
 
-    return null;
-  }
+		return null;
+	}
 
-  const beforeAnchor = normalizedBefore.length ? seekSequence(content, normalizedBefore) : null;
-  const afterAnchor = normalizedAfter.length ? seekSequence(content, normalizedAfter) : null;
+	const beforeAnchor = normalizedBefore.length ? seekSequence(content, normalizedBefore) : null;
+	const afterAnchor = normalizedAfter.length ? seekSequence(content, normalizedAfter) : null;
 
-  if (beforeAnchor !== null && afterAnchor !== null) {
-    const startLine = beforeAnchor + normalizedBefore.length;
-    const endLine = Math.max(startLine, afterAnchor - 1);
-    return {
-      startLine,
-      startColumn: 1,
-      endLine,
-      endColumn: 1,
-    };
-  }
+	if (beforeAnchor !== null && afterAnchor !== null) {
+		const startLine = beforeAnchor + normalizedBefore.length;
+		const endLine = Math.max(startLine, afterAnchor - 1);
+		return {
+			startLine,
+			startColumn: 1,
+			endLine,
+			endColumn: 1,
+		};
+	}
 
-  if (beforeAnchor !== null) {
-    const line = beforeAnchor + normalizedBefore.length;
-    return {
-      startLine: line,
-      startColumn: 1,
-      endLine: line,
-      endColumn: 1,
-    };
-  }
+	if (beforeAnchor !== null) {
+		const line = beforeAnchor + normalizedBefore.length;
+		return {
+			startLine: line,
+			startColumn: 1,
+			endLine: line,
+			endColumn: 1,
+		};
+	}
 
-  if (afterAnchor !== null) {
-    const line = Math.max(afterAnchor - 1, 1);
-    return {
-      startLine: line,
-      startColumn: 1,
-      endLine: line,
-      endColumn: 1,
-    };
-  }
+	if (afterAnchor !== null) {
+		const line = Math.max(afterAnchor - 1, 1);
+		return {
+			startLine: line,
+			startColumn: 1,
+			endLine: line,
+			endColumn: 1,
+		};
+	}
 
-  return null;
+	return null;
 }

--- a/client/src/core/ai/patchParser.ts
+++ b/client/src/core/ai/patchParser.ts
@@ -1,102 +1,101 @@
 export type PatchChunk = {
-  context?: string;
-  oldLines: string[];
-  newLines: string[];
+	context?: string;
+	oldLines: string[];
+	newLines: string[];
 };
 
 export type PatchHunk = {
-  type: 'add' | 'delete' | 'update';
-  filepath: string;
-  chunks: PatchChunk[];
+	type: "add" | "delete" | "update";
+	filepath: string;
+	chunks: PatchChunk[];
 };
 
 const fileHeaderRegex = /^\*\*\* (Update|Add|Delete) File:\s*(.+)$/;
 
 export function parsePatchFormat(text: string): PatchHunk[] {
-  const patchHunks: PatchHunk[] = [];
-  // Accept both "*** End Patch" and just "***" as end markers (AI sometimes outputs shortened version)
-  const blockRegex = /\*\*\* Begin Patch([\s\S]*?)(?:\*\*\* End Patch|\*\*\*(?:\s*$|\n))/g;
-  blockRegex.lastIndex = 0;
-  let match: RegExpExecArray | null;
+	const patchHunks: PatchHunk[] = [];
+	// Accept both "*** End Patch" and just "***" as end markers (AI sometimes outputs shortened version)
+	const blockRegex = /\*\*\* Begin Patch([\s\S]*?)(?:\*\*\* End Patch|\*\*\*(?:\s*$|\n))/g;
+	blockRegex.lastIndex = 0;
+	let match: RegExpExecArray | null;
 
-  while ((match = blockRegex.exec(text)) !== null) {
-    const block = match[1];
-    const lines = block.split(/\r?\n/);
-    let currentHunk: PatchHunk | null = null;
-    let currentChunk: PatchChunk | null = null;
+	while ((match = blockRegex.exec(text)) !== null) {
+		const block = match[1];
+		const lines = block.split(/\r?\n/);
+		let currentHunk: PatchHunk | null = null;
+		let currentChunk: PatchChunk | null = null;
 
-    const pushHunk = () => {
-      if (currentHunk) {
-        patchHunks.push(currentHunk);
-        currentHunk = null;
-        currentChunk = null;
-      }
-    };
+		const pushHunk = () => {
+			if (currentHunk) {
+				patchHunks.push(currentHunk);
+				currentHunk = null;
+				currentChunk = null;
+			}
+		};
 
-    const ensureChunk = (): PatchChunk | null => {
-      if (!currentHunk) {
-        return null;
-      }
-      if (!currentChunk) {
-        currentChunk = { oldLines: [], newLines: [] };
-        currentHunk.chunks.push(currentChunk);
-      }
-      return currentChunk;
-    };
+		const ensureChunk = (): PatchChunk | null => {
+			if (!currentHunk) {
+				return null;
+			}
+			if (!currentChunk) {
+				currentChunk = { oldLines: [], newLines: [] };
+				currentHunk.chunks.push(currentChunk);
+			}
+			return currentChunk;
+		};
 
-    for (const line of lines) {
-      const headerMatch = line.match(fileHeaderRegex);
-      if (headerMatch) {
-        pushHunk();
-        const [, action, filepath] = headerMatch;
-        const type =
-          action === 'Add' ? 'add' : action === 'Delete' ? 'delete' : 'update';
-        currentHunk = { type, filepath: filepath.trim(), chunks: [] };
-        continue;
-      }
+		for (const line of lines) {
+			const headerMatch = line.match(fileHeaderRegex);
+			if (headerMatch) {
+				pushHunk();
+				const [, action, filepath] = headerMatch;
+				const type = action === "Add" ? "add" : action === "Delete" ? "delete" : "update";
+				currentHunk = { type, filepath: filepath.trim(), chunks: [] };
+				continue;
+			}
 
-      if (!currentHunk) {
-        continue;
-      }
+			if (!currentHunk) {
+				continue;
+			}
 
-      if (line.startsWith('@@')) {
-        currentChunk = {
-          context: line,
-          oldLines: [],
-          newLines: [],
-        };
-        currentHunk.chunks.push(currentChunk);
-        continue;
-      }
+			if (line.startsWith("@@")) {
+				currentChunk = {
+					context: line,
+					oldLines: [],
+					newLines: [],
+				};
+				currentHunk.chunks.push(currentChunk);
+				continue;
+			}
 
-      const chunk = ensureChunk();
-      if (!chunk) {
-        continue;
-      }
+			const chunk = ensureChunk();
+			if (!chunk) {
+				continue;
+			}
 
-      if (line.startsWith('-')) {
-        chunk.oldLines.push(line.slice(1));
-        continue;
-      }
+			if (line.startsWith("-")) {
+				chunk.oldLines.push(line.slice(1));
+				continue;
+			}
 
-      if (line.startsWith('+')) {
-        chunk.newLines.push(line.slice(1));
-        continue;
-      }
+			if (line.startsWith("+")) {
+				chunk.newLines.push(line.slice(1));
+				continue;
+			}
 
-      if (line.startsWith(' ')) {
-        const context = line.slice(1);
-        chunk.oldLines.push(context);
-        chunk.newLines.push(context);
-        continue;
-      }
+			if (line.startsWith(" ")) {
+				const context = line.slice(1);
+				chunk.oldLines.push(context);
+				chunk.newLines.push(context);
+				continue;
+			}
 
-      chunk.oldLines.push(line);
-      chunk.newLines.push(line);
-    }
+			chunk.oldLines.push(line);
+			chunk.newLines.push(line);
+		}
 
-    pushHunk();
-  }
+		pushHunk();
+	}
 
-  return patchHunks;
+	return patchHunks;
 }

--- a/client/src/core/ai/promptUtils.ts
+++ b/client/src/core/ai/promptUtils.ts
@@ -1,47 +1,47 @@
-import type { ExecutionLogEntry } from '@shared/types';
+import type { ExecutionLogEntry } from "@shared/types";
 
 /**
  * Set of code change actions that should be applied to remote files
  * rather than the current editor buffer
  */
-export const REMOTE_FILE_ACTIONS = new Set(['create-file', 'delete-range', 'replace-range']);
+export const REMOTE_FILE_ACTIONS = new Set(["create-file", "delete-range", "replace-range"]);
 
 const MAX_CONSOLE_ITEMS = 3;
 const MAX_CONSOLE_SNIPPET_LENGTH = 800;
 
 const truncateText = (value: string, maxLength: number): string =>
-  value.length > maxLength ? `${value.slice(0, maxLength)}... (truncated)` : value;
+	value.length > maxLength ? `${value.slice(0, maxLength)}... (truncated)` : value;
 
 const formatConsoleEntry = (entry: ExecutionLogEntry): string => {
-  const lines = [
-    `- [${new Date(entry.timestamp).toLocaleString()}] ${entry.success ? 'success' : 'error'} in ${entry.duration}ms`,
-  ];
+	const lines = [
+		`- [${new Date(entry.timestamp).toLocaleString()}] ${entry.success ? "success" : "error"} in ${entry.duration}ms`,
+	];
 
-  if (entry.stdout?.trim()) {
-    lines.push(`stdout: ${truncateText(entry.stdout.trim(), MAX_CONSOLE_SNIPPET_LENGTH)}`);
-  }
+	if (entry.stdout?.trim()) {
+		lines.push(`stdout: ${truncateText(entry.stdout.trim(), MAX_CONSOLE_SNIPPET_LENGTH)}`);
+	}
 
-  if (entry.stderr?.trim()) {
-    lines.push(`stderr: ${truncateText(entry.stderr.trim(), MAX_CONSOLE_SNIPPET_LENGTH)}`);
-  }
+	if (entry.stderr?.trim()) {
+		lines.push(`stderr: ${truncateText(entry.stderr.trim(), MAX_CONSOLE_SNIPPET_LENGTH)}`);
+	}
 
-  if (entry.plots.length > 0) {
-    const plotPaths = entry.plots.map((plot) => plot.path).filter(Boolean);
-    const suffix = plotPaths.length ? ` (${plotPaths.slice(0, 3).join(', ')})` : '';
-    lines.push(`plots: ${entry.plots.length}${suffix}`);
-  }
+	if (entry.plots.length > 0) {
+		const plotPaths = entry.plots.map((plot) => plot.path).filter(Boolean);
+		const suffix = plotPaths.length ? ` (${plotPaths.slice(0, 3).join(", ")})` : "";
+		lines.push(`plots: ${entry.plots.length}${suffix}`);
+	}
 
-  return lines.join('\n');
+	return lines.join("\n");
 };
 
 const buildConsoleContext = (history: ExecutionLogEntry[] = []): string => {
-  if (history.length === 0) {
-    return '';
-  }
+	if (history.length === 0) {
+		return "";
+	}
 
-  const recent = history.slice(-MAX_CONSOLE_ITEMS).reverse();
-  const formatted = recent.map(formatConsoleEntry).join('\n\n');
-  return `Recent console output (newest first, truncated):\n${formatted}\n\n`;
+	const recent = history.slice(-MAX_CONSOLE_ITEMS).reverse();
+	const formatted = recent.map(formatConsoleEntry).join("\n\n");
+	return `Recent console output (newest first, truncated):\n${formatted}\n\n`;
 };
 
 /**
@@ -49,14 +49,14 @@ const buildConsoleContext = (history: ExecutionLogEntry[] = []): string => {
  * and the user's input
  */
 export const buildPromptWithContext = (
-  filepath: string,
-  editorContent: string,
-  userInput: string,
-  consoleHistory: ExecutionLogEntry[] = [],
+	filepath: string,
+	editorContent: string,
+	userInput: string,
+	consoleHistory: ExecutionLogEntry[] = [],
 ): string => {
-  const fileLabel = filepath || 'current editor buffer';
-  const consoleContext = buildConsoleContext(consoleHistory);
-  return `${consoleContext}Current file (${fileLabel}):\n\n\`\`\`r\n${editorContent}\n\`\`\`\n\n${userInput}`;
+	const fileLabel = filepath || "current editor buffer";
+	const consoleContext = buildConsoleContext(consoleHistory);
+	return `${consoleContext}Current file (${fileLabel}):\n\n\`\`\`r\n${editorContent}\n\`\`\`\n\n${userInput}`;
 };
 
 /**
@@ -64,8 +64,11 @@ export const buildPromptWithContext = (
  * Uses crypto.randomUUID if available, otherwise falls back to timestamp-based ID
  */
 export const createRequestId = (): string => {
-  if (typeof globalThis.crypto !== 'undefined' && typeof globalThis.crypto.randomUUID === 'function') {
-    return globalThis.crypto.randomUUID();
-  }
-  return `req-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+	if (
+		typeof globalThis.crypto !== "undefined" &&
+		typeof globalThis.crypto.randomUUID === "function"
+	) {
+		return globalThis.crypto.randomUUID();
+	}
+	return `req-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 };

--- a/client/src/core/ai/simpleChangeParser.ts
+++ b/client/src/core/ai/simpleChangeParser.ts
@@ -1,128 +1,128 @@
-import type { SimpleCodeChange } from '@shared/types';
+import type { SimpleCodeChange } from "@shared/types";
 
 const CODE_FENCE_REGEX = /```[a-zA-Z0-9_-]*\n([\s\S]*?)```/g;
 
-const sanitizeLine = (line: string): string => line.replace(/\r$/, '');
+const sanitizeLine = (line: string): string => line.replace(/\r$/, "");
 
 const normalizeBlock = (value: string): string[] => {
-  const lines = value
-    .split(/\r?\n/)
-    .map(sanitizeLine)
-    .map((line) => line.replace(/^```.*$/, '').trimEnd());
+	const lines = value
+		.split(/\r?\n/)
+		.map(sanitizeLine)
+		.map((line) => line.replace(/^```.*$/, "").trimEnd());
 
-  while (lines.length && !lines[0].trim()) {
-    lines.shift();
-  }
-  while (lines.length && !lines[lines.length - 1].trim()) {
-    lines.pop();
-  }
-  return lines;
+	while (lines.length && !lines[0].trim()) {
+		lines.shift();
+	}
+	while (lines.length && !lines[lines.length - 1].trim()) {
+		lines.pop();
+	}
+	return lines;
 };
 
 const parseDiffBlock = (block: string): SimpleCodeChange | null => {
-  const lines = normalizeBlock(block);
-  const diffLineIndexes = lines
-    .map((line, index) => ({ index, line }))
-    .filter(({ line }) => line.startsWith('-') || line.startsWith('+'));
+	const lines = normalizeBlock(block);
+	const diffLineIndexes = lines
+		.map((line, index) => ({ index, line }))
+		.filter(({ line }) => line.startsWith("-") || line.startsWith("+"));
 
-  if (!diffLineIndexes.length) {
-    return null;
-  }
+	if (!diffLineIndexes.length) {
+		return null;
+	}
 
-  const hasAdditions = diffLineIndexes.some(({ line }) => line.startsWith('+'));
-  const hasRemovals = diffLineIndexes.some(({ line }) => line.startsWith('-'));
+	const hasAdditions = diffLineIndexes.some(({ line }) => line.startsWith("+"));
+	const hasRemovals = diffLineIndexes.some(({ line }) => line.startsWith("-"));
 
-  if (!hasAdditions || !hasRemovals) {
-    return null;
-  }
+	if (!hasAdditions || !hasRemovals) {
+		return null;
+	}
 
-  const firstDiff = diffLineIndexes[0].index;
-  const lastDiff = diffLineIndexes[diffLineIndexes.length - 1].index;
+	const firstDiff = diffLineIndexes[0].index;
+	const lastDiff = diffLineIndexes[diffLineIndexes.length - 1].index;
 
-  const beforeContext = lines.slice(0, firstDiff).filter((line) => line.trim().length > 0);
-  const afterContext = lines.slice(lastDiff + 1).filter((line) => line.trim().length > 0);
+	const beforeContext = lines.slice(0, firstDiff).filter((line) => line.trim().length > 0);
+	const afterContext = lines.slice(lastDiff + 1).filter((line) => line.trim().length > 0);
 
-  const oldLines: string[] = [];
-  const newLines: string[] = [];
+	const oldLines: string[] = [];
+	const newLines: string[] = [];
 
-  for (let idx = firstDiff; idx <= lastDiff; idx++) {
-    const line = lines[idx];
-    if (line.startsWith('-')) {
-      oldLines.push(line.slice(1));
-      continue;
-    }
-    if (line.startsWith('+')) {
-      newLines.push(line.slice(1));
-      continue;
-    }
-    // Treat neutral lines (including blanks) within the diff span as shared context
-    oldLines.push(line.startsWith(' ') ? line.slice(1) : line);
-    newLines.push(line.startsWith(' ') ? line.slice(1) : line);
-  }
+	for (let idx = firstDiff; idx <= lastDiff; idx++) {
+		const line = lines[idx];
+		if (line.startsWith("-")) {
+			oldLines.push(line.slice(1));
+			continue;
+		}
+		if (line.startsWith("+")) {
+			newLines.push(line.slice(1));
+			continue;
+		}
+		// Treat neutral lines (including blanks) within the diff span as shared context
+		oldLines.push(line.startsWith(" ") ? line.slice(1) : line);
+		newLines.push(line.startsWith(" ") ? line.slice(1) : line);
+	}
 
-  if (!oldLines.length && !newLines.length) {
-    return null;
-  }
+	if (!oldLines.length && !newLines.length) {
+		return null;
+	}
 
-  return {
-    beforeContext,
-    afterContext,
-    oldLines,
-    newLines,
-  };
+	return {
+		beforeContext,
+		afterContext,
+		oldLines,
+		newLines,
+	};
 };
 
 const gatherSegments = (text: string, ranges: Array<{ start: number; end: number }>): string[] => {
-  if (!ranges.length) {
-    return [text];
-  }
+	if (!ranges.length) {
+		return [text];
+	}
 
-  const segments: string[] = [];
-  let cursor = 0;
-  for (const range of ranges) {
-    if (cursor < range.start) {
-      segments.push(text.slice(cursor, range.start));
-    }
-    cursor = range.end;
-  }
+	const segments: string[] = [];
+	let cursor = 0;
+	for (const range of ranges) {
+		if (cursor < range.start) {
+			segments.push(text.slice(cursor, range.start));
+		}
+		cursor = range.end;
+	}
 
-  if (cursor < text.length) {
-    segments.push(text.slice(cursor));
-  }
+	if (cursor < text.length) {
+		segments.push(text.slice(cursor));
+	}
 
-  return segments.filter((segment) => segment.trim().length > 0);
+	return segments.filter((segment) => segment.trim().length > 0);
 };
 
 export function parseSimpleChanges(text: string): SimpleCodeChange[] {
-  CODE_FENCE_REGEX.lastIndex = 0;
-  const changes: SimpleCodeChange[] = [];
-  const fenceRanges: Array<{ start: number; end: number }> = [];
+	CODE_FENCE_REGEX.lastIndex = 0;
+	const changes: SimpleCodeChange[] = [];
+	const fenceRanges: Array<{ start: number; end: number }> = [];
 
-  let match: RegExpExecArray | null;
-  while ((match = CODE_FENCE_REGEX.exec(text)) !== null) {
-    const [fullMatch, body] = match;
-    const range = { start: match.index, end: match.index + fullMatch.length };
-    fenceRanges.push(range);
+	let match: RegExpExecArray | null;
+	while ((match = CODE_FENCE_REGEX.exec(text)) !== null) {
+		const [fullMatch, body] = match;
+		const range = { start: match.index, end: match.index + fullMatch.length };
+		fenceRanges.push(range);
 
-    const change = parseDiffBlock(body);
-    if (change) {
-      changes.push(change);
-    }
-  }
+		const change = parseDiffBlock(body);
+		if (change) {
+			changes.push(change);
+		}
+	}
 
-  const remainingSegments = gatherSegments(text, fenceRanges);
-  for (const segment of remainingSegments) {
-    const chunks = segment.split(/\n{2,}/);
-    for (const chunk of chunks) {
-      if (!chunk.trim().length) {
-        continue;
-      }
-      const change = parseDiffBlock(chunk);
-      if (change) {
-        changes.push(change);
-      }
-    }
-  }
+	const remainingSegments = gatherSegments(text, fenceRanges);
+	for (const segment of remainingSegments) {
+		const chunks = segment.split(/\n{2,}/);
+		for (const chunk of chunks) {
+			if (!chunk.trim().length) {
+				continue;
+			}
+			const change = parseDiffBlock(chunk);
+			if (change) {
+				changes.push(change);
+			}
+		}
+	}
 
-  return changes;
+	return changes;
 }

--- a/client/src/core/execution/__tests__/cellExecution.test.ts
+++ b/client/src/core/execution/__tests__/cellExecution.test.ts
@@ -1,215 +1,215 @@
-import { describe, it, expect, vi } from 'vitest';
-import { getExecutionTarget, getExecutionTargetAndNext, getAllCode } from '../cellExecution';
-import type { Cell } from '../cellParser';
-import type { editor as MonacoEditor } from 'monaco-editor';
+import type { editor as MonacoEditor } from "monaco-editor";
+import { describe, expect, it, vi } from "vitest";
+import { getAllCode, getExecutionTarget, getExecutionTargetAndNext } from "../cellExecution";
+import type { Cell } from "../cellParser";
 
-describe('cellExecution', () => {
-  const mockCells: Cell[] = [
-    {
-      startLine: 1,
-      endLine: 3,
-      code: 'x <- 1\ny <- 2\nz <- x + y',
-      type: 'section',
-      label: 'Cell 1'
-    },
-    {
-      startLine: 5,
-      endLine: 7,
-      code: 'a <- 10\nb <- 20\nc <- a + b',
-      type: 'section',
-      label: 'Cell 2'
-    }
-  ];
+describe("cellExecution", () => {
+	const mockCells: Cell[] = [
+		{
+			startLine: 1,
+			endLine: 3,
+			code: "x <- 1\ny <- 2\nz <- x + y",
+			type: "section",
+			label: "Cell 1",
+		},
+		{
+			startLine: 5,
+			endLine: 7,
+			code: "a <- 10\nb <- 20\nc <- a + b",
+			type: "section",
+			label: "Cell 2",
+		},
+	];
 
-  describe('getExecutionTarget', () => {
-    it('should prioritize text selection over cell', () => {
-      const mockEditor = {
-        getSelection: vi.fn().mockReturnValue({
-          isEmpty: () => false,
-          startLineNumber: 4,
-          endLineNumber: 5
-        }),
-        getModel: vi.fn().mockReturnValue({
-          getValueInRange: vi.fn().mockReturnValue('selected text')
-        })
-      } as unknown as MonacoEditor.IStandaloneCodeEditor;
+	describe("getExecutionTarget", () => {
+		it("should prioritize text selection over cell", () => {
+			const mockEditor = {
+				getSelection: vi.fn().mockReturnValue({
+					isEmpty: () => false,
+					startLineNumber: 4,
+					endLineNumber: 5,
+				}),
+				getModel: vi.fn().mockReturnValue({
+					getValueInRange: vi.fn().mockReturnValue("selected text"),
+				}),
+			} as unknown as MonacoEditor.IStandaloneCodeEditor;
 
-      const result = getExecutionTarget(mockEditor, mockCells, 2);
+			const result = getExecutionTarget(mockEditor, mockCells, 2);
 
-      expect(result).toEqual({
-        code: 'selected text',
-        cellIndex: undefined,
-        source: 'selection',
-        range: {
-          startLine: 4,
-          endLine: 5
-        }
-      });
-    });
+			expect(result).toEqual({
+				code: "selected text",
+				cellIndex: undefined,
+				source: "selection",
+				range: {
+					startLine: 4,
+					endLine: 5,
+				},
+			});
+		});
 
-    it('should execute current cell when no selection', () => {
-      const mockEditor = {
-        getSelection: vi.fn().mockReturnValue({
-          isEmpty: () => true
-        })
-      } as unknown as MonacoEditor.IStandaloneCodeEditor;
+		it("should execute current cell when no selection", () => {
+			const mockEditor = {
+				getSelection: vi.fn().mockReturnValue({
+					isEmpty: () => true,
+				}),
+			} as unknown as MonacoEditor.IStandaloneCodeEditor;
 
-      const result = getExecutionTarget(mockEditor, mockCells, 2);
+			const result = getExecutionTarget(mockEditor, mockCells, 2);
 
-      expect(result).toEqual({
-        code: 'x <- 1\ny <- 2\nz <- x + y',
-        cellIndex: 0,
-        source: 'cell'
-      });
-    });
+			expect(result).toEqual({
+				code: "x <- 1\ny <- 2\nz <- x + y",
+				cellIndex: 0,
+				source: "cell",
+			});
+		});
 
-    it('should execute whole document when no cells', () => {
-      const mockEditor = {
-        getSelection: vi.fn().mockReturnValue({
-          isEmpty: () => true
-        }),
-        getValue: vi.fn().mockReturnValue('whole document code')
-      } as unknown as MonacoEditor.IStandaloneCodeEditor;
+		it("should execute whole document when no cells", () => {
+			const mockEditor = {
+				getSelection: vi.fn().mockReturnValue({
+					isEmpty: () => true,
+				}),
+				getValue: vi.fn().mockReturnValue("whole document code"),
+			} as unknown as MonacoEditor.IStandaloneCodeEditor;
 
-      const result = getExecutionTarget(mockEditor, [], 1);
+			const result = getExecutionTarget(mockEditor, [], 1);
 
-      expect(result).toEqual({
-        code: 'whole document code',
-        cellIndex: undefined,
-        source: 'whole-document'
-      });
-    });
+			expect(result).toEqual({
+				code: "whole document code",
+				cellIndex: undefined,
+				source: "whole-document",
+			});
+		});
 
-    it('should execute cell when editor is null but cells exist', () => {
-      const result = getExecutionTarget(null, mockCells, 2);
+		it("should execute cell when editor is null but cells exist", () => {
+			const result = getExecutionTarget(null, mockCells, 2);
 
-      // Should fall back to cell execution
-      expect(result).toEqual({
-        code: 'x <- 1\ny <- 2\nz <- x + y',
-        cellIndex: 0,
-        source: 'cell'
-      });
-    });
+			// Should fall back to cell execution
+			expect(result).toEqual({
+				code: "x <- 1\ny <- 2\nz <- x + y",
+				cellIndex: 0,
+				source: "cell",
+			});
+		});
 
-    it('should return null when editor is null and no cells', () => {
-      const result = getExecutionTarget(null, [], 1);
+		it("should return null when editor is null and no cells", () => {
+			const result = getExecutionTarget(null, [], 1);
 
-      expect(result).toBeNull();
-    });
+			expect(result).toBeNull();
+		});
 
-    it('should ignore empty selection', () => {
-      const mockEditor = {
-        getSelection: vi.fn().mockReturnValue({
-          isEmpty: () => false,
-          startLineNumber: 3,
-          endLineNumber: 3
-        }),
-        getModel: vi.fn().mockReturnValue({
-          getValueInRange: vi.fn().mockReturnValue('   ')
-        })
-      } as unknown as MonacoEditor.IStandaloneCodeEditor;
+		it("should ignore empty selection", () => {
+			const mockEditor = {
+				getSelection: vi.fn().mockReturnValue({
+					isEmpty: () => false,
+					startLineNumber: 3,
+					endLineNumber: 3,
+				}),
+				getModel: vi.fn().mockReturnValue({
+					getValueInRange: vi.fn().mockReturnValue("   "),
+				}),
+			} as unknown as MonacoEditor.IStandaloneCodeEditor;
 
-      const result = getExecutionTarget(mockEditor, mockCells, 2);
+			const result = getExecutionTarget(mockEditor, mockCells, 2);
 
-      expect(result).toEqual({
-        code: 'x <- 1\ny <- 2\nz <- x + y',
-        cellIndex: 0,
-        source: 'cell'
-      });
-    });
-  });
+			expect(result).toEqual({
+				code: "x <- 1\ny <- 2\nz <- x + y",
+				cellIndex: 0,
+				source: "cell",
+			});
+		});
+	});
 
-  describe('getExecutionTargetAndNext', () => {
-    it('should return next cell when executing a cell', () => {
-      const mockEditor = {
-        getSelection: vi.fn().mockReturnValue({
-          isEmpty: () => true
-        })
-      } as unknown as MonacoEditor.IStandaloneCodeEditor;
+	describe("getExecutionTargetAndNext", () => {
+		it("should return next cell when executing a cell", () => {
+			const mockEditor = {
+				getSelection: vi.fn().mockReturnValue({
+					isEmpty: () => true,
+				}),
+			} as unknown as MonacoEditor.IStandaloneCodeEditor;
 
-      const result = getExecutionTargetAndNext(mockEditor, mockCells, 2);
+			const result = getExecutionTargetAndNext(mockEditor, mockCells, 2);
 
-      expect(result).toEqual({
-        target: {
-          code: 'x <- 1\ny <- 2\nz <- x + y',
-          cellIndex: 0,
-          source: 'cell'
-        },
-        nextCell: mockCells[1]
-      });
-    });
+			expect(result).toEqual({
+				target: {
+					code: "x <- 1\ny <- 2\nz <- x + y",
+					cellIndex: 0,
+					source: "cell",
+				},
+				nextCell: mockCells[1],
+			});
+		});
 
-    it('should not return next cell when executing selection', () => {
-      const mockEditor = {
-        getSelection: vi.fn().mockReturnValue({
-          isEmpty: () => false,
-          startLineNumber: 3,
-          endLineNumber: 3
-        }),
-        getModel: vi.fn().mockReturnValue({
-          getValueInRange: vi.fn().mockReturnValue('selected text')
-        })
-      } as unknown as MonacoEditor.IStandaloneCodeEditor;
+		it("should not return next cell when executing selection", () => {
+			const mockEditor = {
+				getSelection: vi.fn().mockReturnValue({
+					isEmpty: () => false,
+					startLineNumber: 3,
+					endLineNumber: 3,
+				}),
+				getModel: vi.fn().mockReturnValue({
+					getValueInRange: vi.fn().mockReturnValue("selected text"),
+				}),
+			} as unknown as MonacoEditor.IStandaloneCodeEditor;
 
-      const result = getExecutionTargetAndNext(mockEditor, mockCells, 2);
+			const result = getExecutionTargetAndNext(mockEditor, mockCells, 2);
 
-      expect(result).toEqual({
-        target: {
-          code: 'selected text',
-          cellIndex: undefined,
-          source: 'selection',
-          range: {
-            startLine: 3,
-            endLine: 3
-          }
-        }
-      });
-    });
+			expect(result).toEqual({
+				target: {
+					code: "selected text",
+					cellIndex: undefined,
+					source: "selection",
+					range: {
+						startLine: 3,
+						endLine: 3,
+					},
+				},
+			});
+		});
 
-    it('should not return next cell when on last cell', () => {
-      const mockEditor = {
-        getSelection: vi.fn().mockReturnValue({
-          isEmpty: () => true
-        })
-      } as unknown as MonacoEditor.IStandaloneCodeEditor;
+		it("should not return next cell when on last cell", () => {
+			const mockEditor = {
+				getSelection: vi.fn().mockReturnValue({
+					isEmpty: () => true,
+				}),
+			} as unknown as MonacoEditor.IStandaloneCodeEditor;
 
-      const result = getExecutionTargetAndNext(mockEditor, mockCells, 6);
+			const result = getExecutionTargetAndNext(mockEditor, mockCells, 6);
 
-      expect(result).toEqual({
-        target: {
-          code: 'a <- 10\nb <- 20\nc <- a + b',
-          cellIndex: 1,
-          source: 'cell'
-        }
-      });
-    });
-  });
+			expect(result).toEqual({
+				target: {
+					code: "a <- 10\nb <- 20\nc <- a + b",
+					cellIndex: 1,
+					source: "cell",
+				},
+			});
+		});
+	});
 
-  describe('getAllCode', () => {
-    it('should return all code from editor', () => {
-      const mockEditor = {
-        getValue: vi.fn().mockReturnValue('all code content')
-      } as unknown as MonacoEditor.IStandaloneCodeEditor;
+	describe("getAllCode", () => {
+		it("should return all code from editor", () => {
+			const mockEditor = {
+				getValue: vi.fn().mockReturnValue("all code content"),
+			} as unknown as MonacoEditor.IStandaloneCodeEditor;
 
-      const result = getAllCode(mockEditor);
+			const result = getAllCode(mockEditor);
 
-      expect(result).toBe('all code content');
-    });
+			expect(result).toBe("all code content");
+		});
 
-    it('should return null when editor is null', () => {
-      const result = getAllCode(null);
+		it("should return null when editor is null", () => {
+			const result = getAllCode(null);
 
-      expect(result).toBeNull();
-    });
+			expect(result).toBeNull();
+		});
 
-    it('should return null when content is empty', () => {
-      const mockEditor = {
-        getValue: vi.fn().mockReturnValue('   ')
-      } as unknown as MonacoEditor.IStandaloneCodeEditor;
+		it("should return null when content is empty", () => {
+			const mockEditor = {
+				getValue: vi.fn().mockReturnValue("   "),
+			} as unknown as MonacoEditor.IStandaloneCodeEditor;
 
-      const result = getAllCode(mockEditor);
+			const result = getAllCode(mockEditor);
 
-      expect(result).toBeNull();
-    });
-  });
+			expect(result).toBeNull();
+		});
+	});
 });

--- a/client/src/core/execution/__tests__/requestBuilder.test.ts
+++ b/client/src/core/execution/__tests__/requestBuilder.test.ts
@@ -1,106 +1,106 @@
-import { describe, expect, it } from 'vitest';
-import { buildExecutionRequest } from '../requestBuilder';
-import type { ExecutionTarget } from '../cellExecution';
-import type { Cell } from '../cellParser';
+import { describe, expect, it } from "vitest";
+import type { ExecutionTarget } from "../cellExecution";
+import type { Cell } from "../cellParser";
+import { buildExecutionRequest } from "../requestBuilder";
 
 const stubIdFactory = (() => {
-  let counter = 0;
-  return () => {
-    counter += 1;
-    return `block-${counter}`;
-  };
+	let counter = 0;
+	return () => {
+		counter += 1;
+		return `block-${counter}`;
+	};
 })();
 
-describe('buildExecutionRequest', () => {
-  const baseCells: Cell[] = [
-    {
-      startLine: 1,
-      endLine: 3,
-      code: "# Setup ----\nprint('setup')",
-      type: 'section',
-      label: 'Setup'
-    },
-    {
-      startLine: 4,
-      endLine: 6,
-      code: "# Plot ----\nplot(1:10)",
-      type: 'section',
-      label: 'Plot'
-    }
-  ];
+describe("buildExecutionRequest", () => {
+	const baseCells: Cell[] = [
+		{
+			startLine: 1,
+			endLine: 3,
+			code: "# Setup ----\nprint('setup')",
+			type: "section",
+			label: "Setup",
+		},
+		{
+			startLine: 4,
+			endLine: 6,
+			code: "# Plot ----\nplot(1:10)",
+			type: "section",
+			label: "Plot",
+		},
+	];
 
-  it('creates a request for cell execution', () => {
-    const target: ExecutionTarget = {
-      code: "print('setup')",
-      cellIndex: 0,
-      source: 'cell'
-    };
+	it("creates a request for cell execution", () => {
+		const target: ExecutionTarget = {
+			code: "print('setup')",
+			cellIndex: 0,
+			source: "cell",
+		};
 
-    const request = buildExecutionRequest({
-      target,
-      cells: baseCells,
-      documentContent: baseCells.map((cell) => cell.code).join('\n'),
-      filepath: 'analysis.R',
-      idFactory: stubIdFactory
-    });
+		const request = buildExecutionRequest({
+			target,
+			cells: baseCells,
+			documentContent: baseCells.map((cell) => cell.code).join("\n"),
+			filepath: "analysis.R",
+			idFactory: stubIdFactory,
+		});
 
-    expect(request.context.source).toBe('cell');
-    expect(request.context.document_path).toBe('analysis.R');
-    expect(request.blocks).toHaveLength(1);
-    expect(request.blocks[0]).toMatchObject({
-      id: 'block-1',
-      kind: 'section',
-      label: 'Setup',
-      start_line: 1,
-      end_line: 3,
-      code: "print('setup')"
-    });
-  });
+		expect(request.context.source).toBe("cell");
+		expect(request.context.document_path).toBe("analysis.R");
+		expect(request.blocks).toHaveLength(1);
+		expect(request.blocks[0]).toMatchObject({
+			id: "block-1",
+			kind: "section",
+			label: "Setup",
+			start_line: 1,
+			end_line: 3,
+			code: "print('setup')",
+		});
+	});
 
-  it('captures selection metadata when executing highlighted code', () => {
-    const target: ExecutionTarget = {
-      code: 'mean(x)',
-      source: 'selection',
-      range: { startLine: 5, endLine: 5 }
-    };
+	it("captures selection metadata when executing highlighted code", () => {
+		const target: ExecutionTarget = {
+			code: "mean(x)",
+			source: "selection",
+			range: { startLine: 5, endLine: 5 },
+		};
 
-    const request = buildExecutionRequest({
-      target,
-      cells: baseCells,
-      documentContent: baseCells.map((cell) => cell.code).join('\n'),
-      idFactory: stubIdFactory
-    });
+		const request = buildExecutionRequest({
+			target,
+			cells: baseCells,
+			documentContent: baseCells.map((cell) => cell.code).join("\n"),
+			idFactory: stubIdFactory,
+		});
 
-    expect(request.context.source).toBe('selection');
-    expect(request.blocks).toHaveLength(1);
-    expect(request.blocks[0]).toMatchObject({
-      kind: 'selection',
-      start_line: 5,
-      end_line: 5,
-      code: 'mean(x)'
-    });
-  });
+		expect(request.context.source).toBe("selection");
+		expect(request.blocks).toHaveLength(1);
+		expect(request.blocks[0]).toMatchObject({
+			kind: "selection",
+			start_line: 5,
+			end_line: 5,
+			code: "mean(x)",
+		});
+	});
 
-  it('falls back to document block when no cells available', () => {
-    const target: ExecutionTarget = {
-      code: 'x <- 1:10\nsummary(x)',
-      source: 'whole-document'
-    };
+	it("falls back to document block when no cells available", () => {
+		const target: ExecutionTarget = {
+			code: "x <- 1:10\nsummary(x)",
+			source: "whole-document",
+		};
 
-    const request = buildExecutionRequest({
-      target,
-      cells: [],
-      documentContent: target.code,
-      idFactory: stubIdFactory
-    });
+		const request = buildExecutionRequest({
+			target,
+			cells: [],
+			documentContent: target.code,
+			idFactory: stubIdFactory,
+		});
 
-    expect(request.context.source).toBe('whole_document');
-    expect(request.blocks).toHaveLength(1);
-    expect(request.blocks[0]).toMatchObject({
-      kind: 'document',
-      start_line: 1,
-      end_line: 2,
-      code: target.code
-    });
-  });
+		expect(request.context.source).toBe("whole_document");
+		expect(request.blocks).toHaveLength(1);
+		expect(request.blocks[0]).toMatchObject({
+			kind: "document",
+			start_line: 1,
+			end_line: 2,
+			code: target.code,
+		});
+	});
 });

--- a/client/src/core/execution/cellExecution.ts
+++ b/client/src/core/execution/cellExecution.ts
@@ -1,26 +1,26 @@
-import type { editor as MonacoEditor } from 'monaco-editor';
-import type { Cell } from './cellParser';
-import { getCurrentCell, getCellCode } from './cellParser';
+import type { editor as MonacoEditor } from "monaco-editor";
+import type { Cell } from "./cellParser";
+import { getCellCode, getCurrentCell } from "./cellParser";
 
 /**
  * Represents what code should be executed and its context
  */
 export interface ExecutionTarget {
-  code: string;
-  cellIndex?: number; // undefined for selection/whole document
-  source: 'selection' | 'cell' | 'whole-document';
-  range?: {
-    startLine: number;
-    endLine: number;
-  };
+	code: string;
+	cellIndex?: number; // undefined for selection/whole document
+	source: "selection" | "cell" | "whole-document";
+	range?: {
+		startLine: number;
+		endLine: number;
+	};
 }
 
 /**
  * Result of getExecutionTargetAndNext
  */
 export interface ExecutionTargetWithNext {
-  target: ExecutionTarget;
-  nextCell?: Cell;
+	target: ExecutionTarget;
+	nextCell?: Cell;
 }
 
 /**
@@ -37,57 +37,57 @@ export interface ExecutionTargetWithNext {
  * @returns ExecutionTarget or null if nothing to execute
  */
 export function getExecutionTarget(
-  monacoEditor: MonacoEditor.IStandaloneCodeEditor | null,
-  cells: Cell[],
-  cursorLine: number
+	monacoEditor: MonacoEditor.IStandaloneCodeEditor | null,
+	cells: Cell[],
+	cursorLine: number,
 ): ExecutionTarget | null {
-  // Priority 1: Text selection
-  if (monacoEditor) {
-    const selection = monacoEditor.getSelection();
-    if (selection && !selection.isEmpty()) {
-      const model = monacoEditor.getModel();
-      const selectedText = model?.getValueInRange(selection);
-      if (selectedText && selectedText.trim()) {
-        return {
-          code: selectedText,
-          cellIndex: undefined,
-          source: 'selection',
-          range: {
-            startLine: selection.startLineNumber,
-            endLine: selection.endLineNumber
-          }
-        };
-      }
-    }
-  }
+	// Priority 1: Text selection
+	if (monacoEditor) {
+		const selection = monacoEditor.getSelection();
+		if (selection && !selection.isEmpty()) {
+			const model = monacoEditor.getModel();
+			const selectedText = model?.getValueInRange(selection);
+			if (selectedText && selectedText.trim()) {
+				return {
+					code: selectedText,
+					cellIndex: undefined,
+					source: "selection",
+					range: {
+						startLine: selection.startLineNumber,
+						endLine: selection.endLineNumber,
+					},
+				};
+			}
+		}
+	}
 
-  // Priority 2: Current cell
-  if (cells.length > 0) {
-    const currentCell = getCurrentCell(cells, cursorLine);
-    if (currentCell) {
-      const cellIndex = cells.indexOf(currentCell);
-      const code = getCellCode(currentCell);
-      return {
-        code,
-        cellIndex,
-        source: 'cell'
-      };
-    }
-  }
+	// Priority 2: Current cell
+	if (cells.length > 0) {
+		const currentCell = getCurrentCell(cells, cursorLine);
+		if (currentCell) {
+			const cellIndex = cells.indexOf(currentCell);
+			const code = getCellCode(currentCell);
+			return {
+				code,
+				cellIndex,
+				source: "cell",
+			};
+		}
+	}
 
-  // Priority 3: Whole document
-  if (monacoEditor) {
-    const wholeContent = monacoEditor.getValue();
-    if (wholeContent.trim()) {
-      return {
-        code: wholeContent,
-        cellIndex: undefined,
-        source: 'whole-document'
-      };
-    }
-  }
+	// Priority 3: Whole document
+	if (monacoEditor) {
+		const wholeContent = monacoEditor.getValue();
+		if (wholeContent.trim()) {
+			return {
+				code: wholeContent,
+				cellIndex: undefined,
+				source: "whole-document",
+			};
+		}
+	}
 
-  return null;
+	return null;
 }
 
 /**
@@ -103,27 +103,27 @@ export function getExecutionTarget(
  * @returns ExecutionTarget with optional nextCell, or null
  */
 export function getExecutionTargetAndNext(
-  monacoEditor: MonacoEditor.IStandaloneCodeEditor | null,
-  cells: Cell[],
-  cursorLine: number
+	monacoEditor: MonacoEditor.IStandaloneCodeEditor | null,
+	cells: Cell[],
+	cursorLine: number,
 ): ExecutionTargetWithNext | null {
-  const target = getExecutionTarget(monacoEditor, cells, cursorLine);
+	const target = getExecutionTarget(monacoEditor, cells, cursorLine);
 
-  if (!target) return null;
+	if (!target) return null;
 
-  // Only move to next cell if we executed a cell (not selection or whole document)
-  if (target.source === 'cell' && target.cellIndex !== undefined) {
-    const nextCellIndex = target.cellIndex + 1;
-    if (nextCellIndex < cells.length) {
-      return {
-        target,
-        nextCell: cells[nextCellIndex]
-      };
-    }
-  }
+	// Only move to next cell if we executed a cell (not selection or whole document)
+	if (target.source === "cell" && target.cellIndex !== undefined) {
+		const nextCellIndex = target.cellIndex + 1;
+		if (nextCellIndex < cells.length) {
+			return {
+				target,
+				nextCell: cells[nextCellIndex],
+			};
+		}
+	}
 
-  // Return target without nextCell for selection or whole-document execution
-  return { target };
+	// Return target without nextCell for selection or whole-document execution
+	return { target };
 }
 
 /**
@@ -133,11 +133,9 @@ export function getExecutionTargetAndNext(
  * @param monacoEditor - Monaco editor instance
  * @returns Code string or null if editor not ready
  */
-export function getAllCode(
-  monacoEditor: MonacoEditor.IStandaloneCodeEditor | null
-): string | null {
-  if (!monacoEditor) return null;
+export function getAllCode(monacoEditor: MonacoEditor.IStandaloneCodeEditor | null): string | null {
+	if (!monacoEditor) return null;
 
-  const content = monacoEditor.getValue();
-  return content.trim() ? content : null;
+	const content = monacoEditor.getValue();
+	return content.trim() ? content : null;
 }

--- a/client/src/core/execution/cellParser.ts
+++ b/client/src/core/execution/cellParser.ts
@@ -10,11 +10,11 @@
  */
 
 export interface Cell {
-  startLine: number;  // 1-indexed
-  endLine: number;    // 1-indexed
-  code: string;
-  type: 'section' | 'chunk';
-  label?: string;     // Section name if present
+	startLine: number; // 1-indexed
+	endLine: number; // 1-indexed
+	code: string;
+	type: "section" | "chunk";
+	label?: string; // Section name if present
 }
 
 /**
@@ -22,54 +22,54 @@ export interface Cell {
  * Sections are marked by: # Text ---- (at least 4 dashes)
  */
 export function parseRCells(content: string): Cell[] {
-  const lines = content.split('\n');
-  const cells: Cell[] = [];
+	const lines = content.split("\n");
+	const cells: Cell[] = [];
 
-  // RStudio section pattern: one or more #, optional text, at least 4 dashes
-  const sectionPattern = /^(#+)\s*(.*?)\s*-{4,}\s*$/;
+	// RStudio section pattern: one or more #, optional text, at least 4 dashes
+	const sectionPattern = /^(#+)\s*(.*?)\s*-{4,}\s*$/;
 
-  const sectionStarts: Array<{ line: number; label: string }> = [];
+	const sectionStarts: Array<{ line: number; label: string }> = [];
 
-  // Find all section markers
-  lines.forEach((line, index) => {
-    const match = line.match(sectionPattern);
-    if (match) {
-      const label = match[2].trim() || `Section ${sectionStarts.length + 1}`;
-      sectionStarts.push({ line: index + 1, label });
-    }
-  });
+	// Find all section markers
+	lines.forEach((line, index) => {
+		const match = line.match(sectionPattern);
+		if (match) {
+			const label = match[2].trim() || `Section ${sectionStarts.length + 1}`;
+			sectionStarts.push({ line: index + 1, label });
+		}
+	});
 
-  // If no sections found, treat entire file as one cell
-  if (sectionStarts.length === 0) {
-    return [{
-      startLine: 1,
-      endLine: lines.length,
-      code: content,
-      type: 'section',
-      label: 'All Code'
-    }];
-  }
+	// If no sections found, treat entire file as one cell
+	if (sectionStarts.length === 0) {
+		return [
+			{
+				startLine: 1,
+				endLine: lines.length,
+				code: content,
+				type: "section",
+				label: "All Code",
+			},
+		];
+	}
 
-  // Create cells from sections
-  for (let i = 0; i < sectionStarts.length; i++) {
-    const start = sectionStarts[i];
-    const end = i < sectionStarts.length - 1
-      ? sectionStarts[i + 1].line - 1
-      : lines.length;
+	// Create cells from sections
+	for (let i = 0; i < sectionStarts.length; i++) {
+		const start = sectionStarts[i];
+		const end = i < sectionStarts.length - 1 ? sectionStarts[i + 1].line - 1 : lines.length;
 
-    const cellLines = lines.slice(start.line - 1, end);
-    const code = cellLines.join('\n');
+		const cellLines = lines.slice(start.line - 1, end);
+		const code = cellLines.join("\n");
 
-    cells.push({
-      startLine: start.line,
-      endLine: end,
-      code,
-      type: 'section',
-      label: start.label
-    });
-  }
+		cells.push({
+			startLine: start.line,
+			endLine: end,
+			code,
+			type: "section",
+			label: start.label,
+		});
+	}
 
-  return cells;
+	return cells;
 }
 
 /**
@@ -77,72 +77,70 @@ export function parseRCells(content: string): Cell[] {
  * Chunks are marked by: ```{r} ... ```
  */
 export function parseRmdCells(content: string): Cell[] {
-  const lines = content.split('\n');
-  const cells: Cell[] = [];
+	const lines = content.split("\n");
+	const cells: Cell[] = [];
 
-  let inChunk = false;
-  let chunkStart = 0;
-  let chunkLabel = '';
-  let chunkIndex = 0;
+	let inChunk = false;
+	let chunkStart = 0;
+	let chunkLabel = "";
+	let chunkIndex = 0;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
 
-    // Start of chunk: ```{r} or ```{r label}
-    if (line.match(/^```\{r[\s,}]/)) {
-      inChunk = true;
-      chunkStart = i + 1; // Line number (1-indexed)
+		// Start of chunk: ```{r} or ```{r label}
+		if (line.match(/^```\{r[\s,}]/)) {
+			inChunk = true;
+			chunkStart = i + 1; // Line number (1-indexed)
 
-      // Extract chunk label if present
-      const labelMatch = line.match(/^```\{r\s+([^,}]+)/);
-      chunkLabel = labelMatch
-        ? labelMatch[1].trim()
-        : `Chunk ${++chunkIndex}`;
-    }
-    // End of chunk: ```
-    else if (inChunk && line.match(/^```\s*$/)) {
-      const cellLines = lines.slice(chunkStart, i + 1);
-      // Remove the chunk markers
-      const code = cellLines.slice(1, -1).join('\n');
+			// Extract chunk label if present
+			const labelMatch = line.match(/^```\{r\s+([^,}]+)/);
+			chunkLabel = labelMatch ? labelMatch[1].trim() : `Chunk ${++chunkIndex}`;
+		}
+		// End of chunk: ```
+		else if (inChunk && line.match(/^```\s*$/)) {
+			const cellLines = lines.slice(chunkStart, i + 1);
+			// Remove the chunk markers
+			const code = cellLines.slice(1, -1).join("\n");
 
-      cells.push({
-        startLine: chunkStart + 1,
-        endLine: i,
-        code,
-        type: 'chunk',
-        label: chunkLabel
-      });
+			cells.push({
+				startLine: chunkStart + 1,
+				endLine: i,
+				code,
+				type: "chunk",
+				label: chunkLabel,
+			});
 
-      inChunk = false;
-    }
-  }
+			inChunk = false;
+		}
+	}
 
-  return cells;
+	return cells;
 }
 
 /**
  * Find which cell contains the given line number
  */
 export function getCurrentCell(cells: Cell[], cursorLine: number): Cell | null {
-  for (const cell of cells) {
-    if (cursorLine >= cell.startLine && cursorLine <= cell.endLine) {
-      return cell;
-    }
-  }
-  return null;
+	for (const cell of cells) {
+		if (cursorLine >= cell.startLine && cursorLine <= cell.endLine) {
+			return cell;
+		}
+	}
+	return null;
 }
 
 /**
  * Determine file type and parse accordingly
  */
 export function parseCells(content: string, filename: string): Cell[] {
-  const isRmd = filename.toLowerCase().endsWith('.rmd');
+	const isRmd = filename.toLowerCase().endsWith(".rmd");
 
-  if (isRmd) {
-    return parseRmdCells(content);
-  } else {
-    return parseRCells(content);
-  }
+	if (isRmd) {
+		return parseRmdCells(content);
+	} else {
+		return parseRCells(content);
+	}
 }
 
 /**
@@ -151,17 +149,17 @@ export function parseCells(content: string, filename: string): Cell[] {
  * For R sections, we need to extract it
  */
 export function getCellCode(cell: Cell): string {
-  if (cell.type === 'chunk') {
-    return cell.code;
-  }
+	if (cell.type === "chunk") {
+		return cell.code;
+	}
 
-  // For sections, remove the section marker line
-  const lines = cell.code.split('\n');
+	// For sections, remove the section marker line
+	const lines = cell.code.split("\n");
 
-  // Skip first line if it's the section marker
-  if (lines[0].match(/^#+\s*.*\s*-{4,}\s*$/)) {
-    return lines.slice(1).join('\n').trim();
-  }
+	// Skip first line if it's the section marker
+	if (lines[0].match(/^#+\s*.*\s*-{4,}\s*$/)) {
+		return lines.slice(1).join("\n").trim();
+	}
 
-  return cell.code.trim();
+	return cell.code.trim();
 }

--- a/client/src/core/execution/requestBuilder.ts
+++ b/client/src/core/execution/requestBuilder.ts
@@ -1,127 +1,134 @@
 import type {
-  ExecutionRequestPayload,
-  ExecutionContextPayload,
-  CodeBlockMetadataPayload,
-  ExecutionSource,
-  ExecutionActor,
-} from '@shared/types';
-import type { ExecutionTarget } from './cellExecution';
-import type { Cell } from './cellParser';
+	CodeBlockMetadataPayload,
+	ExecutionActor,
+	ExecutionContextPayload,
+	ExecutionRequestPayload,
+	ExecutionSource,
+} from "@shared/types";
+import type { ExecutionTarget } from "./cellExecution";
+import type { Cell } from "./cellParser";
 
 interface BuildRequestParams {
-  target: ExecutionTarget;
-  cells: Cell[];
-  documentContent: string;
-  filepath?: string;
-  idFactory?: () => string;
-  actor?: ExecutionActor;
+	target: ExecutionTarget;
+	cells: Cell[];
+	documentContent: string;
+	filepath?: string;
+	idFactory?: () => string;
+	actor?: ExecutionActor;
 }
 
-const DEFAULT_ACTOR: ExecutionActor = 'user';
+const DEFAULT_ACTOR: ExecutionActor = "user";
 
-const SOURCE_MAP: Record<ExecutionTarget['source'], ExecutionSource> = {
-  selection: 'selection',
-  cell: 'cell',
-  'whole-document': 'whole_document'
+const SOURCE_MAP: Record<ExecutionTarget["source"], ExecutionSource> = {
+	selection: "selection",
+	cell: "cell",
+	"whole-document": "whole_document",
 };
 
 const FALLBACK_ID = (): string => {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return `block-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+	if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+		return crypto.randomUUID();
+	}
+	return `block-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 };
 
 function buildContext(
-  target: ExecutionTarget,
-  filepath: string | undefined,
-  actor: ExecutionActor
+	target: ExecutionTarget,
+	filepath: string | undefined,
+	actor: ExecutionActor,
 ): ExecutionContextPayload {
-  return {
-    source: SOURCE_MAP[target.source],
-    document_path: filepath ?? null,
-    cell_index: target.cellIndex ?? null,
-    triggered_at_ms: Date.now(),
-    actor
-  };
+	return {
+		source: SOURCE_MAP[target.source],
+		document_path: filepath ?? null,
+		cell_index: target.cellIndex ?? null,
+		triggered_at_ms: Date.now(),
+		actor,
+	};
 }
 
 function buildBlocks(
-  target: ExecutionTarget,
-  cells: Cell[],
-  documentContent: string,
-  idFactory: () => string
+	target: ExecutionTarget,
+	cells: Cell[],
+	documentContent: string,
+	idFactory: () => string,
 ): CodeBlockMetadataPayload[] {
-  if (target.source === 'selection') {
-    const lineCount = target.code.split('\n').length;
-    const startLine = target.range?.startLine ?? 1;
-    const endLine = target.range?.endLine ?? startLine + lineCount - 1;
+	if (target.source === "selection") {
+		const lineCount = target.code.split("\n").length;
+		const startLine = target.range?.startLine ?? 1;
+		const endLine = target.range?.endLine ?? startLine + lineCount - 1;
 
-    return [
-      {
-        id: idFactory(),
-        index: 0,
-        kind: 'selection',
-        label: 'Selection',
-        start_line: startLine,
-        end_line: endLine,
-        code: target.code
-      }
-    ];
-  }
+		return [
+			{
+				id: idFactory(),
+				index: 0,
+				kind: "selection",
+				label: "Selection",
+				start_line: startLine,
+				end_line: endLine,
+				code: target.code,
+			},
+		];
+	}
 
-  if (target.source === 'cell' && target.cellIndex !== undefined) {
-    const cell = cells[target.cellIndex];
-    if (cell) {
-      return [
-        {
-          id: idFactory(),
-          index: 0,
-          kind: cell.type === 'chunk' ? 'chunk' : 'section',
-          label: cell.label ?? `Cell ${target.cellIndex + 1}`,
-          start_line: cell.startLine,
-          end_line: cell.endLine,
-          code: target.code
-        }
-      ];
-    }
-  }
+	if (target.source === "cell" && target.cellIndex !== undefined) {
+		const cell = cells[target.cellIndex];
+		if (cell) {
+			return [
+				{
+					id: idFactory(),
+					index: 0,
+					kind: cell.type === "chunk" ? "chunk" : "section",
+					label: cell.label ?? `Cell ${target.cellIndex + 1}`,
+					start_line: cell.startLine,
+					end_line: cell.endLine,
+					code: target.code,
+				},
+			];
+		}
+	}
 
-  if (target.source === 'whole-document' && cells.length > 0) {
-    return cells.map((cell, index) => ({
-      id: idFactory(),
-      index,
-      kind: cell.type === 'chunk' ? 'chunk' : 'section',
-      label: cell.label ?? `Section ${index + 1}`,
-      start_line: cell.startLine,
-      end_line: cell.endLine,
-      code: cell.code
-    }));
-  }
+	if (target.source === "whole-document" && cells.length > 0) {
+		return cells.map((cell, index) => ({
+			id: idFactory(),
+			index,
+			kind: cell.type === "chunk" ? "chunk" : "section",
+			label: cell.label ?? `Section ${index + 1}`,
+			start_line: cell.startLine,
+			end_line: cell.endLine,
+			code: cell.code,
+		}));
+	}
 
-  const totalLines = documentContent.trim() ? documentContent.split('\n').length : 0;
-  return [
-    {
-      id: idFactory(),
-      index: 0,
-      kind: 'document',
-      label: 'Document',
-      start_line: 1,
-      end_line: Math.max(1, totalLines),
-      code: documentContent
-    }
-  ];
+	const totalLines = documentContent.trim() ? documentContent.split("\n").length : 0;
+	return [
+		{
+			id: idFactory(),
+			index: 0,
+			kind: "document",
+			label: "Document",
+			start_line: 1,
+			end_line: Math.max(1, totalLines),
+			code: documentContent,
+		},
+	];
 }
 
 export function buildExecutionRequest(params: BuildRequestParams): ExecutionRequestPayload {
-  const { target, cells, documentContent, filepath, idFactory = FALLBACK_ID, actor = DEFAULT_ACTOR } = params;
+	const {
+		target,
+		cells,
+		documentContent,
+		filepath,
+		idFactory = FALLBACK_ID,
+		actor = DEFAULT_ACTOR,
+	} = params;
 
-  const context = buildContext(target, filepath, actor);
-  const blocks = buildBlocks(target, cells, documentContent, idFactory);
+	const context = buildContext(target, filepath, actor);
+	const blocks = buildBlocks(target, cells, documentContent, idFactory);
 
-  return {
-    code: target.code,
-    context,
-    blocks
-  };
+	return {
+		code: target.code,
+		context,
+		blocks,
+	};
 }

--- a/client/src/core/fileSystemStore.ts
+++ b/client/src/core/fileSystemStore.ts
@@ -1,198 +1,210 @@
-import { create } from 'zustand';
-import { ROOT_PATH, normalizeRelativePath } from '@/core/pathUtils';
-import type { FileEntry, FileSystemEvent } from '@/services/fileSystem';
-import { fileSystem } from '@/services/fileSystem';
+import { create } from "zustand";
+import { normalizeRelativePath, ROOT_PATH } from "@/core/pathUtils";
+import type { FileEntry, FileSystemEvent } from "@/services/fileSystem";
+import { fileSystem } from "@/services/fileSystem";
 
 const normalizeStorePath = (path: string): string => normalizeRelativePath(path);
 
 const getParentPath = (path: string): string => {
-  const normalized = normalizeStorePath(path);
-  if (normalized === ROOT_PATH) {
-    return ROOT_PATH;
-  }
-  const segments = normalized.split('/');
-  if (segments.length <= 1) {
-    return ROOT_PATH;
-  }
-  segments.pop();
-  const parent = segments.join('/');
-  return parent || ROOT_PATH;
+	const normalized = normalizeStorePath(path);
+	if (normalized === ROOT_PATH) {
+		return ROOT_PATH;
+	}
+	const segments = normalized.split("/");
+	if (segments.length <= 1) {
+		return ROOT_PATH;
+	}
+	segments.pop();
+	const parent = segments.join("/");
+	return parent || ROOT_PATH;
 };
 
-const updateChildren = (nodes: FileEntry[], targetPath: string, children: FileEntry[]): FileEntry[] => {
-  return nodes.map((node) => {
-    if (node.path === targetPath) {
-      return { ...node, children };
-    }
-    if (node.children) {
-      return { ...node, children: updateChildren(node.children, targetPath, children) };
-    }
-    return node;
-  });
+const updateChildren = (
+	nodes: FileEntry[],
+	targetPath: string,
+	children: FileEntry[],
+): FileEntry[] => {
+	return nodes.map((node) => {
+		if (node.path === targetPath) {
+			return { ...node, children };
+		}
+		if (node.children) {
+			return {
+				...node,
+				children: updateChildren(node.children, targetPath, children),
+			};
+		}
+		return node;
+	});
 };
 
 const normalizeFsEvent = (event: FileSystemEvent): FileSystemEvent => {
-  switch (event.type) {
-    case 'created':
-    case 'deleted':
-    case 'modified':
-      return { ...event, path: normalizeStorePath(event.path) };
-    case 'renamed':
-      return {
-        ...event,
-        from: normalizeStorePath(event.from),
-        to: normalizeStorePath(event.to),
-      };
-    default:
-      return event;
-  }
+	switch (event.type) {
+		case "created":
+		case "deleted":
+		case "modified":
+			return { ...event, path: normalizeStorePath(event.path) };
+		case "renamed":
+			return {
+				...event,
+				from: normalizeStorePath(event.from),
+				to: normalizeStorePath(event.to),
+			};
+		default:
+			return event;
+	}
 };
 
 const deriveRefreshTargets = (event: FileSystemEvent): string[] => {
-  switch (event.type) {
-    case 'created':
-    case 'deleted':
-    case 'modified':
-      return [getParentPath(event.path)];
-    case 'renamed':
-      return [getParentPath(event.from), getParentPath(event.to)];
-    default:
-      return [];
-  }
+	switch (event.type) {
+		case "created":
+		case "deleted":
+		case "modified":
+			return [getParentPath(event.path)];
+		case "renamed":
+			return [getParentPath(event.from), getParentPath(event.to)];
+		default:
+			return [];
+	}
 };
 
 interface FileSystemState {
-  files: FileEntry[];
-  expandedFolders: Set<string>;
-  selectedFiles: Set<string>;
-  pendingFolders: Set<string>;
-  loading: boolean;
-  error: string | null;
-  activePath: string | null;
-  workspaceRoot: string;
-  loadRoot: () => Promise<void>;
-  toggleFolder: (path: string) => Promise<void>;
-  selectPaths: (paths: string[]) => void;
-  toggleSelection: (path: string) => void;
-  clearSelection: () => void;
-  setActivePath: (path: string | null) => void;
-  refreshPath: (path: string) => Promise<void>;
-  handleFsEvent: (event: FileSystemEvent) => Promise<void>;
+	files: FileEntry[];
+	expandedFolders: Set<string>;
+	selectedFiles: Set<string>;
+	pendingFolders: Set<string>;
+	loading: boolean;
+	error: string | null;
+	activePath: string | null;
+	workspaceRoot: string;
+	loadRoot: () => Promise<void>;
+	toggleFolder: (path: string) => Promise<void>;
+	selectPaths: (paths: string[]) => void;
+	toggleSelection: (path: string) => void;
+	clearSelection: () => void;
+	setActivePath: (path: string | null) => void;
+	refreshPath: (path: string) => Promise<void>;
+	handleFsEvent: (event: FileSystemEvent) => Promise<void>;
 }
 
 export const useFileSystemStore = create<FileSystemState>((set, get) => ({
-  files: [],
-  expandedFolders: new Set([ROOT_PATH]),
-  selectedFiles: new Set(),
-  pendingFolders: new Set(),
-  loading: false,
-  error: null,
-  activePath: null,
-  workspaceRoot: '',
+	files: [],
+	expandedFolders: new Set([ROOT_PATH]),
+	selectedFiles: new Set(),
+	pendingFolders: new Set(),
+	loading: false,
+	error: null,
+	activePath: null,
+	workspaceRoot: "",
 
-  loadRoot: async () => {
-    set({ loading: true, error: null });
-    try {
-      let workspaceRoot = get().workspaceRoot;
-      if (!workspaceRoot) {
-        workspaceRoot = await fileSystem.getWorkspaceRoot();
-      }
-      const files = await fileSystem.listDir(ROOT_PATH);
-      set((state) => {
-        const expanded = new Set(state.expandedFolders);
-        expanded.add(ROOT_PATH);
-        return { files, loading: false, expandedFolders: expanded, workspaceRoot };
-      });
-    } catch (error) {
-      set({ error: (error as Error).message, loading: false });
-    }
-  },
+	loadRoot: async () => {
+		set({ loading: true, error: null });
+		try {
+			let workspaceRoot = get().workspaceRoot;
+			if (!workspaceRoot) {
+				workspaceRoot = await fileSystem.getWorkspaceRoot();
+			}
+			const files = await fileSystem.listDir(ROOT_PATH);
+			set((state) => {
+				const expanded = new Set(state.expandedFolders);
+				expanded.add(ROOT_PATH);
+				return {
+					files,
+					loading: false,
+					expandedFolders: expanded,
+					workspaceRoot,
+				};
+			});
+		} catch (error) {
+			set({ error: (error as Error).message, loading: false });
+		}
+	},
 
-  toggleFolder: async (rawPath: string) => {
-    const path = rawPath === ROOT_PATH ? ROOT_PATH : normalizeStorePath(rawPath);
-    const expanded = new Set(get().expandedFolders);
+	toggleFolder: async (rawPath: string) => {
+		const path = rawPath === ROOT_PATH ? ROOT_PATH : normalizeStorePath(rawPath);
+		const expanded = new Set(get().expandedFolders);
 
-    if (expanded.has(path)) {
-      expanded.delete(path);
-      set({ expandedFolders: expanded });
-      return;
-    }
+		if (expanded.has(path)) {
+			expanded.delete(path);
+			set({ expandedFolders: expanded });
+			return;
+		}
 
-    expanded.add(path);
-    set({ expandedFolders: expanded });
-    await get().refreshPath(path);
-  },
+		expanded.add(path);
+		set({ expandedFolders: expanded });
+		await get().refreshPath(path);
+	},
 
-  selectPaths: (paths: string[]) =>
-    set({
-      selectedFiles: new Set(paths),
-    }),
+	selectPaths: (paths: string[]) =>
+		set({
+			selectedFiles: new Set(paths),
+		}),
 
-  toggleSelection: (path: string) =>
-    set((state) => {
-      const selection = new Set(state.selectedFiles);
-      if (selection.has(path)) {
-        selection.delete(path);
-      } else {
-        selection.add(path);
-      }
-      return { selectedFiles: selection };
-    }),
+	toggleSelection: (path: string) =>
+		set((state) => {
+			const selection = new Set(state.selectedFiles);
+			if (selection.has(path)) {
+				selection.delete(path);
+			} else {
+				selection.add(path);
+			}
+			return { selectedFiles: selection };
+		}),
 
-  clearSelection: () => set({ selectedFiles: new Set() }),
+	clearSelection: () => set({ selectedFiles: new Set() }),
 
-  setActivePath: (path: string | null) => set({ activePath: path }),
+	setActivePath: (path: string | null) => set({ activePath: path }),
 
-  refreshPath: async (rawPath: string) => {
-    const path = rawPath === ROOT_PATH ? ROOT_PATH : normalizeStorePath(rawPath);
-    if (path === ROOT_PATH) {
-      try {
-        const files = await fileSystem.listDir(ROOT_PATH);
-        set({ files });
-      } catch (error) {
-        set({ error: (error as Error).message });
-      }
-      return;
-    }
+	refreshPath: async (rawPath: string) => {
+		const path = rawPath === ROOT_PATH ? ROOT_PATH : normalizeStorePath(rawPath);
+		if (path === ROOT_PATH) {
+			try {
+				const files = await fileSystem.listDir(ROOT_PATH);
+				set({ files });
+			} catch (error) {
+				set({ error: (error as Error).message });
+			}
+			return;
+		}
 
-    if (!get().expandedFolders.has(path)) {
-      return;
-    }
+		if (!get().expandedFolders.has(path)) {
+			return;
+		}
 
-    set((state) => {
-      const pending = new Set(state.pendingFolders);
-      pending.add(path);
-      return { pendingFolders: pending };
-    });
+		set((state) => {
+			const pending = new Set(state.pendingFolders);
+			pending.add(path);
+			return { pendingFolders: pending };
+		});
 
-    try {
-      const children = await fileSystem.listDir(path);
-      set((state) => {
-        const pending = new Set(state.pendingFolders);
-        pending.delete(path);
-        return {
-          files: updateChildren(state.files, path, children),
-          pendingFolders: pending,
-        };
-      });
-    } catch (error) {
-      set((state) => {
-        const pending = new Set(state.pendingFolders);
-        pending.delete(path);
-        return { error: (error as Error).message, pendingFolders: pending };
-      });
-    }
-  },
+		try {
+			const children = await fileSystem.listDir(path);
+			set((state) => {
+				const pending = new Set(state.pendingFolders);
+				pending.delete(path);
+				return {
+					files: updateChildren(state.files, path, children),
+					pendingFolders: pending,
+				};
+			});
+		} catch (error) {
+			set((state) => {
+				const pending = new Set(state.pendingFolders);
+				pending.delete(path);
+				return { error: (error as Error).message, pendingFolders: pending };
+			});
+		}
+	},
 
-  handleFsEvent: async (event: FileSystemEvent) => {
-    if (event.type === 'error') {
-      set({ error: event.message });
-      return;
-    }
-    const normalizedEvent = normalizeFsEvent(event);
-    const targets = Array.from(new Set(deriveRefreshTargets(normalizedEvent).filter(Boolean)));
-    for (const target of targets) {
-      await get().refreshPath(target);
-    }
-  },
+	handleFsEvent: async (event: FileSystemEvent) => {
+		if (event.type === "error") {
+			set({ error: event.message });
+			return;
+		}
+		const normalizedEvent = normalizeFsEvent(event);
+		const targets = Array.from(new Set(deriveRefreshTargets(normalizedEvent).filter(Boolean)));
+		for (const target of targets) {
+			await get().refreshPath(target);
+		}
+	},
 }));

--- a/client/src/core/index.ts
+++ b/client/src/core/index.ts
@@ -1,5 +1,5 @@
-export { useStore, type StoreState } from './state/store';
-export { useFileSystemStore } from './fileSystemStore';
-export * from './execution/cellParser';
-export * from './execution/cellExecution';
-export * from './execution/requestBuilder';
+export * from "./execution/cellExecution";
+export * from "./execution/cellParser";
+export * from "./execution/requestBuilder";
+export { useFileSystemStore } from "./fileSystemStore";
+export { type StoreState, useStore } from "./state/store";

--- a/client/src/core/menu/menuConfig.ts
+++ b/client/src/core/menu/menuConfig.ts
@@ -1,151 +1,277 @@
-import type { MenuSection } from '@/types/menu';
-import type { ViewPane } from '@/core/state/slices/viewSlice';
-import { menuActions } from '@/services/menuActions';
+import type { ViewPane } from "@/core/state/slices/viewSlice";
+import { menuActions } from "@/services/menuActions";
+import type { MenuSection } from "@/types/menu";
 
 export interface MenuStateSnapshot {
-  isEditorDirty: boolean;
-  isExecutionRunning: boolean;
-  viewPanes: Record<ViewPane, boolean>;
+	isEditorDirty: boolean;
+	isExecutionRunning: boolean;
+	viewPanes: Record<ViewPane, boolean>;
 }
 
 export function buildMenuSections(snapshot: MenuStateSnapshot): MenuSection[] {
-  const { isEditorDirty, isExecutionRunning, viewPanes } = snapshot;
+	const { isEditorDirty, isExecutionRunning, viewPanes } = snapshot;
 
-  return [
-    {
-      id: 'file',
-      label: 'File',
-      items: [
-        { id: 'file:new', label: 'New R Script', shortcut: '⌘N', action: () => menuActions.file.new() },
-        { id: 'file:open', label: 'Open...', shortcut: '⌘O', action: () => menuActions.file.open() },
-        { type: 'separator' },
-        {
-          id: 'file:save',
-          label: 'Save',
-          shortcut: '⌘S',
-          action: () => menuActions.file.save(),
-          enabled: () => isEditorDirty,
-        },
-        { id: 'file:save-as', label: 'Save As...', shortcut: '⌘⇧S', action: () => menuActions.file.saveAs() },
-        { id: 'file:projects', label: 'Projects...', action: () => menuActions.file.projects() },
-        { type: 'separator' },
-        {
-          id: 'file:export-session',
-          label: 'Export Reproducible Session...',
-          action: () => menuActions.file.exportSession(),
-        },
-      ],
-    },
-    {
-      id: 'edit',
-      label: 'Edit',
-      items: [
-        { id: 'edit:undo', label: 'Undo', shortcut: '⌘Z', action: () => menuActions.edit.undo() },
-        { id: 'edit:redo', label: 'Redo', shortcut: '⌘⇧Z', action: () => menuActions.edit.redo() },
-        { type: 'separator' },
-        { id: 'edit:cut', label: 'Cut', shortcut: '⌘X', action: () => menuActions.edit.cut() },
-        { id: 'edit:copy', label: 'Copy', shortcut: '⌘C', action: () => menuActions.edit.copy() },
-        { id: 'edit:paste', label: 'Paste', shortcut: '⌘V', action: () => menuActions.edit.paste() },
-        { type: 'separator' },
-        { id: 'edit:find', label: 'Find...', shortcut: '⌘F', action: () => menuActions.edit.find() },
-        { id: 'edit:replace', label: 'Replace...', shortcut: '⌘H', action: () => menuActions.edit.replace() },
-        { type: 'separator' },
-        {
-          id: 'edit:ai-assist',
-          label: 'Ask AI Assistant...',
-          shortcut: '⌘K',
-          action: () => menuActions.edit.aiAssist(),
-          prominent: true,
-        },
-      ],
-    },
-    {
-      id: 'code',
-      label: 'Code',
-      items: [
-        {
-          id: 'code:run-selection',
-          label: 'Run Current Line/Selection',
-          shortcut: '⌘↵',
-          action: () => menuActions.code.runSelection(),
-          description: 'Uses Editor execution with metadata',
-        },
-        {
-          id: 'code:run-all',
-          label: 'Run All',
-          shortcut: '⌘⇧↵',
-          action: () => menuActions.code.runAll(),
-          description: 'Uses Editor execution with metadata',
-        },
-        { id: 'code:source-file', label: 'Source File', action: () => menuActions.code.sourceFile() },
-        { type: 'separator' },
-        {
-          id: 'code:interrupt',
-          label: 'Interrupt R',
-          shortcut: 'Esc',
-          action: () => menuActions.code.interrupt(),
-          enabled: () => isExecutionRunning,
-        },
-        { id: 'code:restart-session', label: 'Restart R Session', shortcut: '⌘⇧0', action: () => menuActions.code.restartSession() },
-        { type: 'separator' },
-        { id: 'code:comment', label: 'Comment/Uncomment Lines', shortcut: '⌘/', action: () => menuActions.code.comment() },
-      ],
-    },
-    {
-      id: 'session',
-      label: 'Session',
-      items: [
-        { id: 'session:timeline', label: 'Timeline...', shortcut: '⌘T', action: () => menuActions.session.showTimeline() },
-        { type: 'separator' },
-        { id: 'session:new', label: 'New Session', shortcut: '⌘⇧N', action: () => menuActions.session.new() },
-        { id: 'session:save', label: 'Save Session...', action: () => menuActions.session.save() },
-        { id: 'session:load', label: 'Load Session...', action: () => menuActions.session.load() },
-        { type: 'separator' },
-        { id: 'session:info', label: 'Session Info', action: () => menuActions.session.info() },
-        { id: 'session:settings', label: 'Settings...', shortcut: '⌘,', action: () => menuActions.session.settings() },
-      ],
-    },
-    {
-      id: 'view',
-      label: 'View',
-      items: [
-        {
-          id: 'view:toggle-files',
-          label: 'Show/Hide Files Pane',
-          shortcut: 'Cmd/Ctrl+Shift+E',
-          action: () => menuActions.view.togglePane('files'),
-          checked: () => viewPanes.files,
-        },
-        {
-          id: 'view:toggle-editor',
-          label: 'Show/Hide Editor',
-          shortcut: '⌘1',
-          action: () => menuActions.view.togglePane('editor'),
-          checked: () => viewPanes.editor,
-        },
-        {
-          id: 'view:toggle-ai-assistant',
-          label: 'Show/Hide AI Assistant',
-          shortcut: '⌘2',
-          action: () => menuActions.view.togglePane('assistant'),
-          checked: () => viewPanes.assistant,
-        },
-        { type: 'separator' },
-        { id: 'view:zoom-in', label: 'Zoom In', shortcut: '⌘+', action: () => menuActions.view.zoomIn() },
-        { id: 'view:zoom-out', label: 'Zoom Out', shortcut: '⌘-', action: () => menuActions.view.zoomOut() },
-        { id: 'view:zoom-reset', label: 'Reset Zoom', shortcut: '⌘0', action: () => menuActions.view.zoomReset() },
-      ],
-    },
-    {
-      id: 'help',
-      label: 'Help',
-      items: [
-        { id: 'help:docs', label: 'Documentation', action: () => menuActions.help.docs() },
-        { id: 'help:shortcuts', label: 'Keyboard Shortcuts', action: () => menuActions.help.shortcuts() },
-        { type: 'separator' },
-        { id: 'help:report-issue', label: 'Report Issue', action: () => menuActions.help.reportIssue() },
-        { id: 'help:about', label: 'About Re-prod', action: () => menuActions.help.about() },
-      ],
-    },
-  ];
+	return [
+		{
+			id: "file",
+			label: "File",
+			items: [
+				{
+					id: "file:new",
+					label: "New R Script",
+					shortcut: "⌘N",
+					action: () => menuActions.file.new(),
+				},
+				{
+					id: "file:open",
+					label: "Open...",
+					shortcut: "⌘O",
+					action: () => menuActions.file.open(),
+				},
+				{ type: "separator" },
+				{
+					id: "file:save",
+					label: "Save",
+					shortcut: "⌘S",
+					action: () => menuActions.file.save(),
+					enabled: () => isEditorDirty,
+				},
+				{
+					id: "file:save-as",
+					label: "Save As...",
+					shortcut: "⌘⇧S",
+					action: () => menuActions.file.saveAs(),
+				},
+				{
+					id: "file:projects",
+					label: "Projects...",
+					action: () => menuActions.file.projects(),
+				},
+				{ type: "separator" },
+				{
+					id: "file:export-session",
+					label: "Export Reproducible Session...",
+					action: () => menuActions.file.exportSession(),
+				},
+			],
+		},
+		{
+			id: "edit",
+			label: "Edit",
+			items: [
+				{
+					id: "edit:undo",
+					label: "Undo",
+					shortcut: "⌘Z",
+					action: () => menuActions.edit.undo(),
+				},
+				{
+					id: "edit:redo",
+					label: "Redo",
+					shortcut: "⌘⇧Z",
+					action: () => menuActions.edit.redo(),
+				},
+				{ type: "separator" },
+				{
+					id: "edit:cut",
+					label: "Cut",
+					shortcut: "⌘X",
+					action: () => menuActions.edit.cut(),
+				},
+				{
+					id: "edit:copy",
+					label: "Copy",
+					shortcut: "⌘C",
+					action: () => menuActions.edit.copy(),
+				},
+				{
+					id: "edit:paste",
+					label: "Paste",
+					shortcut: "⌘V",
+					action: () => menuActions.edit.paste(),
+				},
+				{ type: "separator" },
+				{
+					id: "edit:find",
+					label: "Find...",
+					shortcut: "⌘F",
+					action: () => menuActions.edit.find(),
+				},
+				{
+					id: "edit:replace",
+					label: "Replace...",
+					shortcut: "⌘H",
+					action: () => menuActions.edit.replace(),
+				},
+				{ type: "separator" },
+				{
+					id: "edit:ai-assist",
+					label: "Ask AI Assistant...",
+					shortcut: "⌘K",
+					action: () => menuActions.edit.aiAssist(),
+					prominent: true,
+				},
+			],
+		},
+		{
+			id: "code",
+			label: "Code",
+			items: [
+				{
+					id: "code:run-selection",
+					label: "Run Current Line/Selection",
+					shortcut: "⌘↵",
+					action: () => menuActions.code.runSelection(),
+					description: "Uses Editor execution with metadata",
+				},
+				{
+					id: "code:run-all",
+					label: "Run All",
+					shortcut: "⌘⇧↵",
+					action: () => menuActions.code.runAll(),
+					description: "Uses Editor execution with metadata",
+				},
+				{
+					id: "code:source-file",
+					label: "Source File",
+					action: () => menuActions.code.sourceFile(),
+				},
+				{ type: "separator" },
+				{
+					id: "code:interrupt",
+					label: "Interrupt R",
+					shortcut: "Esc",
+					action: () => menuActions.code.interrupt(),
+					enabled: () => isExecutionRunning,
+				},
+				{
+					id: "code:restart-session",
+					label: "Restart R Session",
+					shortcut: "⌘⇧0",
+					action: () => menuActions.code.restartSession(),
+				},
+				{ type: "separator" },
+				{
+					id: "code:comment",
+					label: "Comment/Uncomment Lines",
+					shortcut: "⌘/",
+					action: () => menuActions.code.comment(),
+				},
+			],
+		},
+		{
+			id: "session",
+			label: "Session",
+			items: [
+				{
+					id: "session:timeline",
+					label: "Timeline...",
+					shortcut: "⌘T",
+					action: () => menuActions.session.showTimeline(),
+				},
+				{ type: "separator" },
+				{
+					id: "session:new",
+					label: "New Session",
+					shortcut: "⌘⇧N",
+					action: () => menuActions.session.new(),
+				},
+				{
+					id: "session:save",
+					label: "Save Session...",
+					action: () => menuActions.session.save(),
+				},
+				{
+					id: "session:load",
+					label: "Load Session...",
+					action: () => menuActions.session.load(),
+				},
+				{ type: "separator" },
+				{
+					id: "session:info",
+					label: "Session Info",
+					action: () => menuActions.session.info(),
+				},
+				{
+					id: "session:settings",
+					label: "Settings...",
+					shortcut: "⌘,",
+					action: () => menuActions.session.settings(),
+				},
+			],
+		},
+		{
+			id: "view",
+			label: "View",
+			items: [
+				{
+					id: "view:toggle-files",
+					label: "Show/Hide Files Pane",
+					shortcut: "Cmd/Ctrl+Shift+E",
+					action: () => menuActions.view.togglePane("files"),
+					checked: () => viewPanes.files,
+				},
+				{
+					id: "view:toggle-editor",
+					label: "Show/Hide Editor",
+					shortcut: "⌘1",
+					action: () => menuActions.view.togglePane("editor"),
+					checked: () => viewPanes.editor,
+				},
+				{
+					id: "view:toggle-ai-assistant",
+					label: "Show/Hide AI Assistant",
+					shortcut: "⌘2",
+					action: () => menuActions.view.togglePane("assistant"),
+					checked: () => viewPanes.assistant,
+				},
+				{ type: "separator" },
+				{
+					id: "view:zoom-in",
+					label: "Zoom In",
+					shortcut: "⌘+",
+					action: () => menuActions.view.zoomIn(),
+				},
+				{
+					id: "view:zoom-out",
+					label: "Zoom Out",
+					shortcut: "⌘-",
+					action: () => menuActions.view.zoomOut(),
+				},
+				{
+					id: "view:zoom-reset",
+					label: "Reset Zoom",
+					shortcut: "⌘0",
+					action: () => menuActions.view.zoomReset(),
+				},
+			],
+		},
+		{
+			id: "help",
+			label: "Help",
+			items: [
+				{
+					id: "help:docs",
+					label: "Documentation",
+					action: () => menuActions.help.docs(),
+				},
+				{
+					id: "help:shortcuts",
+					label: "Keyboard Shortcuts",
+					action: () => menuActions.help.shortcuts(),
+				},
+				{ type: "separator" },
+				{
+					id: "help:report-issue",
+					label: "Report Issue",
+					action: () => menuActions.help.reportIssue(),
+				},
+				{
+					id: "help:about",
+					label: "About Re-prod",
+					action: () => menuActions.help.about(),
+				},
+			],
+		},
+	];
 }

--- a/client/src/core/pathUtils.ts
+++ b/client/src/core/pathUtils.ts
@@ -1,24 +1,24 @@
-export const ROOT_PATH = '/';
+export const ROOT_PATH = "/";
 
-export const normalizeSeparators = (value: string): string => value.replace(/\\/g, '/');
+export const normalizeSeparators = (value: string): string => value.replace(/\\/g, "/");
 
 export const normalizeRelativePath = (
-  path: string,
-  options?: { keepRootEmpty?: boolean }
+	path: string,
+	options?: { keepRootEmpty?: boolean },
 ): string => {
-  if (!path || path === ROOT_PATH) {
-    return options?.keepRootEmpty ? '' : ROOT_PATH;
-  }
-  let normalized = normalizeSeparators(path).replace(/^\.\/+/, '');
-  normalized = normalized.replace(/\/\/+/g, '/');
-  normalized = normalized.replace(/^\/+/, '').replace(/\/+$/, '');
-  if (!normalized) {
-    return options?.keepRootEmpty ? '' : ROOT_PATH;
-  }
-  return normalized;
+	if (!path || path === ROOT_PATH) {
+		return options?.keepRootEmpty ? "" : ROOT_PATH;
+	}
+	let normalized = normalizeSeparators(path).replace(/^\.\/+/, "");
+	normalized = normalized.replace(/\/\/+/g, "/");
+	normalized = normalized.replace(/^\/+/, "").replace(/\/+$/, "");
+	if (!normalized) {
+		return options?.keepRootEmpty ? "" : ROOT_PATH;
+	}
+	return normalized;
 };
 
 export const normalizePathInput = (path: string): string => {
-  const normalized = normalizeRelativePath(path, { keepRootEmpty: true });
-  return normalized || ROOT_PATH;
+	const normalized = normalizeRelativePath(path, { keepRootEmpty: true });
+	return normalized || ROOT_PATH;
 };

--- a/client/src/core/state/__tests__/aiSlice.test.ts
+++ b/client/src/core/state/__tests__/aiSlice.test.ts
@@ -1,38 +1,36 @@
-import { describe, expect, it } from 'vitest';
-import { createStore } from 'zustand/vanilla';
-import { createAISlice, type AIState } from '../slices/aiSlice';
+import { describe, expect, it } from "vitest";
+import { createStore } from "zustand/vanilla";
+import { type AIState, createAISlice } from "../slices/aiSlice";
 
 function createTestStore() {
-  return createStore<AIState>()((...args) => createAISlice(...args));
+	return createStore<AIState>()((...args) => createAISlice(...args));
 }
 
-describe('aiSlice streaming helpers', () => {
-  it('handles streaming lifecycle', () => {
-    const store = createTestStore();
-    store.getState().startStreamingMessage('msg-1', 'agent');
+describe("aiSlice streaming helpers", () => {
+	it("handles streaming lifecycle", () => {
+		const store = createTestStore();
+		store.getState().startStreamingMessage("msg-1", "agent");
 
-    store.getState().appendStreamingChunk('msg-1', 'Hello');
-    store.getState().appendStreamingChunk('msg-1', ' world');
-    expect(store.getState().ai.messages.at(-1)?.content).toBe('Hello world');
-    expect(store.getState().ai.messages.at(-1)?.mode).toBe('agent');
+		store.getState().appendStreamingChunk("msg-1", "Hello");
+		store.getState().appendStreamingChunk("msg-1", " world");
+		expect(store.getState().ai.messages.at(-1)?.content).toBe("Hello world");
+		expect(store.getState().ai.messages.at(-1)?.mode).toBe("agent");
 
-    const plan = [
-      { id: 'plan-1', title: 'Step', status: 'running' as const },
-    ];
-    store.getState().updateStreamingPlan('msg-1', plan);
-    expect(store.getState().ai.messages.at(-1)?.planSteps).toEqual(plan);
+		const plan = [{ id: "plan-1", title: "Step", status: "running" as const }];
+		store.getState().updateStreamingPlan("msg-1", plan);
+		expect(store.getState().ai.messages.at(-1)?.planSteps).toEqual(plan);
 
-    store.getState().recordToolEvent('msg-1', {
-      id: 'tool-1',
-      name: 'read_file',
-      status: 'running',
-      input: { path: 'analysis.R' },
-    });
-    expect(store.getState().ai.messages.at(-1)?.toolLogs).toHaveLength(1);
+		store.getState().recordToolEvent("msg-1", {
+			id: "tool-1",
+			name: "read_file",
+			status: "running",
+			input: { path: "analysis.R" },
+		});
+		expect(store.getState().ai.messages.at(-1)?.toolLogs).toHaveLength(1);
 
-    store.getState().completeStreamingMessage('msg-1', 'Hello world!');
-    const message = store.getState().ai.messages.at(-1);
-    expect(message?.isComplete).toBe(true);
-    expect(message?.content).toBe('Hello world!');
-  });
+		store.getState().completeStreamingMessage("msg-1", "Hello world!");
+		const message = store.getState().ai.messages.at(-1);
+		expect(message?.isComplete).toBe(true);
+		expect(message?.content).toBe("Hello world!");
+	});
 });

--- a/client/src/core/state/__tests__/store.test.ts
+++ b/client/src/core/state/__tests__/store.test.ts
@@ -1,92 +1,92 @@
-import { beforeEach, describe, expect, it } from 'vitest';
-import { useStore } from '../store';
+import { beforeEach, describe, expect, it } from "vitest";
+import { useStore } from "../store";
 
 const createExecutionResult = () => ({
-  stdout: 'output',
-  stderr: '',
-  plots: [],
-  timestamp: Date.now(),
-  duration: 100,
-  success: true
+	stdout: "output",
+	stderr: "",
+	plots: [],
+	timestamp: Date.now(),
+	duration: 100,
+	success: true,
 });
 
 const createAIMessage = () => ({
-  id: 'msg-1',
-  role: 'user' as const,
-  content: 'Test message',
-  timestamp: Date.now()
+	id: "msg-1",
+	role: "user" as const,
+	content: "Test message",
+	timestamp: Date.now(),
 });
 
-describe('Zustand Store', () => {
-  beforeEach(() => {
-    useStore.setState({
-      editor: {
-        content: '',
-        filepath: '',
-        isDirty: false,
-        cursorPosition: { line: 1, column: 1 }
-      },
-      applyCodeChange: null,
-      execution: {
-        isRunning: false,
-        results: [],
-        history: [],
-        currentCell: undefined
-      },
-      ai: {
-        messages: [],
-        isLoading: false,
-        suggestions: []
-      },
-      settings: {
-        autoRun: false,
-        theme: 'light',
-        rPath: 'Rscript',
-        fontSize: 13,
-        showCellDecorations: true,
-        highlightExecutingCell: true
-      },
-      isConnected: false
-    });
-  });
+describe("Zustand Store", () => {
+	beforeEach(() => {
+		useStore.setState({
+			editor: {
+				content: "",
+				filepath: "",
+				isDirty: false,
+				cursorPosition: { line: 1, column: 1 },
+			},
+			applyCodeChange: null,
+			execution: {
+				isRunning: false,
+				results: [],
+				history: [],
+				currentCell: undefined,
+			},
+			ai: {
+				messages: [],
+				isLoading: false,
+				suggestions: [],
+			},
+			settings: {
+				autoRun: false,
+				theme: "light",
+				rPath: "Rscript",
+				fontSize: 13,
+				showCellDecorations: true,
+				highlightExecutingCell: true,
+			},
+			isConnected: false,
+		});
+	});
 
-  it('updates editor content and dirty flag', () => {
-    const setEditorContent = useStore.getState().setEditorContent;
+	it("updates editor content and dirty flag", () => {
+		const setEditorContent = useStore.getState().setEditorContent;
 
-    setEditorContent('x <- 1');
+		setEditorContent("x <- 1");
 
-    const state = useStore.getState();
-    expect(state.editor.content).toBe('x <- 1');
-    expect(state.editor.isDirty).toBe(true);
-  });
+		const state = useStore.getState();
+		expect(state.editor.content).toBe("x <- 1");
+		expect(state.editor.isDirty).toBe(true);
+	});
 
-  it('tracks execution results in history', () => {
-    const addExecutionResult = useStore.getState().addExecutionResult;
-    const result = createExecutionResult();
+	it("tracks execution results in history", () => {
+		const addExecutionResult = useStore.getState().addExecutionResult;
+		const result = createExecutionResult();
 
-    addExecutionResult(result);
+		addExecutionResult(result);
 
-    const state = useStore.getState();
-    expect(state.execution.results).toHaveLength(1);
-    expect(state.execution.history).toHaveLength(1);
-  });
+		const state = useStore.getState();
+		expect(state.execution.results).toHaveLength(1);
+		expect(state.execution.history).toHaveLength(1);
+	});
 
-  it('stores AI messages', () => {
-    const addAIMessage = useStore.getState().addAIMessage;
-    const message = createAIMessage();
+	it("stores AI messages", () => {
+		const addAIMessage = useStore.getState().addAIMessage;
+		const message = createAIMessage();
 
-    addAIMessage(message);
+		addAIMessage(message);
 
-    const state = useStore.getState();
-    expect(state.ai.messages).toHaveLength(1);
-    expect(state.ai.messages[0]).toMatchObject({ id: 'msg-1', role: 'user' });
-  });
+		const state = useStore.getState();
+		expect(state.ai.messages).toHaveLength(1);
+		expect(state.ai.messages[0]).toMatchObject({ id: "msg-1", role: "user" });
+	});
 
-  it('updates connection state', () => {
-    const setConnected = useStore.getState().setConnected;
+	it("updates connection state", () => {
+		const setConnected = useStore.getState().setConnected;
 
-    setConnected(true);
+		setConnected(true);
 
-    expect(useStore.getState().isConnected).toBe(true);
-  });
+		expect(useStore.getState().isConnected).toBe(true);
+	});
 });

--- a/client/src/core/state/slices/__tests__/timelineSlice.test.ts
+++ b/client/src/core/state/slices/__tests__/timelineSlice.test.ts
@@ -1,384 +1,384 @@
-import { beforeEach, describe, expect, it } from 'vitest';
-import { create } from 'zustand';
-import { createTimelineSlice, type TimelineState } from '../timelineSlice';
-import type { ExecutionEventPayload } from 'shared';
+import type { ExecutionEventPayload } from "shared";
+import { beforeEach, describe, expect, it } from "vitest";
+import { create } from "zustand";
+import { createTimelineSlice, type TimelineState } from "../timelineSlice";
 
 const createMockEvent = (overrides?: Partial<ExecutionEventPayload>): ExecutionEventPayload => ({
-  event_id: 'evt-123',
-  context: {
-    source: 'cell',
-    document_path: 'analysis.R',
-    cell_index: 1,
-    triggered_at_ms: 1700000000000,
-    actor: 'user',
-  },
-  blocks: [
-    {
-      id: 'block-1',
-      index: 0,
-      kind: 'section',
-      label: 'Setup',
-      start_line: 1,
-      end_line: 3,
-      code: 'x <- 1:10',
-    },
-  ],
-  result: {
-    success: true,
-    output: '[1] 1 2 3',
-    error: null,
-    plots: [],
-    execution_time_ms: 42,
-  },
-  environment: {
-    r_path: 'Rscript',
-    working_dir: '/tmp',
-    temp_dir: '/tmp/reprod',
-  },
-  created_at_ms: 1700000000500,
-  ...overrides,
+	event_id: "evt-123",
+	context: {
+		source: "cell",
+		document_path: "analysis.R",
+		cell_index: 1,
+		triggered_at_ms: 1700000000000,
+		actor: "user",
+	},
+	blocks: [
+		{
+			id: "block-1",
+			index: 0,
+			kind: "section",
+			label: "Setup",
+			start_line: 1,
+			end_line: 3,
+			code: "x <- 1:10",
+		},
+	],
+	result: {
+		success: true,
+		output: "[1] 1 2 3",
+		error: null,
+		plots: [],
+		execution_time_ms: 42,
+	},
+	environment: {
+		r_path: "Rscript",
+		working_dir: "/tmp",
+		temp_dir: "/tmp/reprod",
+	},
+	created_at_ms: 1700000000500,
+	...overrides,
 });
 
-describe('timelineSlice', () => {
-  let store: ReturnType<typeof create<TimelineState>>;
-
-  beforeEach(() => {
-    store = create<TimelineState>()(createTimelineSlice);
-  });
-
-  describe('initial state', () => {
-    it('should have correct initial state', () => {
-      const state = store.getState();
-
-      expect(state.events).toEqual([]);
-      expect(state.total).toBe(0);
-      expect(state.hasMore).toBe(false);
-      expect(state.loading).toBe(false);
-      expect(state.error).toBe(null);
-      expect(state.filters).toEqual({});
-      expect(state.sort).toBe('desc');
-      expect(state.limit).toBe(50);
-      expect(state.offset).toBe(0);
-    });
-  });
-
-  describe('setEvents', () => {
-    it('should set events and update state', () => {
-      const events = [createMockEvent(), createMockEvent({ event_id: 'evt-456' })];
-
-      store.getState().setEvents(events, 100, true);
-
-      const state = store.getState();
-      expect(state.events).toEqual(events);
-      expect(state.total).toBe(100);
-      expect(state.hasMore).toBe(true);
-      expect(state.offset).toBe(2);
-      expect(state.loading).toBe(false);
-      expect(state.error).toBe(null);
-    });
-
-    it('should handle empty events array', () => {
-      store.getState().setEvents([], 0, false);
-
-      const state = store.getState();
-      expect(state.events).toEqual([]);
-      expect(state.total).toBe(0);
-      expect(state.hasMore).toBe(false);
-      expect(state.offset).toBe(0);
-    });
-
-    it('should override previous events', () => {
-      const firstEvents = [createMockEvent()];
-      const secondEvents = [createMockEvent({ event_id: 'evt-new' })];
-
-      store.getState().setEvents(firstEvents, 1, false);
-      store.getState().setEvents(secondEvents, 1, false);
-
-      const state = store.getState();
-      expect(state.events).toEqual(secondEvents);
-      expect(state.events[0].event_id).toBe('evt-new');
-    });
-  });
-
-  describe('addEvent', () => {
-    it('should add new event to the beginning when sort is desc', () => {
-      const existingEvent = createMockEvent({ event_id: 'evt-1' });
-      const newEvent = createMockEvent({ event_id: 'evt-2' });
-
-      store.getState().setEvents([existingEvent], 1, false);
-      store.getState().addEvent(newEvent);
-
-      const state = store.getState();
-      expect(state.events).toHaveLength(2);
-      expect(state.events[0].event_id).toBe('evt-2');
-      expect(state.events[1].event_id).toBe('evt-1');
-      expect(state.total).toBe(2);
-    });
-
-    it('should add new event to the end when sort is asc', () => {
-      const existingEvent = createMockEvent({ event_id: 'evt-1' });
-      const newEvent = createMockEvent({ event_id: 'evt-2' });
-
-      store.getState().setSort('asc');
-      store.getState().setEvents([existingEvent], 1, false);
-      store.getState().addEvent(newEvent);
-
-      const state = store.getState();
-      expect(state.events).toHaveLength(2);
-      expect(state.events[0].event_id).toBe('evt-1');
-      expect(state.events[1].event_id).toBe('evt-2');
-      expect(state.total).toBe(2);
-    });
-
-    it('should not add duplicate event', () => {
-      const event = createMockEvent({ event_id: 'evt-1' });
-
-      store.getState().setEvents([event], 1, false);
-      store.getState().addEvent(event);
-
-      const state = store.getState();
-      expect(state.events).toHaveLength(1);
-      expect(state.total).toBe(1);
-    });
-
-    it('should trim events when exceeding limit (desc)', () => {
-      // Set limit to 2
-      store.setState({ limit: 2, sort: 'desc' });
-
-      const event1 = createMockEvent({ event_id: 'evt-1' });
-      const event2 = createMockEvent({ event_id: 'evt-2' });
-      const event3 = createMockEvent({ event_id: 'evt-3' });
-
-      store.getState().setEvents([event1, event2], 2, false);
-      store.getState().addEvent(event3);
-
-      const state = store.getState();
-      expect(state.events).toHaveLength(2);
-      expect(state.events[0].event_id).toBe('evt-3');
-      expect(state.events[1].event_id).toBe('evt-1');
-      expect(state.total).toBe(3);
-    });
-
-    it('should trim events when exceeding limit (asc)', () => {
-      // Set limit to 2
-      store.setState({ limit: 2, sort: 'asc' });
-
-      const event1 = createMockEvent({ event_id: 'evt-1' });
-      const event2 = createMockEvent({ event_id: 'evt-2' });
-      const event3 = createMockEvent({ event_id: 'evt-3' });
-
-      store.getState().setEvents([event1, event2], 2, false);
-      store.getState().addEvent(event3);
-
-      const state = store.getState();
-      expect(state.events).toHaveLength(2);
-      expect(state.events[0].event_id).toBe('evt-2');
-      expect(state.events[1].event_id).toBe('evt-3');
-      expect(state.total).toBe(3);
-    });
-  });
-
-  describe('setFilters', () => {
-    it('should set filters and reset offset', () => {
-      store.setState({ offset: 50 });
-
-      const filters = {
-        actor: 'user' as const,
-        hasPlots: true,
-      };
+describe("timelineSlice", () => {
+	let store: ReturnType<typeof create<TimelineState>>;
+
+	beforeEach(() => {
+		store = create<TimelineState>()(createTimelineSlice);
+	});
+
+	describe("initial state", () => {
+		it("should have correct initial state", () => {
+			const state = store.getState();
+
+			expect(state.events).toEqual([]);
+			expect(state.total).toBe(0);
+			expect(state.hasMore).toBe(false);
+			expect(state.loading).toBe(false);
+			expect(state.error).toBe(null);
+			expect(state.filters).toEqual({});
+			expect(state.sort).toBe("desc");
+			expect(state.limit).toBe(50);
+			expect(state.offset).toBe(0);
+		});
+	});
+
+	describe("setEvents", () => {
+		it("should set events and update state", () => {
+			const events = [createMockEvent(), createMockEvent({ event_id: "evt-456" })];
+
+			store.getState().setEvents(events, 100, true);
+
+			const state = store.getState();
+			expect(state.events).toEqual(events);
+			expect(state.total).toBe(100);
+			expect(state.hasMore).toBe(true);
+			expect(state.offset).toBe(2);
+			expect(state.loading).toBe(false);
+			expect(state.error).toBe(null);
+		});
+
+		it("should handle empty events array", () => {
+			store.getState().setEvents([], 0, false);
+
+			const state = store.getState();
+			expect(state.events).toEqual([]);
+			expect(state.total).toBe(0);
+			expect(state.hasMore).toBe(false);
+			expect(state.offset).toBe(0);
+		});
+
+		it("should override previous events", () => {
+			const firstEvents = [createMockEvent()];
+			const secondEvents = [createMockEvent({ event_id: "evt-new" })];
+
+			store.getState().setEvents(firstEvents, 1, false);
+			store.getState().setEvents(secondEvents, 1, false);
+
+			const state = store.getState();
+			expect(state.events).toEqual(secondEvents);
+			expect(state.events[0].event_id).toBe("evt-new");
+		});
+	});
+
+	describe("addEvent", () => {
+		it("should add new event to the beginning when sort is desc", () => {
+			const existingEvent = createMockEvent({ event_id: "evt-1" });
+			const newEvent = createMockEvent({ event_id: "evt-2" });
+
+			store.getState().setEvents([existingEvent], 1, false);
+			store.getState().addEvent(newEvent);
+
+			const state = store.getState();
+			expect(state.events).toHaveLength(2);
+			expect(state.events[0].event_id).toBe("evt-2");
+			expect(state.events[1].event_id).toBe("evt-1");
+			expect(state.total).toBe(2);
+		});
+
+		it("should add new event to the end when sort is asc", () => {
+			const existingEvent = createMockEvent({ event_id: "evt-1" });
+			const newEvent = createMockEvent({ event_id: "evt-2" });
+
+			store.getState().setSort("asc");
+			store.getState().setEvents([existingEvent], 1, false);
+			store.getState().addEvent(newEvent);
+
+			const state = store.getState();
+			expect(state.events).toHaveLength(2);
+			expect(state.events[0].event_id).toBe("evt-1");
+			expect(state.events[1].event_id).toBe("evt-2");
+			expect(state.total).toBe(2);
+		});
+
+		it("should not add duplicate event", () => {
+			const event = createMockEvent({ event_id: "evt-1" });
+
+			store.getState().setEvents([event], 1, false);
+			store.getState().addEvent(event);
+
+			const state = store.getState();
+			expect(state.events).toHaveLength(1);
+			expect(state.total).toBe(1);
+		});
+
+		it("should trim events when exceeding limit (desc)", () => {
+			// Set limit to 2
+			store.setState({ limit: 2, sort: "desc" });
+
+			const event1 = createMockEvent({ event_id: "evt-1" });
+			const event2 = createMockEvent({ event_id: "evt-2" });
+			const event3 = createMockEvent({ event_id: "evt-3" });
+
+			store.getState().setEvents([event1, event2], 2, false);
+			store.getState().addEvent(event3);
+
+			const state = store.getState();
+			expect(state.events).toHaveLength(2);
+			expect(state.events[0].event_id).toBe("evt-3");
+			expect(state.events[1].event_id).toBe("evt-1");
+			expect(state.total).toBe(3);
+		});
+
+		it("should trim events when exceeding limit (asc)", () => {
+			// Set limit to 2
+			store.setState({ limit: 2, sort: "asc" });
+
+			const event1 = createMockEvent({ event_id: "evt-1" });
+			const event2 = createMockEvent({ event_id: "evt-2" });
+			const event3 = createMockEvent({ event_id: "evt-3" });
+
+			store.getState().setEvents([event1, event2], 2, false);
+			store.getState().addEvent(event3);
+
+			const state = store.getState();
+			expect(state.events).toHaveLength(2);
+			expect(state.events[0].event_id).toBe("evt-2");
+			expect(state.events[1].event_id).toBe("evt-3");
+			expect(state.total).toBe(3);
+		});
+	});
+
+	describe("setFilters", () => {
+		it("should set filters and reset offset", () => {
+			store.setState({ offset: 50 });
+
+			const filters = {
+				actor: "user" as const,
+				hasPlots: true,
+			};
 
-      store.getState().setFilters(filters);
+			store.getState().setFilters(filters);
 
-      const state = store.getState();
-      expect(state.filters).toEqual(filters);
-      expect(state.offset).toBe(0);
-    });
+			const state = store.getState();
+			expect(state.filters).toEqual(filters);
+			expect(state.offset).toBe(0);
+		});
 
-    it('should handle empty filters', () => {
-      store.getState().setFilters({});
+		it("should handle empty filters", () => {
+			store.getState().setFilters({});
 
-      const state = store.getState();
-      expect(state.filters).toEqual({});
-    });
+			const state = store.getState();
+			expect(state.filters).toEqual({});
+		});
 
-    it('should handle complex filters', () => {
-      const filters = {
-        actor: 'ai' as const,
-        source: 'cell' as const,
-        startTime: 1700000000000,
-        endTime: 1700003600000,
-        hasPlots: true,
-        hasErrors: false,
-        codeContains: 'ggplot',
-      };
+		it("should handle complex filters", () => {
+			const filters = {
+				actor: "ai" as const,
+				source: "cell" as const,
+				startTime: 1700000000000,
+				endTime: 1700003600000,
+				hasPlots: true,
+				hasErrors: false,
+				codeContains: "ggplot",
+			};
 
-      store.getState().setFilters(filters);
-
-      const state = store.getState();
-      expect(state.filters).toEqual(filters);
-    });
-  });
+			store.getState().setFilters(filters);
+
+			const state = store.getState();
+			expect(state.filters).toEqual(filters);
+		});
+	});
 
-  describe('setSort', () => {
-    it('should set sort to asc and reset offset', () => {
-      store.setState({ offset: 50 });
-
-      store.getState().setSort('asc');
-
-      const state = store.getState();
-      expect(state.sort).toBe('asc');
-      expect(state.offset).toBe(0);
-    });
-
-    it('should set sort to desc and reset offset', () => {
-      store.setState({ offset: 50, sort: 'asc' });
-
-      store.getState().setSort('desc');
-
-      const state = store.getState();
-      expect(state.sort).toBe('desc');
-      expect(state.offset).toBe(0);
-    });
-  });
-
-  describe('setLoading', () => {
-    it('should set loading to true', () => {
-      store.getState().setLoading(true);
-
-      expect(store.getState().loading).toBe(true);
-    });
-
-    it('should set loading to false', () => {
-      store.setState({ loading: true });
-
-      store.getState().setLoading(false);
-
-      expect(store.getState().loading).toBe(false);
-    });
-  });
-
-  describe('setError', () => {
-    it('should set error message and stop loading', () => {
-      store.setState({ loading: true });
-
-      store.getState().setError('Failed to load timeline');
-
-      const state = store.getState();
-      expect(state.error).toBe('Failed to load timeline');
-      expect(state.loading).toBe(false);
-    });
-
-    it('should clear error', () => {
-      store.setState({ error: 'Previous error', loading: true });
-
-      store.getState().setError(null);
-
-      const state = store.getState();
-      expect(state.error).toBe(null);
-      expect(state.loading).toBe(false);
-    });
-  });
-
-  describe('loadMore', () => {
-    it('should increment offset by limit', () => {
-      store.setState({ limit: 20, offset: 0 });
-
-      store.getState().loadMore();
-
-      expect(store.getState().offset).toBe(20);
-
-      store.getState().loadMore();
-
-      expect(store.getState().offset).toBe(40);
-    });
-
-    it('should respect custom limit', () => {
-      store.setState({ limit: 100, offset: 0 });
-
-      store.getState().loadMore();
-
-      expect(store.getState().offset).toBe(100);
-    });
-  });
-
-  describe('reset', () => {
-    it('should reset to initial state', () => {
-      // Modify state
-      store.setState({
-        events: [createMockEvent()],
-        total: 100,
-        hasMore: true,
-        loading: true,
-        error: 'Some error',
-        filters: { actor: 'user' },
-        sort: 'asc',
-        limit: 100,
-        offset: 50,
-      });
-
-      store.getState().reset();
-
-      const state = store.getState();
-      expect(state.events).toEqual([]);
-      expect(state.total).toBe(0);
-      expect(state.hasMore).toBe(false);
-      expect(state.loading).toBe(false);
-      expect(state.error).toBe(null);
-      expect(state.filters).toEqual({});
-      expect(state.sort).toBe('desc');
-      expect(state.limit).toBe(50);
-      expect(state.offset).toBe(0);
-    });
-  });
-
-  describe('integration scenarios', () => {
-    it('should handle pagination flow', () => {
-      // Initial load
-      const firstBatch = [
-        createMockEvent({ event_id: 'evt-1' }),
-        createMockEvent({ event_id: 'evt-2' }),
-      ];
-      store.getState().setEvents(firstBatch, 100, true);
-
-      expect(store.getState().offset).toBe(2);
-      expect(store.getState().hasMore).toBe(true);
-
-      // Load more
-      store.getState().loadMore();
-      expect(store.getState().offset).toBe(52); // 2 + 50
-    });
-
-    it('should handle filter change flow', () => {
-      // Initial load
-      const events = [createMockEvent()];
-      store.getState().setEvents(events, 100, true);
-      store.setState({ offset: 50 });
-
-      // Change filters - should reset offset
-      store.getState().setFilters({ actor: 'user' });
-
-      expect(store.getState().offset).toBe(0);
-    });
-
-    it('should handle real-time event additions', () => {
-      // Initial load
-      const events = [
-        createMockEvent({ event_id: 'evt-1', created_at_ms: 1700000000000 }),
-        createMockEvent({ event_id: 'evt-2', created_at_ms: 1700000001000 }),
-      ];
-      store.getState().setEvents(events, 2, false);
-
-      // New real-time event
-      const newEvent = createMockEvent({
-        event_id: 'evt-3',
-        created_at_ms: 1700000002000,
-      });
-      store.getState().addEvent(newEvent);
-
-      const state = store.getState();
-      expect(state.events).toHaveLength(3);
-      expect(state.events[0].event_id).toBe('evt-3'); // Most recent first (desc)
-      expect(state.total).toBe(3);
-    });
-  });
+	describe("setSort", () => {
+		it("should set sort to asc and reset offset", () => {
+			store.setState({ offset: 50 });
+
+			store.getState().setSort("asc");
+
+			const state = store.getState();
+			expect(state.sort).toBe("asc");
+			expect(state.offset).toBe(0);
+		});
+
+		it("should set sort to desc and reset offset", () => {
+			store.setState({ offset: 50, sort: "asc" });
+
+			store.getState().setSort("desc");
+
+			const state = store.getState();
+			expect(state.sort).toBe("desc");
+			expect(state.offset).toBe(0);
+		});
+	});
+
+	describe("setLoading", () => {
+		it("should set loading to true", () => {
+			store.getState().setLoading(true);
+
+			expect(store.getState().loading).toBe(true);
+		});
+
+		it("should set loading to false", () => {
+			store.setState({ loading: true });
+
+			store.getState().setLoading(false);
+
+			expect(store.getState().loading).toBe(false);
+		});
+	});
+
+	describe("setError", () => {
+		it("should set error message and stop loading", () => {
+			store.setState({ loading: true });
+
+			store.getState().setError("Failed to load timeline");
+
+			const state = store.getState();
+			expect(state.error).toBe("Failed to load timeline");
+			expect(state.loading).toBe(false);
+		});
+
+		it("should clear error", () => {
+			store.setState({ error: "Previous error", loading: true });
+
+			store.getState().setError(null);
+
+			const state = store.getState();
+			expect(state.error).toBe(null);
+			expect(state.loading).toBe(false);
+		});
+	});
+
+	describe("loadMore", () => {
+		it("should increment offset by limit", () => {
+			store.setState({ limit: 20, offset: 0 });
+
+			store.getState().loadMore();
+
+			expect(store.getState().offset).toBe(20);
+
+			store.getState().loadMore();
+
+			expect(store.getState().offset).toBe(40);
+		});
+
+		it("should respect custom limit", () => {
+			store.setState({ limit: 100, offset: 0 });
+
+			store.getState().loadMore();
+
+			expect(store.getState().offset).toBe(100);
+		});
+	});
+
+	describe("reset", () => {
+		it("should reset to initial state", () => {
+			// Modify state
+			store.setState({
+				events: [createMockEvent()],
+				total: 100,
+				hasMore: true,
+				loading: true,
+				error: "Some error",
+				filters: { actor: "user" },
+				sort: "asc",
+				limit: 100,
+				offset: 50,
+			});
+
+			store.getState().reset();
+
+			const state = store.getState();
+			expect(state.events).toEqual([]);
+			expect(state.total).toBe(0);
+			expect(state.hasMore).toBe(false);
+			expect(state.loading).toBe(false);
+			expect(state.error).toBe(null);
+			expect(state.filters).toEqual({});
+			expect(state.sort).toBe("desc");
+			expect(state.limit).toBe(50);
+			expect(state.offset).toBe(0);
+		});
+	});
+
+	describe("integration scenarios", () => {
+		it("should handle pagination flow", () => {
+			// Initial load
+			const firstBatch = [
+				createMockEvent({ event_id: "evt-1" }),
+				createMockEvent({ event_id: "evt-2" }),
+			];
+			store.getState().setEvents(firstBatch, 100, true);
+
+			expect(store.getState().offset).toBe(2);
+			expect(store.getState().hasMore).toBe(true);
+
+			// Load more
+			store.getState().loadMore();
+			expect(store.getState().offset).toBe(52); // 2 + 50
+		});
+
+		it("should handle filter change flow", () => {
+			// Initial load
+			const events = [createMockEvent()];
+			store.getState().setEvents(events, 100, true);
+			store.setState({ offset: 50 });
+
+			// Change filters - should reset offset
+			store.getState().setFilters({ actor: "user" });
+
+			expect(store.getState().offset).toBe(0);
+		});
+
+		it("should handle real-time event additions", () => {
+			// Initial load
+			const events = [
+				createMockEvent({ event_id: "evt-1", created_at_ms: 1700000000000 }),
+				createMockEvent({ event_id: "evt-2", created_at_ms: 1700000001000 }),
+			];
+			store.getState().setEvents(events, 2, false);
+
+			// New real-time event
+			const newEvent = createMockEvent({
+				event_id: "evt-3",
+				created_at_ms: 1700000002000,
+			});
+			store.getState().addEvent(newEvent);
+
+			const state = store.getState();
+			expect(state.events).toHaveLength(3);
+			expect(state.events[0].event_id).toBe("evt-3"); // Most recent first (desc)
+			expect(state.total).toBe(3);
+		});
+	});
 });

--- a/client/src/core/state/slices/aiSlice.ts
+++ b/client/src/core/state/slices/aiSlice.ts
@@ -1,185 +1,182 @@
-import type { StateCreator } from 'zustand';
-import type { AIMode, AIMessage, CodeBlock, PlanStep, ToolCallLog } from '@shared/types';
+import type { AIMessage, AIMode, CodeBlock, PlanStep, ToolCallLog } from "@shared/types";
+import type { StateCreator } from "zustand";
 
 type StreamingExtras = {
-  codeBlocks?: CodeBlock[];
-  planSteps?: PlanStep[];
-  toolLogs?: ToolCallLog[];
+	codeBlocks?: CodeBlock[];
+	planSteps?: PlanStep[];
+	toolLogs?: ToolCallLog[];
 };
 
 const updateStreamingMessage = (
-  messages: AIMessage[],
-  streamingId: string,
-  updater: (message: AIMessage) => AIMessage,
+	messages: AIMessage[],
+	streamingId: string,
+	updater: (message: AIMessage) => AIMessage,
 ): AIMessage[] => {
-  const idx = messages.findIndex(
-    (message) => message.streamingId === streamingId || message.id === streamingId,
-  );
+	const idx = messages.findIndex(
+		(message) => message.streamingId === streamingId || message.id === streamingId,
+	);
 
-  if (idx === -1) {
-    return messages;
-  }
+	if (idx === -1) {
+		return messages;
+	}
 
-  const next = [...messages];
-  next[idx] = updater(next[idx]);
-  return next;
+	const next = [...messages];
+	next[idx] = updater(next[idx]);
+	return next;
 };
 
-const upsertToolLog = (
-  logs: ToolCallLog[] | undefined,
-  incoming: ToolCallLog,
-): ToolCallLog[] => {
-  if (!logs) {
-    return [incoming];
-  }
+const upsertToolLog = (logs: ToolCallLog[] | undefined, incoming: ToolCallLog): ToolCallLog[] => {
+	if (!logs) {
+		return [incoming];
+	}
 
-  const idx = logs.findIndex((log) => log.id === incoming.id);
-  if (idx === -1) {
-    return [...logs, incoming];
-  }
+	const idx = logs.findIndex((log) => log.id === incoming.id);
+	if (idx === -1) {
+		return [...logs, incoming];
+	}
 
-  const next = [...logs];
-  next[idx] = { ...next[idx], ...incoming };
-  return next;
+	const next = [...logs];
+	next[idx] = { ...next[idx], ...incoming };
+	return next;
 };
 
 export interface PatchMatchStatus {
-  lastFailureId: string | null;
-  lastFailureReason: string | null;
+	lastFailureId: string | null;
+	lastFailureReason: string | null;
 }
 
 export interface AIState {
-  ai: {
-    messages: AIMessage[];
-    isLoading: boolean;
-    suggestions: string[];
-    patchMatchFailures: number;
-    patchMatchStatus: PatchMatchStatus;
-  };
-  addAIMessage: (message: AIMessage) => void;
-  setAILoading: (isLoading: boolean) => void;
-  clearAIMessages: () => void;
-  setAIMessages: (messages: AIMessage[]) => void;
-  setAISuggestions: (suggestions: string[]) => void;
-  recordPatchMatchFailure: (reason: string, id: string) => void;
-  recordPatchMatchSuccess: () => void;
-  startStreamingMessage: (streamingId: string, mode?: AIMode) => void;
-  appendStreamingChunk: (streamingId: string, chunk: string) => void;
-  updateStreamingPlan: (streamingId: string, plan: PlanStep[]) => void;
-  recordToolEvent: (streamingId: string, log: ToolCallLog) => void;
-  completeStreamingMessage: (
-    streamingId: string,
-    finalContent?: string,
-    extras?: StreamingExtras,
-  ) => void;
+	ai: {
+		messages: AIMessage[];
+		isLoading: boolean;
+		suggestions: string[];
+		patchMatchFailures: number;
+		patchMatchStatus: PatchMatchStatus;
+	};
+	addAIMessage: (message: AIMessage) => void;
+	setAILoading: (isLoading: boolean) => void;
+	clearAIMessages: () => void;
+	setAIMessages: (messages: AIMessage[]) => void;
+	setAISuggestions: (suggestions: string[]) => void;
+	recordPatchMatchFailure: (reason: string, id: string) => void;
+	recordPatchMatchSuccess: () => void;
+	startStreamingMessage: (streamingId: string, mode?: AIMode) => void;
+	appendStreamingChunk: (streamingId: string, chunk: string) => void;
+	updateStreamingPlan: (streamingId: string, plan: PlanStep[]) => void;
+	recordToolEvent: (streamingId: string, log: ToolCallLog) => void;
+	completeStreamingMessage: (
+		streamingId: string,
+		finalContent?: string,
+		extras?: StreamingExtras,
+	) => void;
 }
 
 export const createAISlice: StateCreator<AIState> = (set) => ({
-  ai: {
-    messages: [],
-    isLoading: false,
-    suggestions: [],
-    patchMatchFailures: 0,
-    patchMatchStatus: { lastFailureId: null, lastFailureReason: null },
-  },
-  addAIMessage: (message) =>
-    set((state) => ({
-      ai: { ...state.ai, messages: [...state.ai.messages, message] }
-    })),
-  setAIMessages: (messages) =>
-    set((state) => ({
-      ai: { ...state.ai, messages }
-    })),
-  setAILoading: (isLoading) =>
-    set((state) => ({
-      ai: { ...state.ai, isLoading }
-    })),
-  clearAIMessages: () =>
-    set((state) => ({
-      ai: { ...state.ai, messages: [] }
-    })),
-  setAISuggestions: (suggestions) =>
-    set((state) => ({
-      ai: { ...state.ai, suggestions }
-    })),
-  recordPatchMatchFailure: (reason, id) =>
-    set((state) => ({
-      ai: {
-        ...state.ai,
-        patchMatchFailures: state.ai.patchMatchFailures + 1,
-        patchMatchStatus: {
-          lastFailureId: id,
-          lastFailureReason: reason,
-        },
-      },
-    })),
-  recordPatchMatchSuccess: () =>
-    set((state) => ({
-      ai: {
-        ...state.ai,
-        patchMatchStatus: { lastFailureId: null, lastFailureReason: null },
-      },
-    })),
-  startStreamingMessage: (streamingId, mode) =>
-    set((state) => ({
-      ai: {
-        ...state.ai,
-        messages: [
-          ...state.ai.messages,
-          {
-            id: streamingId,
-            streamingId,
-            role: 'assistant',
-            content: '',
-            isComplete: false,
-            timestamp: Date.now(),
-            mode,
-          },
-        ],
-      },
-    })),
-  appendStreamingChunk: (streamingId, chunk) =>
-    set((state) => ({
-      ai: {
-        ...state.ai,
-        messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => ({
-          ...message,
-          content: `${message.content ?? ''}${chunk}`,
-        })),
-      },
-    })),
-  updateStreamingPlan: (streamingId, plan) =>
-    set((state) => ({
-      ai: {
-        ...state.ai,
-        messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => ({
-          ...message,
-          planSteps: plan,
-        })),
-      },
-    })),
-  recordToolEvent: (streamingId, log) =>
-    set((state) => ({
-      ai: {
-        ...state.ai,
-        messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => ({
-          ...message,
-          toolLogs: upsertToolLog(message.toolLogs, log),
-        })),
-      },
-    })),
-  completeStreamingMessage: (streamingId, finalContent, extras) =>
-    set((state) => ({
-      ai: {
-        ...state.ai,
-        messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => ({
-          ...message,
-          content: finalContent ?? message.content,
-          isComplete: true,
-          codeBlocks: extras?.codeBlocks ?? message.codeBlocks,
-          planSteps: extras?.planSteps ?? message.planSteps,
-          toolLogs: extras?.toolLogs ?? message.toolLogs,
-        })),
-      },
-    })),
+	ai: {
+		messages: [],
+		isLoading: false,
+		suggestions: [],
+		patchMatchFailures: 0,
+		patchMatchStatus: { lastFailureId: null, lastFailureReason: null },
+	},
+	addAIMessage: (message) =>
+		set((state) => ({
+			ai: { ...state.ai, messages: [...state.ai.messages, message] },
+		})),
+	setAIMessages: (messages) =>
+		set((state) => ({
+			ai: { ...state.ai, messages },
+		})),
+	setAILoading: (isLoading) =>
+		set((state) => ({
+			ai: { ...state.ai, isLoading },
+		})),
+	clearAIMessages: () =>
+		set((state) => ({
+			ai: { ...state.ai, messages: [] },
+		})),
+	setAISuggestions: (suggestions) =>
+		set((state) => ({
+			ai: { ...state.ai, suggestions },
+		})),
+	recordPatchMatchFailure: (reason, id) =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				patchMatchFailures: state.ai.patchMatchFailures + 1,
+				patchMatchStatus: {
+					lastFailureId: id,
+					lastFailureReason: reason,
+				},
+			},
+		})),
+	recordPatchMatchSuccess: () =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				patchMatchStatus: { lastFailureId: null, lastFailureReason: null },
+			},
+		})),
+	startStreamingMessage: (streamingId, mode) =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				messages: [
+					...state.ai.messages,
+					{
+						id: streamingId,
+						streamingId,
+						role: "assistant",
+						content: "",
+						isComplete: false,
+						timestamp: Date.now(),
+						mode,
+					},
+				],
+			},
+		})),
+	appendStreamingChunk: (streamingId, chunk) =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => ({
+					...message,
+					content: `${message.content ?? ""}${chunk}`,
+				})),
+			},
+		})),
+	updateStreamingPlan: (streamingId, plan) =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => ({
+					...message,
+					planSteps: plan,
+				})),
+			},
+		})),
+	recordToolEvent: (streamingId, log) =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => ({
+					...message,
+					toolLogs: upsertToolLog(message.toolLogs, log),
+				})),
+			},
+		})),
+	completeStreamingMessage: (streamingId, finalContent, extras) =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => ({
+					...message,
+					content: finalContent ?? message.content,
+					isComplete: true,
+					codeBlocks: extras?.codeBlocks ?? message.codeBlocks,
+					planSteps: extras?.planSteps ?? message.planSteps,
+					toolLogs: extras?.toolLogs ?? message.toolLogs,
+				})),
+			},
+		})),
 });

--- a/client/src/core/state/slices/connectionSlice.ts
+++ b/client/src/core/state/slices/connectionSlice.ts
@@ -1,11 +1,11 @@
-import type { StateCreator } from 'zustand';
+import type { StateCreator } from "zustand";
 
 export interface ConnectionState {
-  isConnected: boolean;
-  setConnected: (connected: boolean) => void;
+	isConnected: boolean;
+	setConnected: (connected: boolean) => void;
 }
 
 export const createConnectionSlice: StateCreator<ConnectionState> = (set) => ({
-  isConnected: false,
-  setConnected: (isConnected) => set({ isConnected })
+	isConnected: false,
+	setConnected: (isConnected) => set({ isConnected }),
 });

--- a/client/src/core/state/slices/editorSlice.ts
+++ b/client/src/core/state/slices/editorSlice.ts
@@ -1,7 +1,7 @@
-import type { RefObject } from 'react';
-import type { StateCreator } from 'zustand';
-import type { CodeBlock } from '@shared/types';
-import type { EditorRef } from '@/components/editor/editorRef';
+import type { CodeBlock } from "@shared/types";
+import type { RefObject } from "react";
+import type { StateCreator } from "zustand";
+import type { EditorRef } from "@/components/editor/editorRef";
 
 export const DEFAULT_R_SCRIPT = `# Welcome to Re-prod ----
 # AI-Powered R Analysis IDE
@@ -27,62 +27,62 @@ abline(lm(hp ~ mpg, data = mtcars), col = "red", lwd = 2)
 `;
 
 export interface EditorState {
-  editor: {
-    content: string;
-    filepath: string;
-    isDirty: boolean;
-    cursorPosition: {
-      line: number;
-      column: number;
-    };
-  };
-  monacoEditor: any | null;
-  applyCodeChange: ((codeBlock: CodeBlock) => void) | null;
-  runCurrentCell: (() => void) | null;
-  runAll: (() => void) | null;
-  editorRef: RefObject<EditorRef> | null;
-  setEditorContent: (content: string) => void;
-  setEditorFilepath: (filepath: string) => void;
-  setEditorCursorPosition: (position: { line: number; column: number }) => void;
-  setEditorIsDirty: (isDirty: boolean) => void;
-  setMonacoEditor: (editor: any) => void;
-  setApplyCodeChange: (handler: (codeBlock: CodeBlock) => void) => void;
-  setRunCurrentCell: (handler: () => void) => void;
-  setRunAll: (handler: () => void) => void;
-  setEditorRef: (editorRef: RefObject<EditorRef> | null) => void;
+	editor: {
+		content: string;
+		filepath: string;
+		isDirty: boolean;
+		cursorPosition: {
+			line: number;
+			column: number;
+		};
+	};
+	monacoEditor: any | null;
+	applyCodeChange: ((codeBlock: CodeBlock) => void) | null;
+	runCurrentCell: (() => void) | null;
+	runAll: (() => void) | null;
+	editorRef: RefObject<EditorRef> | null;
+	setEditorContent: (content: string) => void;
+	setEditorFilepath: (filepath: string) => void;
+	setEditorCursorPosition: (position: { line: number; column: number }) => void;
+	setEditorIsDirty: (isDirty: boolean) => void;
+	setMonacoEditor: (editor: any) => void;
+	setApplyCodeChange: (handler: (codeBlock: CodeBlock) => void) => void;
+	setRunCurrentCell: (handler: () => void) => void;
+	setRunAll: (handler: () => void) => void;
+	setEditorRef: (editorRef: RefObject<EditorRef> | null) => void;
 }
 
 export const createEditorSlice: StateCreator<EditorState> = (set) => ({
-  editor: {
-    content: DEFAULT_R_SCRIPT,
-    filepath: '',
-    isDirty: false,
-    cursorPosition: { line: 1, column: 1 }
-  },
-  monacoEditor: null,
-  applyCodeChange: null,
-  runCurrentCell: null,
-  runAll: null,
-  editorRef: null,
-  setEditorContent: (content) =>
-    set((state) => ({
-      editor: { ...state.editor, content, isDirty: true }
-    })),
-  setEditorFilepath: (filepath) =>
-    set((state) => ({
-      editor: { ...state.editor, filepath }
-    })),
-  setEditorCursorPosition: (cursorPosition) =>
-    set((state) => ({
-      editor: { ...state.editor, cursorPosition }
-    })),
-  setEditorIsDirty: (isDirty) =>
-    set((state) => ({
-      editor: { ...state.editor, isDirty }
-    })),
-  setMonacoEditor: (monacoEditor) => set({ monacoEditor }),
-  setApplyCodeChange: (handler) => set({ applyCodeChange: handler }),
-  setRunCurrentCell: (handler) => set({ runCurrentCell: handler }),
-  setRunAll: (handler) => set({ runAll: handler }),
-  setEditorRef: (editorRef: RefObject<EditorRef> | null) => set({ editorRef })
+	editor: {
+		content: DEFAULT_R_SCRIPT,
+		filepath: "",
+		isDirty: false,
+		cursorPosition: { line: 1, column: 1 },
+	},
+	monacoEditor: null,
+	applyCodeChange: null,
+	runCurrentCell: null,
+	runAll: null,
+	editorRef: null,
+	setEditorContent: (content) =>
+		set((state) => ({
+			editor: { ...state.editor, content, isDirty: true },
+		})),
+	setEditorFilepath: (filepath) =>
+		set((state) => ({
+			editor: { ...state.editor, filepath },
+		})),
+	setEditorCursorPosition: (cursorPosition) =>
+		set((state) => ({
+			editor: { ...state.editor, cursorPosition },
+		})),
+	setEditorIsDirty: (isDirty) =>
+		set((state) => ({
+			editor: { ...state.editor, isDirty },
+		})),
+	setMonacoEditor: (monacoEditor) => set({ monacoEditor }),
+	setApplyCodeChange: (handler) => set({ applyCodeChange: handler }),
+	setRunCurrentCell: (handler) => set({ runCurrentCell: handler }),
+	setRunAll: (handler) => set({ runAll: handler }),
+	setEditorRef: (editorRef: RefObject<EditorRef> | null) => set({ editorRef }),
 });

--- a/client/src/core/state/slices/executionSlice.ts
+++ b/client/src/core/state/slices/executionSlice.ts
@@ -1,64 +1,64 @@
-import type { StateCreator } from 'zustand';
-import type { ExecutionLogEntry } from '@shared/types';
+import type { ExecutionLogEntry } from "@shared/types";
+import type { StateCreator } from "zustand";
 
 export interface ExecutionState {
-  execution: {
-    isRunning: boolean;
-    results: ExecutionLogEntry[];
-    history: ExecutionLogEntry[];
-    currentCell: number | undefined;
-  };
-  setIsRunning: (isRunning: boolean) => void;
-  addExecutionResult: (result: ExecutionLogEntry) => void;
-  clearExecutionResults: () => void;
-  setCurrentCell: (cellIndex: number | undefined) => void;
-  resetExecutionState: () => void;
-  loadExecutionHistory: (history: ExecutionLogEntry[]) => void;
+	execution: {
+		isRunning: boolean;
+		results: ExecutionLogEntry[];
+		history: ExecutionLogEntry[];
+		currentCell: number | undefined;
+	};
+	setIsRunning: (isRunning: boolean) => void;
+	addExecutionResult: (result: ExecutionLogEntry) => void;
+	clearExecutionResults: () => void;
+	setCurrentCell: (cellIndex: number | undefined) => void;
+	resetExecutionState: () => void;
+	loadExecutionHistory: (history: ExecutionLogEntry[]) => void;
 }
 
 export const createExecutionSlice: StateCreator<ExecutionState> = (set) => ({
-  execution: {
-    isRunning: false,
-    results: [],
-    history: [],
-    currentCell: undefined
-  },
-  setIsRunning: (isRunning) =>
-    set((state) => ({
-      execution: { ...state.execution, isRunning }
-    })),
-  addExecutionResult: (result) =>
-    set((state) => ({
-      execution: {
-        ...state.execution,
-        results: [...state.execution.results, result],
-        history: [...state.execution.history, result]
-      }
-    })),
-  clearExecutionResults: () =>
-    set((state) => ({
-      execution: { ...state.execution, results: [] }
-    })),
-  setCurrentCell: (currentCell) =>
-    set((state) => ({
-      execution: { ...state.execution, currentCell }
-    })),
-  resetExecutionState: () =>
-    set(() => ({
-      execution: {
-        isRunning: false,
-        results: [],
-        history: [],
-        currentCell: undefined
-      }
-    })),
-  loadExecutionHistory: (history) =>
-    set(() => ({
-      execution: {
-        isRunning: false,
-        results: history.slice(-10),
-        history,
-        currentCell: undefined
-      }
-    }))
+	execution: {
+		isRunning: false,
+		results: [],
+		history: [],
+		currentCell: undefined,
+	},
+	setIsRunning: (isRunning) =>
+		set((state) => ({
+			execution: { ...state.execution, isRunning },
+		})),
+	addExecutionResult: (result) =>
+		set((state) => ({
+			execution: {
+				...state.execution,
+				results: [...state.execution.results, result],
+				history: [...state.execution.history, result],
+			},
+		})),
+	clearExecutionResults: () =>
+		set((state) => ({
+			execution: { ...state.execution, results: [] },
+		})),
+	setCurrentCell: (currentCell) =>
+		set((state) => ({
+			execution: { ...state.execution, currentCell },
+		})),
+	resetExecutionState: () =>
+		set(() => ({
+			execution: {
+				isRunning: false,
+				results: [],
+				history: [],
+				currentCell: undefined,
+			},
+		})),
+	loadExecutionHistory: (history) =>
+		set(() => ({
+			execution: {
+				isRunning: false,
+				results: history.slice(-10),
+				history,
+				currentCell: undefined,
+			},
+		})),
 });

--- a/client/src/core/state/slices/projectSlice.ts
+++ b/client/src/core/state/slices/projectSlice.ts
@@ -1,20 +1,20 @@
-import type { StateCreator } from 'zustand';
-import type { ProjectRecord } from 'shared';
+import type { ProjectRecord } from "shared";
+import type { StateCreator } from "zustand";
 
 export interface ProjectState {
-  project: ProjectRecord | null;
-  projects: ProjectRecord[];
-  lastRestoredState: Record<string, unknown> | null;
-  setProject: (project: ProjectRecord | null) => void;
-  setProjects: (projects: ProjectRecord[]) => void;
-  setLastRestoredState: (state: Record<string, unknown> | null) => void;
+	project: ProjectRecord | null;
+	projects: ProjectRecord[];
+	lastRestoredState: Record<string, unknown> | null;
+	setProject: (project: ProjectRecord | null) => void;
+	setProjects: (projects: ProjectRecord[]) => void;
+	setLastRestoredState: (state: Record<string, unknown> | null) => void;
 }
 
 export const createProjectSlice: StateCreator<ProjectState> = (set) => ({
-  project: null,
-  projects: [],
-  lastRestoredState: null,
-  setProject: (project) => set({ project }),
-  setProjects: (projects) => set({ projects }),
-  setLastRestoredState: (state) => set({ lastRestoredState: state }),
+	project: null,
+	projects: [],
+	lastRestoredState: null,
+	setProject: (project) => set({ project }),
+	setProjects: (projects) => set({ projects }),
+	setLastRestoredState: (state) => set({ lastRestoredState: state }),
 });

--- a/client/src/core/state/slices/settingsSlice.ts
+++ b/client/src/core/state/slices/settingsSlice.ts
@@ -1,16 +1,16 @@
-import type { StateCreator } from 'zustand';
-import type { AppSettings } from '@shared/types';
-import { DEFAULT_SETTINGS } from '@/constants/defaultSettings';
+import type { AppSettings } from "@shared/types";
+import type { StateCreator } from "zustand";
+import { DEFAULT_SETTINGS } from "@/constants/defaultSettings";
 
 export interface SettingsState {
-  settings: AppSettings;
-  updateSettings: (settings: Partial<AppSettings>) => void;
+	settings: AppSettings;
+	updateSettings: (settings: Partial<AppSettings>) => void;
 }
 
 export const createSettingsSlice: StateCreator<SettingsState> = (set) => ({
-  settings: { ...DEFAULT_SETTINGS },
-  updateSettings: (newSettings) =>
-    set((state) => ({
-      settings: { ...state.settings, ...newSettings }
-    }))
+	settings: { ...DEFAULT_SETTINGS },
+	updateSettings: (newSettings) =>
+		set((state) => ({
+			settings: { ...state.settings, ...newSettings },
+		})),
 });

--- a/client/src/core/state/slices/settingsStore.ts
+++ b/client/src/core/state/slices/settingsStore.ts
@@ -1,121 +1,125 @@
-import { create } from 'zustand';
-import { API_CONFIG_PROVIDER_URL, getApiKeyUrl, getTestConnectionUrl } from '@/constants/urls';
+import { create } from "zustand";
+import { API_CONFIG_PROVIDER_URL, getApiKeyUrl, getTestConnectionUrl } from "@/constants/urls";
 
 interface Provider {
-  name: string;
-  displayName: string;
-  models: string[];
-  apiKeyMasked?: string;
-  isConfigured: boolean;
+	name: string;
+	displayName: string;
+	models: string[];
+	apiKeyMasked?: string;
+	isConfigured: boolean;
 }
 
 interface SettingsState {
-  activeProvider: string;
-  providers: Provider[];
-  isLoading: boolean;
-  error: string | null;
+	activeProvider: string;
+	providers: Provider[];
+	isLoading: boolean;
+	error: string | null;
 
-  fetchSettings: () => Promise<void>;
-  setActiveProvider: (provider: string) => Promise<void>;
-  setApiKey: (provider: string, apiKey: string) => Promise<void>;
-  testConnection: (provider: string) => Promise<boolean>;
+	fetchSettings: () => Promise<void>;
+	setActiveProvider: (provider: string) => Promise<void>;
+	setApiKey: (provider: string, apiKey: string) => Promise<void>;
+	testConnection: (provider: string) => Promise<boolean>;
 }
 
 const DEFAULT_PROVIDERS: Provider[] = [
-  {
-    name: 'anthropic',
-    displayName: 'Anthropic Claude',
-    models: ['claude-3-5-sonnet-20240620', 'claude-3-opus-20240229'],
-    isConfigured: false,
-  },
-  {
-    name: 'openai',
-    displayName: 'OpenAI GPT',
-    models: ['gpt-5', 'gpt-4-turbo', 'gpt-4o'],
-    isConfigured: false,
-  },
+	{
+		name: "anthropic",
+		displayName: "Anthropic Claude",
+		models: ["claude-3-5-sonnet-20240620", "claude-3-opus-20240229"],
+		isConfigured: false,
+	},
+	{
+		name: "openai",
+		displayName: "OpenAI GPT",
+		models: ["gpt-5", "gpt-4-turbo", "gpt-4o"],
+		isConfigured: false,
+	},
 ];
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
-  activeProvider: 'openai',
-  providers: DEFAULT_PROVIDERS,
-  isLoading: false,
-  error: null,
+	activeProvider: "openai",
+	providers: DEFAULT_PROVIDERS,
+	isLoading: false,
+	error: null,
 
-  fetchSettings: async () => {
-    set({ isLoading: true, error: null });
-    try {
-      // Fetch active provider
-      const providerRes = await fetch(API_CONFIG_PROVIDER_URL);
-      if (!providerRes.ok) throw new Error('Failed to fetch active provider');
-      const { provider } = await providerRes.json();
+	fetchSettings: async () => {
+		set({ isLoading: true, error: null });
+		try {
+			// Fetch active provider
+			const providerRes = await fetch(API_CONFIG_PROVIDER_URL);
+			if (!providerRes.ok) throw new Error("Failed to fetch active provider");
+			const { provider } = await providerRes.json();
 
-      // Fetch API key status for each provider
-      const updatedProviders = await Promise.all(
-        DEFAULT_PROVIDERS.map(async (p) => {
-          try {
-            const res = await fetch(getApiKeyUrl(p.name));
-            if (res.ok) {
-              const { api_key } = await res.json();
-              return { ...p, isConfigured: true, apiKeyMasked: api_key };
-            }
-          } catch (e) {
-            // Ignore errors, means not configured
-          }
-          return p;
-        })
-      );
+			// Fetch API key status for each provider
+			const updatedProviders = await Promise.all(
+				DEFAULT_PROVIDERS.map(async (p) => {
+					try {
+						const res = await fetch(getApiKeyUrl(p.name));
+						if (res.ok) {
+							const { api_key } = await res.json();
+							return { ...p, isConfigured: true, apiKeyMasked: api_key };
+						}
+					} catch (e) {
+						// Ignore errors, means not configured
+					}
+					return p;
+				}),
+			);
 
-      set({ activeProvider: provider, providers: updatedProviders, isLoading: false });
-    } catch (err: any) {
-      set({ error: err.message, isLoading: false });
-    }
-  },
+			set({
+				activeProvider: provider,
+				providers: updatedProviders,
+				isLoading: false,
+			});
+		} catch (err: any) {
+			set({ error: err.message, isLoading: false });
+		}
+	},
 
-  setActiveProvider: async (provider: string) => {
-    set({ isLoading: true, error: null });
-    try {
-      const res = await fetch(API_CONFIG_PROVIDER_URL, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider }),
-      });
-      if (!res.ok) throw new Error('Failed to set active provider');
-      set({ activeProvider: provider, isLoading: false });
-    } catch (err: any) {
-      set({ error: err.message, isLoading: false });
-    }
-  },
+	setActiveProvider: async (provider: string) => {
+		set({ isLoading: true, error: null });
+		try {
+			const res = await fetch(API_CONFIG_PROVIDER_URL, {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ provider }),
+			});
+			if (!res.ok) throw new Error("Failed to set active provider");
+			set({ activeProvider: provider, isLoading: false });
+		} catch (err: any) {
+			set({ error: err.message, isLoading: false });
+		}
+	},
 
-  setApiKey: async (provider: string, apiKey: string) => {
-    set({ isLoading: true, error: null });
-    try {
-      const res = await fetch(getApiKeyUrl(provider), {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ api_key: apiKey }),
-      });
-      if (!res.ok) throw new Error('Failed to set API key');
-      
-      // Refresh settings to get the masked key
-      await get().fetchSettings();
-    } catch (err: any) {
-      set({ error: err.message, isLoading: false });
-    }
-  },
+	setApiKey: async (provider: string, apiKey: string) => {
+		set({ isLoading: true, error: null });
+		try {
+			const res = await fetch(getApiKeyUrl(provider), {
+				method: "PUT",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ api_key: apiKey }),
+			});
+			if (!res.ok) throw new Error("Failed to set API key");
 
-  testConnection: async (provider: string) => {
-    set({ isLoading: true, error: null });
-    try {
-      const res = await fetch(getTestConnectionUrl(provider), {
-        method: 'POST',
-      });
-      if (!res.ok) throw new Error('Connection test failed');
-      set({ isLoading: false });
-      return true;
-    } catch (err: any) {
-      set({ error: err.message, isLoading: false });
-      return false;
-    }
-  },
+			// Refresh settings to get the masked key
+			await get().fetchSettings();
+		} catch (err: any) {
+			set({ error: err.message, isLoading: false });
+		}
+	},
+
+	testConnection: async (provider: string) => {
+		set({ isLoading: true, error: null });
+		try {
+			const res = await fetch(getTestConnectionUrl(provider), {
+				method: "POST",
+			});
+			if (!res.ok) throw new Error("Connection test failed");
+			set({ isLoading: false });
+			return true;
+		} catch (err: any) {
+			set({ error: err.message, isLoading: false });
+			return false;
+		}
+	},
 }));

--- a/client/src/core/state/slices/timelineSlice.ts
+++ b/client/src/core/state/slices/timelineSlice.ts
@@ -1,102 +1,102 @@
-import type { StateCreator } from 'zustand';
-import type { ExecutionEventPayload, TimelineQuery } from 'shared';
+import type { ExecutionEventPayload, TimelineQuery } from "shared";
+import type { StateCreator } from "zustand";
 
 export interface TimelineState {
-  // Events data
-  events: ExecutionEventPayload[];
-  total: number;
-  hasMore: boolean;
-  loading: boolean;
-  error: string | null;
+	// Events data
+	events: ExecutionEventPayload[];
+	total: number;
+	hasMore: boolean;
+	loading: boolean;
+	error: string | null;
 
-  // Query parameters
-  filters: TimelineQuery['filters'];
-  sort: 'asc' | 'desc';
-  limit: number;
-  offset: number;
+	// Query parameters
+	filters: TimelineQuery["filters"];
+	sort: "asc" | "desc";
+	limit: number;
+	offset: number;
 
-  // Actions
-  setEvents: (events: ExecutionEventPayload[], total: number, hasMore: boolean) => void;
-  addEvent: (event: ExecutionEventPayload) => void;
-  setFilters: (filters: TimelineQuery['filters']) => void;
-  setSort: (sort: 'asc' | 'desc') => void;
-  setLoading: (loading: boolean) => void;
-  setError: (error: string | null) => void;
-  loadMore: () => void;
-  reset: () => void;
+	// Actions
+	setEvents: (events: ExecutionEventPayload[], total: number, hasMore: boolean) => void;
+	addEvent: (event: ExecutionEventPayload) => void;
+	setFilters: (filters: TimelineQuery["filters"]) => void;
+	setSort: (sort: "asc" | "desc") => void;
+	setLoading: (loading: boolean) => void;
+	setError: (error: string | null) => void;
+	loadMore: () => void;
+	reset: () => void;
 }
 
 const initialState = {
-  events: [],
-  total: 0,
-  hasMore: false,
-  loading: false,
-  error: null,
-  filters: {},
-  sort: 'desc' as const,
-  limit: 50,
-  offset: 0,
+	events: [],
+	total: 0,
+	hasMore: false,
+	loading: false,
+	error: null,
+	filters: {},
+	sort: "desc" as const,
+	limit: 50,
+	offset: 0,
 };
 
 export const createTimelineSlice: StateCreator<TimelineState> = (set) => ({
-  ...initialState,
+	...initialState,
 
-  setEvents: (events, total, hasMore) =>
-    set(() => ({
-      events,
-      total,
-      hasMore,
-      offset: events.length,
-      loading: false,
-      error: null,
-    })),
+	setEvents: (events, total, hasMore) =>
+		set(() => ({
+			events,
+			total,
+			hasMore,
+			offset: events.length,
+			loading: false,
+			error: null,
+		})),
 
-  addEvent: (event) =>
-    set((state) => {
-      const exists = state.events.some((existing) => existing.event_id === event.event_id);
-      if (exists) {
-        return {};
-      }
+	addEvent: (event) =>
+		set((state) => {
+			const exists = state.events.some((existing) => existing.event_id === event.event_id);
+			if (exists) {
+				return {};
+			}
 
-      let nextEvents: ExecutionEventPayload[];
-      if (state.sort === 'asc') {
-        nextEvents = [...state.events, event];
-        if (nextEvents.length > state.limit) {
-          nextEvents = nextEvents.slice(nextEvents.length - state.limit);
-        }
-      } else {
-        nextEvents = [event, ...state.events];
-        if (nextEvents.length > state.limit) {
-          nextEvents = nextEvents.slice(0, state.limit);
-        }
-      }
+			let nextEvents: ExecutionEventPayload[];
+			if (state.sort === "asc") {
+				nextEvents = [...state.events, event];
+				if (nextEvents.length > state.limit) {
+					nextEvents = nextEvents.slice(nextEvents.length - state.limit);
+				}
+			} else {
+				nextEvents = [event, ...state.events];
+				if (nextEvents.length > state.limit) {
+					nextEvents = nextEvents.slice(0, state.limit);
+				}
+			}
 
-      return {
-        events: nextEvents,
-        total: state.total + 1,
-      };
-    }),
+			return {
+				events: nextEvents,
+				total: state.total + 1,
+			};
+		}),
 
-  setFilters: (filters) =>
-    set(() => ({
-      filters,
-      offset: 0, // Reset pagination when filters change
-    })),
+	setFilters: (filters) =>
+		set(() => ({
+			filters,
+			offset: 0, // Reset pagination when filters change
+		})),
 
-  setSort: (sort) =>
-    set(() => ({
-      sort,
-      offset: 0, // Reset pagination when sort changes
-    })),
+	setSort: (sort) =>
+		set(() => ({
+			sort,
+			offset: 0, // Reset pagination when sort changes
+		})),
 
-  setLoading: (loading) => set({ loading }),
+	setLoading: (loading) => set({ loading }),
 
-  setError: (error) => set({ error, loading: false }),
+	setError: (error) => set({ error, loading: false }),
 
-  loadMore: () =>
-    set((state) => ({
-      offset: state.offset + state.limit,
-    })),
+	loadMore: () =>
+		set((state) => ({
+			offset: state.offset + state.limit,
+		})),
 
-  reset: () => set(initialState),
+	reset: () => set(initialState),
 });

--- a/client/src/core/state/slices/viewSlice.ts
+++ b/client/src/core/state/slices/viewSlice.ts
@@ -1,90 +1,92 @@
-import type { StateCreator } from 'zustand';
+import type { StateCreator } from "zustand";
 
-export type ViewPane = 'files' | 'editor' | 'assistant';
+export type ViewPane = "files" | "editor" | "assistant";
 
 interface ViewData {
-  panes: Record<ViewPane, boolean>;
-  zoom: number;
+	panes: Record<ViewPane, boolean>;
+	zoom: number;
 }
 
 export interface ViewState {
-  view: ViewData;
-  togglePaneVisibility: (pane: ViewPane) => void;
-  setPaneVisibility: (pane: ViewPane, visible: boolean) => void;
-  setZoomLevel: (zoom: number) => void;
-  adjustZoom: (delta: number) => void;
-  resetZoom: () => void;
+	view: ViewData;
+	togglePaneVisibility: (pane: ViewPane) => void;
+	setPaneVisibility: (pane: ViewPane, visible: boolean) => void;
+	setZoomLevel: (zoom: number) => void;
+	adjustZoom: (delta: number) => void;
+	resetZoom: () => void;
 }
 
 const clampZoom = (value: number): number => Math.min(2, Math.max(0.5, value));
 
 const applyZoomToDom = (zoom: number): void => {
-  if (typeof window === 'undefined') {
-    return;
-  }
+	if (typeof window === "undefined") {
+		return;
+	}
 
-  const rounded = zoom.toFixed(2);
-  document.documentElement.style.setProperty('--app-zoom', rounded);
+	const rounded = zoom.toFixed(2);
+	document.documentElement.style.setProperty("--app-zoom", rounded);
 
-  const bodyStyle = document.body.style as CSSStyleDeclaration & { zoom?: string };
-  if ('zoom' in bodyStyle) {
-    bodyStyle.zoom = rounded;
-    document.body.style.removeProperty('transform');
-    document.body.style.removeProperty('transform-origin');
-  } else {
-    document.body.style.setProperty('transform-origin', '0 0');
-    document.body.style.setProperty('transform', `scale(${rounded})`);
-  }
+	const bodyStyle = document.body.style as CSSStyleDeclaration & {
+		zoom?: string;
+	};
+	if ("zoom" in bodyStyle) {
+		bodyStyle.zoom = rounded;
+		document.body.style.removeProperty("transform");
+		document.body.style.removeProperty("transform-origin");
+	} else {
+		document.body.style.setProperty("transform-origin", "0 0");
+		document.body.style.setProperty("transform", `scale(${rounded})`);
+	}
 };
 
 export const createViewSlice: StateCreator<ViewState> = (set, get) => ({
-  view: {
-    panes: {
-      files: true,
-      editor: true,
-      assistant: true
-    },
-    zoom: 1
-  },
-  togglePaneVisibility: (pane) => {
-    const current = get().view.panes[pane];
-    set((state) => ({
-      view: {
-        ...state.view,
-        panes: {
-          ...state.view.panes,
-          [pane]: !current
-        }
-      }
-    }));
-  },
-  setPaneVisibility: (pane, visible) => {
-    set((state) => ({
-      view: {
-        ...state.view,
-        panes: {
-          ...state.view.panes,
-          [pane]: visible
-        }
-      }
-    }));
-  },
-  setZoomLevel: (zoom) => {
-    const next = clampZoom(zoom);
-    applyZoomToDom(next);
-    set((state) => ({
-      view: {
-        ...state.view,
-        zoom: next
-      }
-    }));
-  },
-  adjustZoom: (delta) => {
-    const { view, setZoomLevel } = get();
-    setZoomLevel(view.zoom + delta);
-  },
-  resetZoom: () => {
-    const { setZoomLevel } = get();
-    setZoomLevel(1);
-  }
+	view: {
+		panes: {
+			files: true,
+			editor: true,
+			assistant: true,
+		},
+		zoom: 1,
+	},
+	togglePaneVisibility: (pane) => {
+		const current = get().view.panes[pane];
+		set((state) => ({
+			view: {
+				...state.view,
+				panes: {
+					...state.view.panes,
+					[pane]: !current,
+				},
+			},
+		}));
+	},
+	setPaneVisibility: (pane, visible) => {
+		set((state) => ({
+			view: {
+				...state.view,
+				panes: {
+					...state.view.panes,
+					[pane]: visible,
+				},
+			},
+		}));
+	},
+	setZoomLevel: (zoom) => {
+		const next = clampZoom(zoom);
+		applyZoomToDom(next);
+		set((state) => ({
+			view: {
+				...state.view,
+				zoom: next,
+			},
+		}));
+	},
+	adjustZoom: (delta) => {
+		const { view, setZoomLevel } = get();
+		setZoomLevel(view.zoom + delta);
+	},
+	resetZoom: () => {
+		const { setZoomLevel } = get();
+		setZoomLevel(1);
+	},
 });

--- a/client/src/core/state/store.ts
+++ b/client/src/core/state/store.ts
@@ -1,35 +1,35 @@
-import { create } from 'zustand';
-import { devtools } from 'zustand/middleware';
-import { createEditorSlice, type EditorState } from './slices/editorSlice';
-import { createExecutionSlice, type ExecutionState } from './slices/executionSlice';
-import { createAISlice, type AIState } from './slices/aiSlice';
-import { createSettingsSlice, type SettingsState } from './slices/settingsSlice';
-import { createConnectionSlice, type ConnectionState } from './slices/connectionSlice';
-import { createTimelineSlice, type TimelineState } from './slices/timelineSlice';
-import { createViewSlice, type ViewState } from './slices/viewSlice';
-import { createProjectSlice, type ProjectState } from './slices/projectSlice';
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { type AIState, createAISlice } from "./slices/aiSlice";
+import { type ConnectionState, createConnectionSlice } from "./slices/connectionSlice";
+import { createEditorSlice, type EditorState } from "./slices/editorSlice";
+import { createExecutionSlice, type ExecutionState } from "./slices/executionSlice";
+import { createProjectSlice, type ProjectState } from "./slices/projectSlice";
+import { createSettingsSlice, type SettingsState } from "./slices/settingsSlice";
+import { createTimelineSlice, type TimelineState } from "./slices/timelineSlice";
+import { createViewSlice, type ViewState } from "./slices/viewSlice";
 
 export type StoreState = EditorState &
-  ExecutionState &
-  AIState &
-  SettingsState &
-  ConnectionState &
-  TimelineState &
-  ViewState &
-  ProjectState;
+	ExecutionState &
+	AIState &
+	SettingsState &
+	ConnectionState &
+	TimelineState &
+	ViewState &
+	ProjectState;
 
 export const useStore = create<StoreState>()(
-  devtools(
-    (...args) => ({
-      ...createEditorSlice(...args),
-      ...createExecutionSlice(...args),
-      ...createAISlice(...args),
-      ...createSettingsSlice(...args),
-      ...createConnectionSlice(...args),
-      ...createTimelineSlice(...args),
-      ...createViewSlice(...args),
-      ...createProjectSlice(...args),
-    }),
-    { name: 'Re-prod Store' }
-  )
+	devtools(
+		(...args) => ({
+			...createEditorSlice(...args),
+			...createExecutionSlice(...args),
+			...createAISlice(...args),
+			...createSettingsSlice(...args),
+			...createConnectionSlice(...args),
+			...createTimelineSlice(...args),
+			...createViewSlice(...args),
+			...createProjectSlice(...args),
+		}),
+		{ name: "Re-prod Store" },
+	),
 );

--- a/client/src/core/timeline/utils.ts
+++ b/client/src/core/timeline/utils.ts
@@ -1,85 +1,81 @@
-import type {
-  ExecutionEventPayload,
-  TimelineQuery,
-  TimelineStats,
-} from 'shared';
+import type { ExecutionEventPayload, TimelineQuery, TimelineStats } from "shared";
 
 export function matchesTimelineFilters(
-  event: ExecutionEventPayload,
-  filters: TimelineQuery['filters'] | undefined,
+	event: ExecutionEventPayload,
+	filters: TimelineQuery["filters"] | undefined,
 ): boolean {
-  if (!filters) return true;
+	if (!filters) return true;
 
-  if (filters.actor && event.context.actor !== filters.actor) {
-    return false;
-  }
+	if (filters.actor && event.context.actor !== filters.actor) {
+		return false;
+	}
 
-  if (filters.source && event.context.source !== filters.source) {
-    return false;
-  }
+	if (filters.source && event.context.source !== filters.source) {
+		return false;
+	}
 
-  if (filters.startTime && event.created_at_ms < filters.startTime) {
-    return false;
-  }
+	if (filters.startTime && event.created_at_ms < filters.startTime) {
+		return false;
+	}
 
-  if (filters.endTime && event.created_at_ms > filters.endTime) {
-    return false;
-  }
+	if (filters.endTime && event.created_at_ms > filters.endTime) {
+		return false;
+	}
 
-  if (filters.hasPlots && event.result.plots.length === 0) {
-    return false;
-  }
+	if (filters.hasPlots && event.result.plots.length === 0) {
+		return false;
+	}
 
-  if (filters.hasErrors && !event.result.error) {
-    return false;
-  }
+	if (filters.hasErrors && !event.result.error) {
+		return false;
+	}
 
-  if (filters.codeContains) {
-    const search = filters.codeContains.toLowerCase();
-    const hasMatch = event.blocks.some((block) => block.code.toLowerCase().includes(search));
-    if (!hasMatch) {
-      return false;
-    }
-  }
+	if (filters.codeContains) {
+		const search = filters.codeContains.toLowerCase();
+		const hasMatch = event.blocks.some((block) => block.code.toLowerCase().includes(search));
+		if (!hasMatch) {
+			return false;
+		}
+	}
 
-  return true;
+	return true;
 }
 
 export function deriveTimelineStatsFromEvent(event: ExecutionEventPayload): TimelineStats {
-  const now = event.created_at_ms;
+	const now = event.created_at_ms;
 
-  return {
-    totalEvents: 1,
-    totalPlots: event.result.plots.length,
-    totalErrors: event.result.error ? 1 : 0,
-    userActions: event.context.actor === 'user' ? 1 : 0,
-    aiActions: event.context.actor === 'ai' ? 1 : 0,
-    sessionStartTime: now,
-    sessionEndTime: now,
-    sessionDuration: 0,
-  };
+	return {
+		totalEvents: 1,
+		totalPlots: event.result.plots.length,
+		totalErrors: event.result.error ? 1 : 0,
+		userActions: event.context.actor === "user" ? 1 : 0,
+		aiActions: event.context.actor === "ai" ? 1 : 0,
+		sessionStartTime: now,
+		sessionEndTime: now,
+		sessionDuration: 0,
+	};
 }
 
 export function appendEventToStats(
-  event: ExecutionEventPayload,
-  current: TimelineStats | null,
+	event: ExecutionEventPayload,
+	current: TimelineStats | null,
 ): TimelineStats {
-  if (!current) {
-    return deriveTimelineStatsFromEvent(event);
-  }
+	if (!current) {
+		return deriveTimelineStatsFromEvent(event);
+	}
 
-  const nextStart = Math.min(current.sessionStartTime, event.created_at_ms);
-  const nextEnd = Math.max(current.sessionEndTime, event.created_at_ms);
+	const nextStart = Math.min(current.sessionStartTime, event.created_at_ms);
+	const nextEnd = Math.max(current.sessionEndTime, event.created_at_ms);
 
-  return {
-    ...current,
-    totalEvents: current.totalEvents + 1,
-    totalPlots: current.totalPlots + event.result.plots.length,
-    totalErrors: current.totalErrors + (event.result.error ? 1 : 0),
-    userActions: current.userActions + (event.context.actor === 'user' ? 1 : 0),
-    aiActions: current.aiActions + (event.context.actor === 'ai' ? 1 : 0),
-    sessionStartTime: nextStart,
-    sessionEndTime: nextEnd,
-    sessionDuration: nextEnd - nextStart,
-  };
+	return {
+		...current,
+		totalEvents: current.totalEvents + 1,
+		totalPlots: current.totalPlots + event.result.plots.length,
+		totalErrors: current.totalErrors + (event.result.error ? 1 : 0),
+		userActions: current.userActions + (event.context.actor === "user" ? 1 : 0),
+		aiActions: current.aiActions + (event.context.actor === "ai" ? 1 : 0),
+		sessionStartTime: nextStart,
+		sessionEndTime: nextEnd,
+		sessionDuration: nextEnd - nextStart,
+	};
 }

--- a/client/src/css/components/ai-panel/code-block.css
+++ b/client/src/css/components/ai-panel/code-block.css
@@ -1,95 +1,99 @@
 .code-block-container {
-  margin: 14px 0;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  border-radius: 14px;
-  overflow: hidden;
-  background: rgba(255, 255, 255, 0.85);
-  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.08);
-  backdrop-filter: blur(10px);
+	margin: 14px 0;
+	border: 1px solid rgba(148, 163, 184, 0.28);
+	border-radius: 14px;
+	overflow: hidden;
+	background: rgba(255, 255, 255, 0.85);
+	box-shadow: 0 14px 28px rgba(15, 23, 42, 0.08);
+	backdrop-filter: blur(10px);
 }
 
 .code-explanation {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 12px 16px;
-  background: linear-gradient(120deg, rgba(47, 111, 237, 0.12), rgba(255, 255, 255, 0));
-  border-bottom: 1px solid rgba(148, 163, 184, 0.22);
-  font-size: 12px;
-  color: var(--text-secondary);
-  line-height: 1.5;
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	padding: 12px 16px;
+	background: linear-gradient(
+		120deg,
+		rgba(47, 111, 237, 0.12),
+		rgba(255, 255, 255, 0)
+	);
+	border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+	font-size: 12px;
+	color: var(--text-secondary);
+	line-height: 1.5;
 }
 
 .code-explanation svg {
-  flex-shrink: 0;
-  color: var(--accent-blue);
+	flex-shrink: 0;
+	color: var(--accent-blue);
 }
 
 .code-explanation span {
-  flex: 1;
+	flex: 1;
 }
 
 .code-block {
-  background: transparent;
+	background: transparent;
 }
 
 .code-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 10px 16px;
-  background: rgba(244, 246, 251, 0.95);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 10px 16px;
+	background: rgba(244, 246, 251, 0.95);
+	border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
 }
 
 .code-language {
-  color: var(--accent-blue);
+	color: var(--accent-blue);
 }
 
 .code-target {
-  color: var(--text-muted);
-  font-size: 10px;
+	color: var(--text-muted);
+	font-size: 10px;
 }
 
 .code-content {
-  margin: 0;
-  padding: 16px;
-  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
-  font-size: 12px;
-  line-height: 1.6;
-  overflow-x: auto;
-  background: var(--bg-code);
-  color: var(--text-primary);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+	margin: 0;
+	padding: 16px;
+	font-family: "Monaco", "Menlo", "Consolas", monospace;
+	font-size: 12px;
+	line-height: 1.6;
+	overflow-x: auto;
+	background: var(--bg-code);
+	color: var(--text-primary);
+	border-bottom: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .code-content code {
-  font-family: inherit;
-  background: none;
+	font-family: inherit;
+	background: none;
 }
 
 .code-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 10px;
-  padding: 12px 16px;
-  background: rgba(255, 255, 255, 0.9);
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+	padding: 12px 16px;
+	background: rgba(255, 255, 255, 0.9);
 }
 
 .code-actions .btn {
-  font-size: 11px;
-  padding: 6px 12px;
+	font-size: 11px;
+	padding: 6px 12px;
 }
 
 .code-actions .btn-primary {
-  font-weight: 600;
+	font-weight: 600;
 }
 
 .code-actions .btn svg {
-  width: 16px;
-  height: 16px;
+	width: 16px;
+	height: 16px;
 }

--- a/client/src/css/components/ai-panel/code-block.css
+++ b/client/src/css/components/ai-panel/code-block.css
@@ -13,11 +13,7 @@
 	align-items: flex-start;
 	gap: 8px;
 	padding: 12px 16px;
-	background: linear-gradient(
-		120deg,
-		rgba(47, 111, 237, 0.12),
-		rgba(255, 255, 255, 0)
-	);
+	background: linear-gradient(120deg, rgba(47, 111, 237, 0.12), rgba(255, 255, 255, 0));
 	border-bottom: 1px solid rgba(148, 163, 184, 0.22);
 	font-size: 12px;
 	color: var(--text-secondary);

--- a/client/src/css/components/ai-panel/index.css
+++ b/client/src/css/components/ai-panel/index.css
@@ -1,5 +1,5 @@
-@import './message.css';
-@import './code-block.css';
-@import './streaming.css';
-@import './plan-card.css';
-@import './tool-log.css';
+@import "./message.css";
+@import "./code-block.css";
+@import "./streaming.css";
+@import "./plan-card.css";
+@import "./tool-log.css";

--- a/client/src/css/components/ai-panel/message.css
+++ b/client/src/css/components/ai-panel/message.css
@@ -88,11 +88,7 @@
 
 .message-user {
 	align-self: flex-end;
-	background: linear-gradient(
-		180deg,
-		rgba(47, 111, 237, 0.92),
-		rgba(37, 87, 200, 0.92)
-	);
+	background: linear-gradient(180deg, rgba(47, 111, 237, 0.92), rgba(37, 87, 200, 0.92));
 	color: white;
 	padding: 10px 14px;
 	border-radius: 12px 12px 4px 12px;
@@ -157,11 +153,7 @@
 .ai-input-container-wrapper {
 	padding: 14px 18px;
 	border-top: 1px solid rgba(148, 163, 184, 0.22);
-	background: linear-gradient(
-		180deg,
-		rgba(244, 246, 251, 0.95),
-		rgba(236, 240, 250, 0.95)
-	);
+	background: linear-gradient(180deg, rgba(244, 246, 251, 0.95), rgba(236, 240, 250, 0.95));
 }
 
 .ai-input-container.vscode-style {

--- a/client/src/css/components/ai-panel/message.css
+++ b/client/src/css/components/ai-panel/message.css
@@ -1,358 +1,372 @@
 .ai-panel .panel-content {
-  display: flex;
-  flex-direction: column;
-  background: inherit;
-  border: none;
+	display: flex;
+	flex-direction: column;
+	background: inherit;
+	border: none;
 }
 
 :root[data-theme="phylo"] .ai-panel .panel-content,
 .ai-panel .panel-content {
-  background: #ffffff;
+	background: #ffffff;
 }
 
 .ai-messages {
-  flex: 1;
-  overflow-y: auto;
-  padding: 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  background: #ffffff;
-  border-radius: 8px;
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+	flex: 1;
+	overflow-y: auto;
+	padding: 18px;
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+	background: #ffffff;
+	border-radius: 8px;
+	box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
 }
 
 .ai-welcome {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  text-align: center;
-  color: var(--text-secondary);
-  padding: 32px;
-  border-radius: 8px;
-  border: 1px dashed rgba(148, 163, 184, 0.28);
-  background-color: #ffffff;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	text-align: center;
+	color: var(--text-secondary);
+	padding: 32px;
+	border-radius: 8px;
+	border: 1px dashed rgba(148, 163, 184, 0.28);
+	background-color: #ffffff;
 }
 
 .ai-welcome h3 {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 8px;
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--text-primary);
+	margin-bottom: 8px;
 }
 
 .ai-welcome p {
-  font-size: 12px;
-  margin-bottom: 16px;
+	font-size: 12px;
+	margin-bottom: 16px;
 }
 
 :root[data-theme="phylo"] .ai-panel .panel-content,
 :root[data-theme="phylo"] .ai-messages {
-  background: #ffffff !important;
+	background: #ffffff !important;
 }
 
 .ai-suggestions {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  width: 100%;
-  max-width: 260px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	width: 100%;
+	max-width: 260px;
 }
 
 .suggestion {
-  padding: 10px 14px;
-  border-radius: 6px;
-  background-color: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  cursor: pointer;
-  font-size: 12px;
-  text-align: left;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+	padding: 10px 14px;
+	border-radius: 6px;
+	background-color: rgba(255, 255, 255, 0.7);
+	border: 1px solid rgba(148, 163, 184, 0.3);
+	cursor: pointer;
+	font-size: 12px;
+	text-align: left;
+	transition:
+		transform 0.15s ease,
+		box-shadow 0.15s ease;
 }
 
 .suggestion:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.08);
+	transform: translateY(-1px);
+	box-shadow: 0 10px 18px rgba(15, 23, 42, 0.08);
 }
 
 .message {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  max-width: 88%;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-width: 88%;
 }
 
 .message-user {
-  align-self: flex-end;
-  background: linear-gradient(180deg, rgba(47, 111, 237, 0.92), rgba(37, 87, 200, 0.92));
-  color: white;
-  padding: 10px 14px;
-  border-radius: 12px 12px 4px 12px;
-  box-shadow: 0 12px 24px rgba(47, 111, 237, 0.28);
+	align-self: flex-end;
+	background: linear-gradient(
+		180deg,
+		rgba(47, 111, 237, 0.92),
+		rgba(37, 87, 200, 0.92)
+	);
+	color: white;
+	padding: 10px 14px;
+	border-radius: 12px 12px 4px 12px;
+	box-shadow: 0 12px 24px rgba(47, 111, 237, 0.28);
 }
 
 .message-assistant {
-  align-self: flex-start;
-  background: transparent;
-  padding: 12px 16px;
-  border-radius: 12px 12px 12px 4px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  box-shadow: none;
+	align-self: flex-start;
+	background: transparent;
+	padding: 12px 16px;
+	border-radius: 12px 12px 12px 4px;
+	border: 1px solid rgba(148, 163, 184, 0.2);
+	box-shadow: none;
 }
 
 .message-header {
-  font-size: 11px;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.85);
-  margin-bottom: 4px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+	font-size: 11px;
+	font-weight: 600;
+	color: rgba(255, 255, 255, 0.85);
+	margin-bottom: 4px;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
 }
 
 .message-assistant .message-header {
-  color: var(--text-muted);
+	color: var(--text-muted);
 }
 
 .message-content {
-  font-size: 12px;
-  line-height: 1.6;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+	font-size: 12px;
+	line-height: 1.6;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 }
 
 .message-assistant .message-content {
-  white-space: pre-wrap;
-  color: var(--text-primary);
+	white-space: pre-wrap;
+	color: var(--text-primary);
 }
 
 .message-assistant .message-content strong {
-  color: var(--accent-blue);
+	color: var(--accent-blue);
 }
 
 .message-code {
-  margin-top: 6px;
-  padding: 10px;
-  background-color: var(--bg-code);
-  border-radius: 6px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
+	margin-top: 6px;
+	padding: 10px;
+	background-color: var(--bg-code);
+	border-radius: 6px;
+	border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .message-code pre {
-  margin: 0 0 8px 0;
-  overflow-x: auto;
-  font-size: 11px;
-  font-family: Monaco, Menlo, Consolas, monospace;
+	margin: 0 0 8px 0;
+	overflow-x: auto;
+	font-size: 11px;
+	font-family: Monaco, Menlo, Consolas, monospace;
 }
 
 /* VSCode-style unified input container */
 .ai-input-container-wrapper {
-  padding: 14px 18px;
-  border-top: 1px solid rgba(148, 163, 184, 0.22);
-  background: linear-gradient(180deg, rgba(244, 246, 251, 0.95), rgba(236, 240, 250, 0.95));
+	padding: 14px 18px;
+	border-top: 1px solid rgba(148, 163, 184, 0.22);
+	background: linear-gradient(
+		180deg,
+		rgba(244, 246, 251, 0.95),
+		rgba(236, 240, 250, 0.95)
+	);
 }
 
 .ai-input-container.vscode-style {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  border-radius: 4px;
-  background-color: var(--bg-primary);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 10px;
+	border: 1px solid rgba(148, 163, 184, 0.4);
+	border-radius: 4px;
+	background-color: var(--bg-primary);
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+	transition:
+		border-color 0.15s ease,
+		box-shadow 0.15s ease;
 }
 
 .ai-input-container.vscode-style:focus-within {
-  outline: none;
-  border-color: rgba(148, 163, 184, 0.5);
-  box-shadow: none;
+	outline: none;
+	border-color: rgba(148, 163, 184, 0.5);
+	box-shadow: none;
 }
 
 /* Controls bar - horizontal layout for Agent and Send */
 .input-controls-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding-top: 8px;
-  border-top: 1px solid rgba(148, 163, 184, 0.22);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding-top: 8px;
+	border-top: 1px solid rgba(148, 163, 184, 0.22);
 }
 
 .input-controls-left {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
 }
 
 .input-controls-right {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
 }
 
 /* Mode dropdown - VSCode style */
 .mode-dropdown {
-  padding: 4px 8px;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-primary);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.15s ease;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M6 8L3 5h6z'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 4px center;
-  padding-right: 20px;
+	padding: 4px 8px;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	color: var(--text-primary);
+	font-size: 12px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background-color 0.15s ease;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236b7280' d='M6 8L3 5h6z'/%3E%3C/svg%3E");
+	background-repeat: no-repeat;
+	background-position: right 4px center;
+	padding-right: 20px;
 }
 
 .mode-dropdown:hover:not(:disabled) {
-  background-color: rgba(148, 163, 184, 0.1);
+	background-color: rgba(148, 163, 184, 0.1);
 }
 
 .mode-dropdown:focus {
-  outline: none;
-  background-color: rgba(47, 111, 237, 0.08);
+	outline: none;
+	background-color: rgba(47, 111, 237, 0.08);
 }
 
 .mode-dropdown:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+	opacity: 0.5;
+	cursor: not-allowed;
 }
 
 /* Textarea inside unified container */
 .ai-input-container.vscode-style .ai-input {
-  width: 100%;
-  padding: 8px 10px;
-  border: none;
-  background: transparent;
-  color: var(--text-primary);
-  font-size: 13px;
-  font-family: inherit;
-  resize: none;
-  min-height: 100px;
-  max-height: 300px;
-  line-height: 1.5;
-  overflow-y: auto;
+	width: 100%;
+	padding: 8px 10px;
+	border: none;
+	background: transparent;
+	color: var(--text-primary);
+	font-size: 13px;
+	font-family: inherit;
+	resize: none;
+	min-height: 100px;
+	max-height: 300px;
+	line-height: 1.5;
+	overflow-y: auto;
 }
 
 .ai-input-container.vscode-style .ai-input:focus {
-  outline: none;
+	outline: none;
 }
 
 .ai-input-container.vscode-style .ai-input::placeholder {
-  color: var(--text-muted);
-  opacity: 0.7;
+	color: var(--text-muted);
+	opacity: 0.7;
 }
 
 /* Icon buttons */
 .icon-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: background-color 0.15s ease, color 0.15s ease;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	color: var(--text-secondary);
+	cursor: pointer;
+	transition:
+		background-color 0.15s ease,
+		color 0.15s ease;
 }
 
 .icon-btn:hover:not(:disabled) {
-  background-color: rgba(148, 163, 184, 0.15);
-  color: var(--text-primary);
+	background-color: rgba(148, 163, 184, 0.15);
+	color: var(--text-primary);
 }
 
 .icon-btn:active:not(:disabled) {
-  background-color: rgba(148, 163, 184, 0.25);
+	background-color: rgba(148, 163, 184, 0.25);
 }
 
 .icon-btn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
+	opacity: 0.4;
+	cursor: not-allowed;
 }
 
 .icon-btn:focus-visible {
-  outline: 2px solid var(--accent-blue);
-  outline-offset: 2px;
+	outline: 2px solid var(--accent-blue);
+	outline-offset: 2px;
 }
 
 /* Send button - wider with text label */
 .send-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 0 12px;
-  height: 28px;
-  border: none;
-  border-radius: 4px;
-  background-color: var(--accent-blue);
-  color: white;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.15s ease;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	padding: 0 12px;
+	height: 28px;
+	border: none;
+	border-radius: 4px;
+	background-color: var(--accent-blue);
+	color: white;
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background-color 0.15s ease;
 }
 
 .send-btn:hover:not(:disabled) {
-  background-color: var(--accent-blue-hover);
+	background-color: var(--accent-blue-hover);
 }
 
 .send-btn:disabled {
-  background-color: rgba(148, 163, 184, 0.3);
-  color: rgba(100, 116, 139, 0.8);
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  cursor: not-allowed;
+	background-color: rgba(148, 163, 184, 0.3);
+	color: rgba(100, 116, 139, 0.8);
+	border: 1px solid rgba(148, 163, 184, 0.4);
+	cursor: not-allowed;
 }
 
 .send-btn:focus-visible {
-  outline: 2px solid var(--accent-blue);
-  outline-offset: 2px;
+	outline: 2px solid var(--accent-blue);
+	outline-offset: 2px;
 }
 
 /* Stop button - danger color */
 .icon-btn.stop-btn {
-  background-color: #dc4c3f;
-  color: white;
+	background-color: #dc4c3f;
+	color: white;
 }
 
 .icon-btn.stop-btn:hover:not(:disabled) {
-  background-color: #c73f33;
+	background-color: #c73f33;
 }
 
 /* Auto-resize textarea behavior */
 .ai-input-container.vscode-style .ai-input {
-  scrollbar-width: thin;
-  scrollbar-color: rgba(148, 163, 184, 0.3) transparent;
+	scrollbar-width: thin;
+	scrollbar-color: rgba(148, 163, 184, 0.3) transparent;
 }
 
 .ai-input-container.vscode-style .ai-input::-webkit-scrollbar {
-  width: 6px;
+	width: 6px;
 }
 
 .ai-input-container.vscode-style .ai-input::-webkit-scrollbar-track {
-  background: transparent;
+	background: transparent;
 }
 
 .ai-input-container.vscode-style .ai-input::-webkit-scrollbar-thumb {
-  background-color: rgba(148, 163, 184, 0.3);
-  border-radius: 3px;
+	background-color: rgba(148, 163, 184, 0.3);
+	border-radius: 3px;
 }
 
 .ai-input-container.vscode-style .ai-input::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(148, 163, 184, 0.5);
+	background-color: rgba(148, 163, 184, 0.5);
 }

--- a/client/src/css/components/ai-panel/plan-card.css
+++ b/client/src/css/components/ai-panel/plan-card.css
@@ -1,48 +1,48 @@
 .ai-plan-card {
-  margin-top: 12px;
-  padding: 12px 14px;
-  border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(248, 250, 255, 0.8);
+	margin-top: 12px;
+	padding: 12px 14px;
+	border-radius: 12px;
+	border: 1px solid rgba(148, 163, 184, 0.3);
+	background: rgba(248, 250, 255, 0.8);
 }
 
 .ai-plan-card__title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-bottom: 8px;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--text-secondary);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	margin-bottom: 8px;
 }
 
 .ai-plan-card ol {
-  margin: 0;
-  padding-left: 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+	margin: 0;
+	padding-left: 18px;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
 }
 
 .ai-plan-card li {
-  font-size: 12px;
-  display: flex;
-  gap: 8px;
-  align-items: baseline;
+	font-size: 12px;
+	display: flex;
+	gap: 8px;
+	align-items: baseline;
 }
 
 .ai-plan-card__status {
-  font-weight: 600;
-  color: var(--accent-blue);
+	font-weight: 600;
+	color: var(--accent-blue);
 }
 
 .ai-plan-card li[data-status="running"] .ai-plan-card__status {
-  color: #f97316;
+	color: #f97316;
 }
 
 .ai-plan-card li[data-status="done"] .ai-plan-card__status {
-  color: #16a34a;
+	color: #16a34a;
 }
 
 .ai-plan-card li[data-status="error"] .ai-plan-card__status {
-  color: #dc2626;
+	color: #dc2626;
 }

--- a/client/src/css/components/ai-panel/streaming.css
+++ b/client/src/css/components/ai-panel/streaming.css
@@ -1,40 +1,40 @@
 .message-streaming {
-  gap: 10px;
+	gap: 10px;
 }
 
 .message-streaming-text {
-  margin: 0;
-  font-family: 'IBM Plex Mono', Menlo, Consolas, monospace;
-  background: rgba(15, 23, 42, 0.02);
-  border-radius: 10px;
-  padding: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  font-size: 12px;
-  white-space: pre-wrap;
+	margin: 0;
+	font-family: "IBM Plex Mono", Menlo, Consolas, monospace;
+	background: rgba(15, 23, 42, 0.02);
+	border-radius: 10px;
+	padding: 12px;
+	border: 1px solid rgba(148, 163, 184, 0.25);
+	font-size: 12px;
+	white-space: pre-wrap;
 }
 
 .message-streaming-indicator {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 11px;
-  color: var(--text-muted);
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 11px;
+	color: var(--text-muted);
 }
 
 .message-streaming-indicator .spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgba(148, 163, 184, 0.3);
-  border-top-color: var(--accent-blue);
-  border-radius: 999px;
-  animation: ai-spin 0.8s linear infinite;
+	width: 14px;
+	height: 14px;
+	border: 2px solid rgba(148, 163, 184, 0.3);
+	border-top-color: var(--accent-blue);
+	border-radius: 999px;
+	animation: ai-spin 0.8s linear infinite;
 }
 
 @keyframes ai-spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
+	0% {
+		transform: rotate(0deg);
+	}
+	100% {
+		transform: rotate(360deg);
+	}
 }

--- a/client/src/css/components/ai-panel/tool-log.css
+++ b/client/src/css/components/ai-panel/tool-log.css
@@ -1,95 +1,95 @@
 .ai-tool-log {
-  margin-top: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 12px;
-  background: #fff;
+	margin-top: 12px;
+	border: 1px solid rgba(148, 163, 184, 0.3);
+	border-radius: 12px;
+	background: #fff;
 }
 
 .ai-tool-log__title {
-  font-size: 12px;
-  font-weight: 600;
-  padding: 10px 14px 0 14px;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+	font-size: 12px;
+	font-weight: 600;
+	padding: 10px 14px 0 14px;
+	color: var(--text-secondary);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
 }
 
 .ai-tool-log ul {
-  list-style: none;
-  margin: 0;
-  padding: 0 14px 10px 14px;
+	list-style: none;
+	margin: 0;
+	padding: 0 14px 10px 14px;
 }
 
 .ai-tool-log li + li {
-  border-top: 1px solid rgba(148, 163, 184, 0.2);
+	border-top: 1px solid rgba(148, 163, 184, 0.2);
 }
 
 .ai-tool-log details {
-  padding: 10px 0;
+	padding: 10px 0;
 }
 
 .ai-tool-log summary {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-primary);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	cursor: pointer;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--text-primary);
 }
 
 .ai-tool-log__tool {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
 }
 
 .ai-tool-log__status {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
 }
 
 .ai-tool-log__status.is-running {
-  color: #f97316;
+	color: #f97316;
 }
 
 .ai-tool-log__status.is-done {
-  color: #16a34a;
+	color: #16a34a;
 }
 
 .ai-tool-log__status.is-pending {
-  color: var(--text-muted);
+	color: var(--text-muted);
 }
 
 .ai-tool-log__status.is-error {
-  color: #dc2626;
+	color: #dc2626;
 }
 
 .ai-tool-log__block {
-  margin-top: 8px;
+	margin-top: 8px;
 }
 
 .ai-tool-log__label {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  margin-bottom: 4px;
+	font-size: 11px;
+	font-weight: 600;
+	color: var(--text-secondary);
+	text-transform: uppercase;
+	margin-bottom: 4px;
 }
 
 .ai-tool-log__block pre {
-  margin: 0;
-  padding: 8px;
-  background: rgba(15, 23, 42, 0.04);
-  border-radius: 8px;
-  font-size: 11px;
-  overflow-x: auto;
+	margin: 0;
+	padding: 8px;
+	background: rgba(15, 23, 42, 0.04);
+	border-radius: 8px;
+	font-size: 11px;
+	overflow-x: auto;
 }
 
 .ai-tool-log__error {
-  margin-top: 8px;
-  font-size: 12px;
-  color: #b42318;
-  font-weight: 600;
+	margin-top: 8px;
+	font-size: 12px;
+	color: #b42318;
+	font-weight: 600;
 }

--- a/client/src/css/components/confirm-dialog.css
+++ b/client/src/css/components/confirm-dialog.css
@@ -1,68 +1,68 @@
 /* Confirm Dialog Overlay */
 .confirm-dialog-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(15, 23, 42, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  backdrop-filter: blur(4px);
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(15, 23, 42, 0.6);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1000;
+	backdrop-filter: blur(4px);
 }
 
 /* Confirm Dialog */
 .confirm-dialog {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-color);
-  border-radius: var(--panel-radius);
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
-  width: 480px;
-  max-width: 90vw;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+	background: var(--bg-elevated);
+	border: 1px solid var(--border-color);
+	border-radius: var(--panel-radius);
+	box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+	width: 480px;
+	max-width: 90vw;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
 }
 
 /* Header */
 .confirm-dialog-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px;
-  background: var(--bg-toolbar);
-  border-bottom: 1px solid var(--border-light);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 16px;
+	background: var(--bg-toolbar);
+	border-bottom: 1px solid var(--border-light);
 }
 
 .confirm-dialog-header h2 {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: var(--letter-spacing-base);
+	margin: 0;
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--text-primary);
+	letter-spacing: var(--letter-spacing-base);
 }
 
 /* Content */
 .confirm-dialog-content {
-  padding: 20px 16px;
-  background: var(--bg-primary);
+	padding: 20px 16px;
+	background: var(--bg-primary);
 }
 
 .confirm-dialog-message {
-  font-size: 13px;
-  color: var(--text-primary);
-  line-height: 1.6;
+	font-size: 13px;
+	color: var(--text-primary);
+	line-height: 1.6;
 }
 
 /* Footer */
 .confirm-dialog-footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 12px;
-  padding: 16px;
-  background: var(--bg-toolbar);
-  border-top: 1px solid var(--border-light);
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 12px;
+	padding: 16px;
+	background: var(--bg-toolbar);
+	border-top: 1px solid var(--border-light);
 }

--- a/client/src/css/components/console.css
+++ b/client/src/css/components/console.css
@@ -1,188 +1,190 @@
 .console-content {
-  font-family: Monaco, Menlo, Consolas, monospace;
-  font-size: 12px;
-  background: var(--bg-primary);
+	font-family: Monaco, Menlo, Consolas, monospace;
+	font-size: 12px;
+	background: var(--bg-primary);
 }
 
 .console-output {
-  padding: 18px;
-  overflow-y: auto;
-  height: 100%;
-  background: var(--bg-primary);
+	padding: 18px;
+	overflow-y: auto;
+	height: 100%;
+	background: var(--bg-primary);
 }
 
 .console-welcome {
-  color: var(--text-secondary);
-  font-style: italic;
+	color: var(--text-secondary);
+	font-style: italic;
 }
 
 .console-entry {
-  margin-bottom: 18px;
-  padding: 16px;
-  border-radius: 12px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  box-shadow: 0 12px 18px rgba(15, 23, 42, 0.06);
+	margin-bottom: 18px;
+	padding: 16px;
+	border-radius: 12px;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-color);
+	box-shadow: 0 12px 18px rgba(15, 23, 42, 0.06);
 }
 
 .console-entry:last-child {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 .console-meta {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 10px;
-  font-size: 11px;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 10px;
+	font-size: 11px;
+	color: var(--text-secondary);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
 }
 
 .console-time {
-  font-weight: 600;
-  color: var(--text-primary);
+	font-weight: 600;
+	color: var(--text-primary);
 }
 
 .console-duration {
-  color: var(--text-muted);
+	color: var(--text-muted);
 }
 
 .console-error-badge {
-  background: rgba(220, 76, 63, 0.12);
-  color: var(--error-color);
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 600;
+	background: rgba(220, 76, 63, 0.12);
+	color: var(--error-color);
+	padding: 2px 8px;
+	border-radius: 999px;
+	font-size: 10px;
+	font-weight: 600;
 }
 
 .console-stdout,
 .console-stderr {
-  margin: 10px 0;
-  padding: 12px;
-  border-radius: 10px;
-  overflow-x: auto;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  font-size: 12px;
-  line-height: 1.55;
-  background: var(--bg-code);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+	margin: 10px 0;
+	padding: 12px;
+	border-radius: 10px;
+	overflow-x: auto;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	font-size: 12px;
+	line-height: 1.55;
+	background: var(--bg-code);
+	border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .console-stdout {
-  border-left: 4px solid var(--success-color);
+	border-left: 4px solid var(--success-color);
 }
 
 .console-stderr {
-  color: var(--error-color);
-  border-left: 4px solid var(--error-color);
-  background: rgba(220, 76, 63, 0.08);
+	color: var(--error-color);
+	border-left: 4px solid var(--error-color);
+	background: rgba(220, 76, 63, 0.08);
 }
 
 .console-plots-info {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
-  background-color: rgba(47, 111, 237, 0.1);
-  border-left: 4px solid var(--accent-blue);
-  border-radius: 10px;
-  margin-top: 10px;
-  font-size: 11px;
-  color: var(--accent-blue);
-  font-weight: 600;
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 12px;
+	background-color: rgba(47, 111, 237, 0.1);
+	border-left: 4px solid var(--accent-blue);
+	border-radius: 10px;
+	margin-top: 10px;
+	font-size: 11px;
+	color: var(--accent-blue);
+	font-weight: 600;
 }
 
 .console-plots-info.clickable {
-  cursor: pointer;
-  transition: all 0.2s ease;
+	cursor: pointer;
+	transition: all 0.2s ease;
 }
 
 .console-plots-info.clickable:hover {
-  background-color: rgba(47, 111, 237, 0.18);
-  transform: translateX(2px);
+	background-color: rgba(47, 111, 237, 0.18);
+	transform: translateX(2px);
 }
 
 .console-plots-info.clickable:active {
-  transform: translateX(4px);
-  background-color: rgba(47, 111, 237, 0.25);
+	transform: translateX(4px);
+	background-color: rgba(47, 111, 237, 0.25);
 }
 
 .console-plots-info svg {
-  width: 16px;
-  height: 16px;
+	width: 16px;
+	height: 16px;
 }
 
 .console-history {
-  padding: 18px;
-  overflow-y: auto;
-  height: 100%;
-  background: var(--bg-primary);
+	padding: 18px;
+	overflow-y: auto;
+	height: 100%;
+	background: var(--bg-primary);
 }
 
 .history-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 
 .history-item {
-  padding: 14px 16px;
-  background-color: var(--bg-secondary);
-  border-radius: 12px;
-  border: 1px solid var(--border-color);
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+	padding: 14px 16px;
+	background-color: var(--bg-secondary);
+	border-radius: 12px;
+	border: 1px solid var(--border-color);
+	cursor: pointer;
+	transition:
+		transform 0.15s ease,
+		box-shadow 0.15s ease;
 }
 
 .history-item:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.08);
+	transform: translateY(-1px);
+	box-shadow: 0 12px 20px rgba(15, 23, 42, 0.08);
 }
 
 .history-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 6px;
-  font-size: 11px;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 6px;
+	font-size: 11px;
 }
 
 .history-number {
-  font-weight: 700;
-  color: var(--accent-blue);
+	font-weight: 700;
+	color: var(--accent-blue);
 }
 
 .history-time {
-  flex: 1;
-  color: var(--text-secondary);
+	flex: 1;
+	color: var(--text-secondary);
 }
 
 .history-status {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
 }
 
 .history-status svg {
-  width: 16px;
-  height: 16px;
+	width: 16px;
+	height: 16px;
 }
 
 .history-status.success {
-  color: var(--success-color);
+	color: var(--success-color);
 }
 
 .history-status.error {
-  color: var(--error-color);
+	color: var(--error-color);
 }
 
 .history-summary {
-  font-size: 11px;
-  color: var(--text-muted);
+	font-size: 11px;
+	color: var(--text-muted);
 }

--- a/client/src/css/components/editor.css
+++ b/client/src/css/components/editor.css
@@ -1,21 +1,21 @@
 .editor-panel {
-  border: none;
-  background: var(--bg-primary);
+	border: none;
+	background: var(--bg-primary);
 }
 
 .dirty-marker {
-  color: var(--warning-color);
-  font-weight: 700;
-  margin-left: 6px;
+	color: var(--warning-color);
+	font-weight: 700;
+	margin-left: 6px;
 }
 
 .cell-boundary-decoration {
-  background: rgba(47, 111, 237, 0.12);
-  border-left: 3px solid var(--accent-blue);
-  width: 6px !important;
-  margin-left: 2px;
+	background: rgba(47, 111, 237, 0.12);
+	border-left: 3px solid var(--accent-blue);
+	width: 6px !important;
+	margin-left: 2px;
 }
 
 .executing-cell-background {
-  background-color: rgba(47, 111, 237, 0.08);
+	background-color: rgba(47, 111, 237, 0.08);
 }

--- a/client/src/css/components/export-dialog.css
+++ b/client/src/css/components/export-dialog.css
@@ -1,268 +1,268 @@
 /* Export Dialog Overlay */
 .export-dialog-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(15, 23, 42, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  backdrop-filter: blur(4px);
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(15, 23, 42, 0.6);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1000;
+	backdrop-filter: blur(4px);
 }
 
 /* Export Dialog */
 .export-dialog {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-color);
-  border-radius: var(--panel-radius);
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
-  width: 560px;
-  max-width: 90vw;
-  max-height: 90vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+	background: var(--bg-elevated);
+	border: 1px solid var(--border-color);
+	border-radius: var(--panel-radius);
+	box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+	width: 560px;
+	max-width: 90vw;
+	max-height: 90vh;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
 }
 
 /* Header */
 .export-dialog-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px;
-  background: var(--bg-toolbar);
-  border-bottom: 1px solid var(--border-light);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 16px;
+	background: var(--bg-toolbar);
+	border-bottom: 1px solid var(--border-light);
 }
 
 .export-dialog-header h2 {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: var(--letter-spacing-base);
+	margin: 0;
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--text-primary);
+	letter-spacing: var(--letter-spacing-base);
 }
 
 /* Content */
 .export-dialog-content {
-  flex: 1;
-  overflow-y: auto;
-  padding: 20px 16px;
-  background: var(--bg-primary);
+	flex: 1;
+	overflow-y: auto;
+	padding: 20px 16px;
+	background: var(--bg-primary);
 }
 
 /* Section */
 .export-section {
-  margin-bottom: 16px;
+	margin-bottom: 16px;
 }
 
 .export-section:last-child {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 
 .export-label {
-  display: block;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 8px;
-  letter-spacing: var(--letter-spacing-base);
+	display: block;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--text-primary);
+	margin-bottom: 8px;
+	letter-spacing: var(--letter-spacing-base);
 }
 
 /* Export Tab panels */
 .export-panel-tabs .tab {
-  padding: 8px 12px;
+	padding: 8px 12px;
 }
 
 .export-tab-content {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
 }
 
 .export-tab-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary);
-  line-height: 1.2;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--text-primary);
+	line-height: 1.2;
 }
 
 .export-tab-description {
-  font-size: 11px;
-  color: var(--text-muted);
-  line-height: 1.4;
+	font-size: 11px;
+	color: var(--text-muted);
+	line-height: 1.4;
 }
 
 /* Checkbox Group */
 .export-checkbox-group {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 }
 
 .export-checkbox {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-height: 32px;
-  cursor: pointer;
-  padding: 4px 0;
-  transition: opacity 0.15s ease;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-height: 32px;
+	cursor: pointer;
+	padding: 4px 0;
+	transition: opacity 0.15s ease;
 }
 
 .export-checkbox:hover {
-  opacity: 0.85;
+	opacity: 0.85;
 }
 
 .export-checkbox input[type="checkbox"] {
-  width: 20px;
-  height: 20px;
-  cursor: pointer;
-  accent-color: var(--accent-blue);
-  border-radius: 4px;
+	width: 20px;
+	height: 20px;
+	cursor: pointer;
+	accent-color: var(--accent-blue);
+	border-radius: 4px;
 }
 
 .export-checkbox input[type="checkbox"]:focus-visible {
-  outline: 2px solid var(--accent-blue);
-  outline-offset: 2px;
+	outline: 2px solid var(--accent-blue);
+	outline-offset: 2px;
 }
 
 .export-checkbox span {
-  font-size: 13px;
-  color: var(--text-primary);
-  line-height: 1.5;
+	font-size: 13px;
+	color: var(--text-primary);
+	line-height: 1.5;
 }
 
 /* Input */
 .export-input {
-  width: 100%;
-  padding: 10px 12px;
-  font-size: 13px;
-  color: var(--text-primary);
-  background: var(--bg-primary);
-  border: 2px solid var(--border-color);
-  border-radius: 6px;
-  outline: none;
-  transition: all 0.15s ease;
-  font-family: var(--font-family-base);
+	width: 100%;
+	padding: 10px 12px;
+	font-size: 13px;
+	color: var(--text-primary);
+	background: var(--bg-primary);
+	border: 2px solid var(--border-color);
+	border-radius: 6px;
+	outline: none;
+	transition: all 0.15s ease;
+	font-family: var(--font-family-base);
 }
 
 .export-input:hover {
-  border-color: var(--border-strong);
+	border-color: var(--border-strong);
 }
 
 .export-input:focus {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 0 3px var(--accent-blue-light);
+	border-color: var(--accent-blue);
+	box-shadow: 0 0 0 3px var(--accent-blue-light);
 }
 
 .export-input:disabled {
-  background: var(--bg-secondary);
-  color: var(--text-muted);
-  cursor: not-allowed;
-  opacity: 0.6;
+	background: var(--bg-secondary);
+	color: var(--text-muted);
+	cursor: not-allowed;
+	opacity: 0.6;
 }
 
 .export-hint {
-  margin: 6px 0 0;
-  font-size: 12px;
-  color: var(--text-muted);
-  line-height: 1.4;
+	margin: 6px 0 0;
+	font-size: 12px;
+	color: var(--text-muted);
+	line-height: 1.4;
 }
 
 /* Error Message */
 .export-error {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 12px 14px;
-  background: rgba(220, 76, 63, 0.08);
-  border: 2px solid rgba(220, 76, 63, 0.4);
-  border-left: 4px solid var(--error-color);
-  border-radius: 6px;
-  margin-top: 16px;
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 12px 14px;
+	background: rgba(220, 76, 63, 0.08);
+	border: 2px solid rgba(220, 76, 63, 0.4);
+	border-left: 4px solid var(--error-color);
+	border-radius: 6px;
+	margin-top: 16px;
 }
 
 .export-error::before {
-  content: '⚠';
-  font-size: 16px;
-  color: var(--error-color);
-  flex-shrink: 0;
-  line-height: 1.4;
+	content: "⚠";
+	font-size: 16px;
+	color: var(--error-color);
+	flex-shrink: 0;
+	line-height: 1.4;
 }
 
 .export-error span {
-  flex: 1;
-  font-size: 13px;
-  color: var(--error-color);
-  font-weight: 500;
-  line-height: 1.5;
+	flex: 1;
+	font-size: 13px;
+	color: var(--error-color);
+	font-weight: 500;
+	line-height: 1.5;
 }
 
 /* Success Message */
 .export-success {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 12px 14px;
-  background: rgba(31, 146, 84, 0.08);
-  border: 2px solid rgba(31, 146, 84, 0.4);
-  border-left: 4px solid var(--success-color);
-  border-radius: 6px;
-  margin-top: 16px;
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	padding: 12px 14px;
+	background: rgba(31, 146, 84, 0.08);
+	border: 2px solid rgba(31, 146, 84, 0.4);
+	border-left: 4px solid var(--success-color);
+	border-radius: 6px;
+	margin-top: 16px;
 }
 
 .export-success::before {
-  content: '✓';
-  font-size: 16px;
-  color: var(--success-color);
-  flex-shrink: 0;
-  line-height: 1.4;
+	content: "✓";
+	font-size: 16px;
+	color: var(--success-color);
+	flex-shrink: 0;
+	line-height: 1.4;
 }
 
 .export-success span {
-  flex: 1;
-  font-size: 13px;
-  color: var(--success-color);
-  font-weight: 500;
-  line-height: 1.5;
+	flex: 1;
+	font-size: 13px;
+	color: var(--success-color);
+	font-weight: 500;
+	line-height: 1.5;
 }
 
 /* Loading State Overlay */
 .export-dialog-content.loading {
-  pointer-events: none;
-  opacity: 0.6;
-  position: relative;
+	pointer-events: none;
+	opacity: 0.6;
+	position: relative;
 }
 
 .export-dialog-content.loading::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(255, 255, 255, 0.5);
-  cursor: wait;
+	content: "";
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(255, 255, 255, 0.5);
+	cursor: wait;
 }
 
 /* Disabled States */
 .export-radio.disabled,
 .export-checkbox.disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  pointer-events: none;
+	opacity: 0.5;
+	cursor: not-allowed;
+	pointer-events: none;
 }
 
 /* Footer */
 .export-dialog-footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 12px;
-  padding: 16px;
-  background: var(--bg-toolbar);
-  border-top: 1px solid var(--border-light);
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 12px;
+	padding: 16px;
+	background: var(--bg-toolbar);
+	border-top: 1px solid var(--border-light);
 }

--- a/client/src/css/components/file-browser.css
+++ b/client/src/css/components/file-browser.css
@@ -1,199 +1,199 @@
 .file-browser {
-  display: flex;
-  flex-direction: column;
+	display: flex;
+	flex-direction: column;
 }
 
 .file-browser-header {
-  padding: 0 12px;
+	padding: 0 12px;
 }
 
 .file-browser-content {
-  overflow: auto;
-  padding: 4px 0;
-  position: relative;
+	overflow: auto;
+	padding: 4px 0;
+	position: relative;
 }
 
 .file-browser-content.is-drag-target {
-  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.35);
+	box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.35);
 }
 
 .file-browser-empty,
 .file-browser-error {
-  padding: 16px;
-  text-align: center;
-  color: var(--text-secondary);
-  font-size: 13px;
+	padding: 16px;
+	text-align: center;
+	color: var(--text-secondary);
+	font-size: 13px;
 }
 
 .file-browser-empty .description {
-  margin: 4px 0 0;
-  font-size: 12px;
+	margin: 4px 0 0;
+	font-size: 12px;
 }
 
 .file-browser-error pre {
-  text-align: left;
-  background: rgba(255, 255, 255, 0.04);
-  border-radius: 6px;
-  padding: 8px;
-  overflow: auto;
-  font-size: 12px;
-  margin-top: 8px;
+	text-align: left;
+	background: rgba(255, 255, 255, 0.04);
+	border-radius: 6px;
+	padding: 8px;
+	overflow: auto;
+	font-size: 12px;
+	margin-top: 8px;
 }
 
 .file-tree {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 4px 0 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	padding: 4px 0 16px;
 }
 
 .file-tree-node {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 28px;
-  padding-right: 8px;
-  font-size: 13px;
-  color: var(--text-primary);
-  border-radius: 6px;
-  cursor: default;
-  user-select: none;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	min-height: 28px;
+	padding-right: 8px;
+	font-size: 13px;
+	color: var(--text-primary);
+	border-radius: 6px;
+	cursor: default;
+	user-select: none;
 }
 
 .file-tree-node[draggable="true"] {
-  cursor: grab;
+	cursor: grab;
 }
 
 .file-tree-node:hover {
-  background: rgba(96, 165, 250, 0.08);
+	background: rgba(96, 165, 250, 0.08);
 }
 
 .file-tree-node.is-selected {
-  background: rgba(47, 111, 237, 0.16);
-  color: var(--text-primary);
+	background: rgba(47, 111, 237, 0.16);
+	color: var(--text-primary);
 }
 
 .file-tree-node.is-focused {
-  outline: 1px solid rgba(148, 163, 184, 0.35);
+	outline: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .file-tree-node.is-drag-target {
-  background: rgba(59, 130, 246, 0.18);
+	background: rgba(59, 130, 246, 0.18);
 }
 
 .file-tree-expander {
-  width: 18px;
-  height: 18px;
-  border: none;
-  background: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-tertiary);
-  flex-shrink: 0;
+	width: 18px;
+	height: 18px;
+	border: none;
+	background: none;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text-tertiary);
+	flex-shrink: 0;
 }
 
 .file-tree-expander:hover {
-  color: var(--text-primary);
+	color: var(--text-primary);
 }
 
 .file-tree-expander svg {
-  width: 12px;
-  height: 12px;
+	width: 12px;
+	height: 12px;
 }
 
 .file-tree-placeholder {
-  display: inline-block;
-  width: 12px;
-  height: 12px;
+	display: inline-block;
+	width: 12px;
+	height: 12px;
 }
 
 .file-type-icon {
-  width: 20px;
-  height: 20px;
-  border-radius: 6px;
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-primary);
-  flex-shrink: 0;
+	width: 20px;
+	height: 20px;
+	border-radius: 6px;
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text-primary);
+	flex-shrink: 0;
 }
 
 .file-type-icon svg {
-  width: 14px;
-  height: 14px;
-  color: var(--text-secondary);
+	width: 14px;
+	height: 14px;
+	color: var(--text-secondary);
 }
 
 .file-tree-label {
-  flex: 1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+	flex: 1;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .file-tree-pending {
-  font-size: 11px;
-  color: var(--text-tertiary);
-  margin-left: auto;
+	font-size: 11px;
+	color: var(--text-tertiary);
+	margin-left: auto;
 }
 
 .file-context-menu {
-  position: fixed;
-  background: var(--bg-elevated);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: 8px;
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
-  padding: 6px;
-  display: flex;
-  flex-direction: column;
-  min-width: 180px;
-  z-index: 1000;
+	position: fixed;
+	background: var(--bg-elevated);
+	border: 1px solid rgba(148, 163, 184, 0.25);
+	border-radius: 8px;
+	box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+	padding: 6px;
+	display: flex;
+	flex-direction: column;
+	min-width: 180px;
+	z-index: 1000;
 }
 
 .file-context-menu button {
-  border: none;
-  background: none;
-  text-align: left;
-  padding: 6px 10px;
-  border-radius: 6px;
-  font-size: 13px;
-  color: var(--text-primary);
-  cursor: pointer;
+	border: none;
+	background: none;
+	text-align: left;
+	padding: 6px 10px;
+	border-radius: 6px;
+	font-size: 13px;
+	color: var(--text-primary);
+	cursor: pointer;
 }
 
 .file-context-menu button:hover:not(:disabled) {
-  background: rgba(96, 165, 250, 0.12);
+	background: rgba(96, 165, 250, 0.12);
 }
 
 .file-context-menu hr {
-  border: none;
-  border-top: 1px solid rgba(148, 163, 184, 0.2);
-  margin: 6px 0;
+	border: none;
+	border-top: 1px solid rgba(148, 163, 184, 0.2);
+	margin: 6px 0;
 }
 
 .file-context-menu button:disabled {
-  color: var(--text-tertiary);
-  cursor: not-allowed;
+	color: var(--text-tertiary);
+	cursor: not-allowed;
 }
 
 .spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgba(96, 165, 250, 0.25);
-  border-top-color: rgba(47, 111, 237, 0.8);
-  border-radius: 50%;
-  display: inline-block;
-  animation: file-browser-spin 1s linear infinite;
-  margin-right: 8px;
+	width: 14px;
+	height: 14px;
+	border: 2px solid rgba(96, 165, 250, 0.25);
+	border-top-color: rgba(47, 111, 237, 0.8);
+	border-radius: 50%;
+	display: inline-block;
+	animation: file-browser-spin 1s linear infinite;
+	margin-right: 8px;
 }
 
 @keyframes file-browser-spin {
-  to {
-    transform: rotate(360deg);
-  }
+	to {
+		transform: rotate(360deg);
+	}
 }

--- a/client/src/css/components/layout.css
+++ b/client/src/css/components/layout.css
@@ -1,249 +1,289 @@
 .app {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  min-height: 100vh;
-  padding: 16px 20px 18px;
-  gap: 14px;
-  background: transparent;
-  overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	min-height: 100vh;
+	padding: 16px 20px 18px;
+	gap: 14px;
+	background: transparent;
+	overflow: hidden;
 }
 
 .workspace-shell {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  padding: 4px;
-  background: #e9edf3;
-  border: 1px solid #d5dae1;
-  border-radius: 6px;
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	padding: 4px;
+	background: #e9edf3;
+	border: 1px solid #d5dae1;
+	border-radius: 6px;
 }
 
 .workspace-shell .allotment {
-  flex: 1;
-  min-height: 0;
+	flex: 1;
+	min-height: 0;
 }
 
 .ai-pane-wrapper {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
 }
 
 .workspace-shell .allotment__layout {
-  gap: 10px !important;
+	gap: 10px !important;
 }
 
 /* Panel base styles */
 .panel {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  background: #ffffff;
-  border: 1px solid #d5dae1;
-  border-radius: 4px;
-  overflow: hidden;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	background: #ffffff;
+	border: 1px solid #d5dae1;
+	border-radius: 4px;
+	overflow: hidden;
 }
 
 .panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  min-height: var(--panel-header-min-height, 38px);
-  padding: var(--panel-header-padding, 0 14px);
-  background: #f8f9fb;
-  border-bottom: 1px solid #dfe3e8;
-  flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	min-height: var(--panel-header-min-height, 38px);
+	padding: var(--panel-header-padding, 0 14px);
+	background: #f8f9fb;
+	border-bottom: 1px solid #dfe3e8;
+	flex-shrink: 0;
 }
 
 .panel-title {
-  font-size: var(--panel-title-font-size, 13px);
-  font-weight: var(--panel-title-font-weight, 600);
-  color: var(--text-primary);
-  display: flex;
-  align-items: center;
-  gap: var(--panel-title-gap, 8px);
-  letter-spacing: var(--panel-title-letter-spacing, var(--letter-spacing-base));
+	font-size: var(--panel-title-font-size, 13px);
+	font-weight: var(--panel-title-font-weight, 600);
+	color: var(--text-primary);
+	display: flex;
+	align-items: center;
+	gap: var(--panel-title-gap, 8px);
+	letter-spacing: var(--panel-title-letter-spacing, var(--letter-spacing-base));
 }
 
 .panel-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--panel-actions-gap, 8px);
+	display: flex;
+	align-items: center;
+	gap: var(--panel-actions-gap, 8px);
 }
 
 .panel-content {
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-  background-color: var(--bg-primary);
+	flex: 1;
+	min-height: 0;
+	overflow: hidden;
+	background-color: var(--bg-primary);
 }
 
 .panel--transparent {
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  backdrop-filter: none;
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	backdrop-filter: none;
 }
 
 .panel--transparent .panel-content {
-  background: transparent;
+	background: transparent;
 }
 
 .panel-header--plain {
-  padding: 0 12px;
-  background: transparent;
-  box-shadow: none;
-  border-bottom: none;
+	padding: 0 12px;
+	background: transparent;
+	box-shadow: none;
+	border-bottom: none;
 }
 
 .panel-tabs--flush {
-  flex: 1;
-  margin: 0;
-  padding-left: 0;
-  background: transparent;
+	flex: 1;
+	margin: 0;
+	padding-left: 0;
+	background: transparent;
 }
 
 .panel-actions--compact {
-  padding: 0 10px;
-  gap: var(--panel-actions-gap, 8px);
+	padding: 0 10px;
+	gap: var(--panel-actions-gap, 8px);
 }
 
 /* Button styles */
 .btn {
-  padding: var(--btn-padding, 6px 14px);
-  font-size: var(--btn-font-size, 12px);
-  border-radius: var(--btn-radius, 999px);
-  border: var(--btn-border, 1px solid rgba(148, 163, 184, 0.4));
-  background: var(--btn-bg, linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(244, 246, 251, 0.85)));
-  color: var(--btn-color, var(--text-primary));
-  cursor: pointer;
-  transition: var(--btn-transition, transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  height: var(--btn-height, 28px);
-  box-shadow: var(--btn-shadow, inset 0 1px 0 rgba(255, 255, 255, 0.7));
+	padding: var(--btn-padding, 6px 14px);
+	font-size: var(--btn-font-size, 12px);
+	border-radius: var(--btn-radius, 999px);
+	border: var(--btn-border, 1px solid rgba(148, 163, 184, 0.4));
+	background: var(
+		--btn-bg,
+		linear-gradient(
+			180deg,
+			rgba(255, 255, 255, 0.85),
+			rgba(244, 246, 251, 0.85)
+		)
+	);
+	color: var(--btn-color, var(--text-primary));
+	cursor: pointer;
+	transition: var(
+		--btn-transition,
+		transform 0.15s ease,
+		box-shadow 0.15s ease,
+		background 0.15s ease
+	);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	height: var(--btn-height, 28px);
+	box-shadow: var(--btn-shadow, inset 0 1px 0 rgba(255, 255, 255, 0.7));
 }
 
 .btn svg {
-  width: 16px;
-  height: 16px;
+	width: 16px;
+	height: 16px;
 }
 
 .btn:hover:not(:disabled) {
-  transform: var(--btn-hover-transform, translateY(-1px));
-  box-shadow: var(--btn-hover-shadow, 0 6px 14px rgba(47, 111, 237, 0.08));
-  background: var(--btn-hover-bg, linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(236, 240, 248, 0.95)));
-  border-color: var(--btn-hover-border-color, rgba(148, 163, 184, 0.4));
+	transform: var(--btn-hover-transform, translateY(-1px));
+	box-shadow: var(--btn-hover-shadow, 0 6px 14px rgba(47, 111, 237, 0.08));
+	background: var(
+		--btn-hover-bg,
+		linear-gradient(
+			180deg,
+			rgba(255, 255, 255, 0.95),
+			rgba(236, 240, 248, 0.95)
+		)
+	);
+	border-color: var(--btn-hover-border-color, rgba(148, 163, 184, 0.4));
 }
 
 .btn:active:not(:disabled) {
-  transform: var(--btn-active-transform, translateY(0));
-  box-shadow: var(--btn-active-shadow, inset 0 1px 2px rgba(15, 23, 42, 0.12));
-  background: var(--btn-active-bg, var(--btn-hover-bg, linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(236, 240, 248, 0.95))));
+	transform: var(--btn-active-transform, translateY(0));
+	box-shadow: var(--btn-active-shadow, inset 0 1px 2px rgba(15, 23, 42, 0.12));
+	background: var(
+		--btn-active-bg,
+		var(
+			--btn-hover-bg,
+			linear-gradient(
+				180deg,
+				rgba(255, 255, 255, 0.95),
+				rgba(236, 240, 248, 0.95)
+			)
+		)
+	);
 }
 
 .btn-primary {
-  background: var(--btn-primary-bg, linear-gradient(180deg, #2f6fed, #2756ca));
-  color: var(--btn-primary-color, #ffffff);
-  border-color: var(--btn-primary-border, transparent);
-  box-shadow: var(--btn-primary-shadow, 0 10px 20px rgba(47, 111, 237, 0.25));
+	background: var(--btn-primary-bg, linear-gradient(180deg, #2f6fed, #2756ca));
+	color: var(--btn-primary-color, #ffffff);
+	border-color: var(--btn-primary-border, transparent);
+	box-shadow: var(--btn-primary-shadow, 0 10px 20px rgba(47, 111, 237, 0.25));
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: var(--btn-primary-hover-bg, linear-gradient(180deg, #2f6fed, #244fc1));
-  box-shadow: var(--btn-primary-hover-shadow, 0 12px 24px rgba(47, 111, 237, 0.35));
+	background: var(
+		--btn-primary-hover-bg,
+		linear-gradient(180deg, #2f6fed, #244fc1)
+	);
+	box-shadow: var(
+		--btn-primary-hover-shadow,
+		0 12px 24px rgba(47, 111, 237, 0.35)
+	);
 }
 
 .btn-icon {
-  padding: var(--btn-icon-padding, 6px);
-  min-width: var(--btn-icon-size, 28px);
-  height: var(--btn-icon-height, 28px);
-  border-radius: var(--btn-icon-radius, 8px);
+	padding: var(--btn-icon-padding, 6px);
+	min-width: var(--btn-icon-size, 28px);
+	height: var(--btn-icon-height, 28px);
+	border-radius: var(--btn-icon-radius, 8px);
 }
 
 .btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  box-shadow: none;
+	opacity: 0.6;
+	cursor: not-allowed;
+	box-shadow: none;
 }
 
 /* Tab styles */
 .tabs {
-  display: flex;
-  align-items: flex-end;
-  gap: var(--tabs-gap, 6px);
-  padding: var(--tabs-padding, 0 12px);
-  background: var(--tabs-background, transparent);
-  border-bottom: var(--tabs-border-bottom, none);
+	display: flex;
+	align-items: flex-end;
+	gap: var(--tabs-gap, 6px);
+	padding: var(--tabs-padding, 0 12px);
+	background: var(--tabs-background, transparent);
+	border-bottom: var(--tabs-border-bottom, none);
 }
 
 .tab {
-  padding: var(--tab-padding, 6px 14px);
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-  font-size: var(--tab-font-size, 12px);
-  color: var(--tab-color, var(--text-secondary));
-  background: var(--tab-bg, rgba(255, 255, 255, 0.65));
-  border-radius: var(--tab-radius, 10px 10px 0 0);
-  border: var(--tab-border, 1px solid transparent);
-  border-right: var(--tab-divider, none);
-  font-family: inherit;
-  appearance: none;
-  outline: none;
-  transition: var(--tab-transition, transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease);
-  box-shadow: var(--tab-shadow, none);
+	padding: var(--tab-padding, 6px 14px);
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+	font-size: var(--tab-font-size, 12px);
+	color: var(--tab-color, var(--text-secondary));
+	background: var(--tab-bg, rgba(255, 255, 255, 0.65));
+	border-radius: var(--tab-radius, 10px 10px 0 0);
+	border: var(--tab-border, 1px solid transparent);
+	border-right: var(--tab-divider, none);
+	font-family: inherit;
+	appearance: none;
+	outline: none;
+	transition: var(
+		--tab-transition,
+		transform 0.15s ease,
+		box-shadow 0.15s ease,
+		background 0.15s ease
+	);
+	box-shadow: var(--tab-shadow, none);
 }
 
 .tab.active {
-  color: var(--tab-active-color, var(--accent-blue));
-  background: var(--tab-active-bg, rgba(47, 111, 237, 0.16));
-  border-color: var(--tab-active-border, rgba(47, 111, 237, 0.32));
-  box-shadow: var(--tab-active-shadow, 0 10px 24px rgba(47, 111, 237, 0.18));
-  border-bottom: var(--tab-active-underline, none);
+	color: var(--tab-active-color, var(--accent-blue));
+	background: var(--tab-active-bg, rgba(47, 111, 237, 0.16));
+	border-color: var(--tab-active-border, rgba(47, 111, 237, 0.32));
+	box-shadow: var(--tab-active-shadow, 0 10px 24px rgba(47, 111, 237, 0.18));
+	border-bottom: var(--tab-active-underline, none);
 }
 
 .tab:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+	opacity: 0.5;
+	cursor: not-allowed;
 }
 
 .panel-tabs--compact {
-  gap: 4px;
-  padding: 0 8px;
+	gap: 4px;
+	padding: 0 8px;
 }
 
 .panel-tabs--compact .tab {
-  padding: 4px 10px;
-  font-size: 11px;
+	padding: 4px 10px;
+	font-size: 11px;
 }
 
 .panel-tabs--equal-width .tab {
-  flex: 1;
-  justify-content: center;
-  min-width: 0;
+	flex: 1;
+	justify-content: center;
+	min-width: 0;
 }
 
 .panel-content .tab-panel {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
 }
 
 .spinner {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.4);
-  border-top-color: rgba(255, 255, 255, 0.9);
-  animation: spin 0.8s linear infinite;
+	width: 12px;
+	height: 12px;
+	border-radius: 50%;
+	border: 2px solid rgba(255, 255, 255, 0.4);
+	border-top-color: rgba(255, 255, 255, 0.9);
+	animation: spin 0.8s linear infinite;
 }
 
 @keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+	to {
+		transform: rotate(360deg);
+	}
 }

--- a/client/src/css/components/layout.css
+++ b/client/src/css/components/layout.css
@@ -117,11 +117,7 @@
 	border: var(--btn-border, 1px solid rgba(148, 163, 184, 0.4));
 	background: var(
 		--btn-bg,
-		linear-gradient(
-			180deg,
-			rgba(255, 255, 255, 0.85),
-			rgba(244, 246, 251, 0.85)
-		)
+		linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(244, 246, 251, 0.85))
 	);
 	color: var(--btn-color, var(--text-primary));
 	cursor: pointer;
@@ -149,11 +145,7 @@
 	box-shadow: var(--btn-hover-shadow, 0 6px 14px rgba(47, 111, 237, 0.08));
 	background: var(
 		--btn-hover-bg,
-		linear-gradient(
-			180deg,
-			rgba(255, 255, 255, 0.95),
-			rgba(236, 240, 248, 0.95)
-		)
+		linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(236, 240, 248, 0.95))
 	);
 	border-color: var(--btn-hover-border-color, rgba(148, 163, 184, 0.4));
 }
@@ -165,11 +157,7 @@
 		--btn-active-bg,
 		var(
 			--btn-hover-bg,
-			linear-gradient(
-				180deg,
-				rgba(255, 255, 255, 0.95),
-				rgba(236, 240, 248, 0.95)
-			)
+			linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(236, 240, 248, 0.95))
 		)
 	);
 }
@@ -182,14 +170,8 @@
 }
 
 .btn-primary:hover:not(:disabled) {
-	background: var(
-		--btn-primary-hover-bg,
-		linear-gradient(180deg, #2f6fed, #244fc1)
-	);
-	box-shadow: var(
-		--btn-primary-hover-shadow,
-		0 12px 24px rgba(47, 111, 237, 0.35)
-	);
+	background: var(--btn-primary-hover-bg, linear-gradient(180deg, #2f6fed, #244fc1));
+	box-shadow: var(--btn-primary-hover-shadow, 0 12px 24px rgba(47, 111, 237, 0.35));
 }
 
 .btn-icon {

--- a/client/src/css/components/menu.css
+++ b/client/src/css/components/menu.css
@@ -11,124 +11,124 @@
 
 /* --- Menu Bar Container --- */
 .menubar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: var(--menu-height, 32px);
-  padding: var(--menu-padding, 0 12px);
-  background: var(--menu-bg, #f6f8fa);
-  border-bottom: 1px solid var(--menu-border-color, #d0d7de);
-  border-radius: var(--menu-border-radius, 0);
-  box-shadow: var(--menu-shadow, none);
-  backdrop-filter: none;
-  position: relative;
-  overflow: visible;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	height: var(--menu-height, 32px);
+	padding: var(--menu-padding, 0 12px);
+	background: var(--menu-bg, #f6f8fa);
+	border-bottom: 1px solid var(--menu-border-color, #d0d7de);
+	border-radius: var(--menu-border-radius, 0);
+	box-shadow: var(--menu-shadow, none);
+	backdrop-filter: none;
+	position: relative;
+	overflow: visible;
 }
 
 /* Remove decorative overlay */
 .menubar::after {
-  display: none;
+	display: none;
 }
 
 .menubar-left {
-  display: flex;
-  align-items: center;
-  gap: var(--menu-gap, 20px);
+	display: flex;
+	align-items: center;
+	gap: var(--menu-gap, 20px);
 }
 
 .menubar-brand {
-  font-size: 13px;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  color: var(--text-primary);
-  font-family: var(--font-ui, var(--font-family-base));
+	font-size: 13px;
+	font-weight: 700;
+	letter-spacing: -0.01em;
+	color: var(--text-primary);
+	font-family: var(--font-ui, var(--font-family-base));
 }
 
 .menubar-menu {
-  display: flex;
-  gap: var(--menu-item-gap, 2px);
+	display: flex;
+	gap: var(--menu-item-gap, 2px);
 }
 
 .menubar-right {
-  display: flex;
-  align-items: center;
+	display: flex;
+	align-items: center;
 }
 
 /* --- Menu Items --- */
 .menu-section {
-  position: relative;
+	position: relative;
 }
 
 .menu-item {
-  padding: var(--menu-item-padding, 4px 10px);
-  font-size: var(--menu-item-font-size, 12px);
-  font-weight: 500;
-  color: var(--text-secondary);
-  border-radius: var(--menu-item-border-radius, 3px);
-  transition: none; /* No animations */
-  background: transparent;
-  cursor: pointer;
-  position: relative;
-  border: none;
-  outline: none;
+	padding: var(--menu-item-padding, 4px 10px);
+	font-size: var(--menu-item-font-size, 12px);
+	font-weight: 500;
+	color: var(--text-secondary);
+	border-radius: var(--menu-item-border-radius, 3px);
+	transition: none; /* No animations */
+	background: transparent;
+	cursor: pointer;
+	position: relative;
+	border: none;
+	outline: none;
 }
 
 .menu-item:hover {
-  color: var(--text-primary);
-  background: var(--menu-item-hover-bg, #e5e7eb);
+	color: var(--text-primary);
+	background: var(--menu-item-hover-bg, #e5e7eb);
 }
 
 .menu-item:active,
 .menu-item.active {
-  background: var(--menu-item-active-bg, #d1d5db);
+	background: var(--menu-item-active-bg, #d1d5db);
 }
 
 /* AI Assistant menu item - Lab notebook accent */
 .menu-item[data-id="edit:ai-assist"],
 .menu-dropdown-item[data-id="edit:ai-assist"] {
-  background: var(--menu-ai-bg, #fefce8);
-  border-left: 3px solid var(--menu-ai-border, #f59e0b);
-  padding-left: 7px; /* Adjust for border */
-  font-weight: 600;
-  color: var(--text-primary);
+	background: var(--menu-ai-bg, #fefce8);
+	border-left: 3px solid var(--menu-ai-border, #f59e0b);
+	padding-left: 7px; /* Adjust for border */
+	font-weight: 600;
+	color: var(--text-primary);
 }
 
 .menu-item[data-id="edit:ai-assist"]:hover,
 .menu-dropdown-item[data-id="edit:ai-assist"]:hover {
-  background: var(--menu-ai-hover-bg, #fef9c3);
+	background: var(--menu-ai-hover-bg, #fef9c3);
 }
 
 /* --- Connection Indicator --- */
 .connection-indicator {
-  display: flex;
-  align-items: center;
-  gap: var(--menu-connection-gap, 6px);
-  font-size: var(--menu-connection-font-size, 11px);
-  color: var(--text-secondary);
-  padding: var(--menu-connection-padding, 4px 8px);
-  border-radius: var(--menu-item-border-radius, 3px);
-  background: var(--menu-connection-bg, #ffffff);
-  border: 1px solid var(--menu-connection-border, #d0d7de);
-  box-shadow: none;
+	display: flex;
+	align-items: center;
+	gap: var(--menu-connection-gap, 6px);
+	font-size: var(--menu-connection-font-size, 11px);
+	color: var(--text-secondary);
+	padding: var(--menu-connection-padding, 4px 8px);
+	border-radius: var(--menu-item-border-radius, 3px);
+	background: var(--menu-connection-bg, #ffffff);
+	border: 1px solid var(--menu-connection-border, #d0d7de);
+	box-shadow: none;
 }
 
 .connection-dot {
-  width: 8px; /* Reduced from 10px */
-  height: 8px;
-  border-radius: 50%;
-  background: var(--menu-error-color, var(--error-color, #ef4444));
-  box-shadow: none; /* No glow effect */
+	width: 8px; /* Reduced from 10px */
+	height: 8px;
+	border-radius: 50%;
+	background: var(--menu-error-color, var(--error-color, #ef4444));
+	box-shadow: none; /* No glow effect */
 }
 
 .connection-indicator.connected .connection-dot {
-  background: var(--menu-success-color, var(--success-color, #10b981));
-  box-shadow: none;
+	background: var(--menu-success-color, var(--success-color, #10b981));
+	box-shadow: none;
 }
 
 .connection-text {
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.01em;
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0.01em;
 }
 
 /* ============================================
@@ -136,83 +136,89 @@
    ============================================ */
 
 .menu-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  min-width: 220px;
-  background: var(--menu-dropdown-bg, #ffffff);
-  border: 1px solid var(--menu-dropdown-border, #d0d7de);
-  border-radius: 0; /* No rounding */
-  box-shadow: var(--menu-dropdown-shadow, 0 4px 12px rgba(0, 0, 0, 0.1));
-  padding: 4px 0;
-  margin-top: 2px;
-  z-index: 1000;
+	position: absolute;
+	top: 100%;
+	left: 0;
+	min-width: 220px;
+	background: var(--menu-dropdown-bg, #ffffff);
+	border: 1px solid var(--menu-dropdown-border, #d0d7de);
+	border-radius: 0; /* No rounding */
+	box-shadow: var(--menu-dropdown-shadow, 0 4px 12px rgba(0, 0, 0, 0.1));
+	padding: 4px 0;
+	margin-top: 2px;
+	z-index: 1000;
 }
 
 .menu-dropdown-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 6px 12px;
-  font-size: 12px;
-  color: var(--text-primary);
-  cursor: pointer;
-  transition: none; /* No animation */
-  background: transparent;
-  border: none;
-  width: 100%;
-  text-align: left;
-  outline: none;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 6px 12px;
+	font-size: 12px;
+	color: var(--text-primary);
+	cursor: pointer;
+	transition: none; /* No animation */
+	background: transparent;
+	border: none;
+	width: 100%;
+	text-align: left;
+	outline: none;
 }
 
 .menu-dropdown-item:hover {
-  background: var(--menu-dropdown-hover-bg, #f6f8fa);
+	background: var(--menu-dropdown-hover-bg, #f6f8fa);
 }
 
 .menu-dropdown-item:active {
-  background: var(--menu-dropdown-active-bg, #e5e7eb);
+	background: var(--menu-dropdown-active-bg, #e5e7eb);
 }
 
 .menu-dropdown-item[data-disabled="true"] {
-  color: var(--text-muted, #9ca3af);
-  cursor: not-allowed;
+	color: var(--text-muted, #9ca3af);
+	cursor: not-allowed;
 }
 
 .menu-dropdown-item[data-disabled="true"]:hover {
-  background: transparent;
+	background: transparent;
 }
 
 /* Separator */
 .menu-dropdown-separator {
-  height: 1px;
-  background: var(--menu-dropdown-separator, #e5e7eb);
-  margin: 4px 0;
+	height: 1px;
+	background: var(--menu-dropdown-separator, #e5e7eb);
+	margin: 4px 0;
 }
 
 /* Shortcut label */
 .menu-item-shortcut {
-  font-size: 11px;
-  color: var(--text-muted, #9ca3af);
-  font-family: var(--font-code, 'Berkeley Mono', 'Fira Code', 'Consolas', monospace);
-  margin-left: 24px;
+	font-size: 11px;
+	color: var(--text-muted, #9ca3af);
+	font-family: var(
+		--font-code,
+		"Berkeley Mono",
+		"Fira Code",
+		"Consolas",
+		monospace
+	);
+	margin-left: 24px;
 }
 
 /* Checkmark for toggle items */
 .menu-item-check {
-  width: 16px;
-  height: 16px;
-  margin-right: 8px;
-  color: var(--menu-success-color, var(--success-color, #10b981));
-  visibility: hidden;
+	width: 16px;
+	height: 16px;
+	margin-right: 8px;
+	color: var(--menu-success-color, var(--success-color, #10b981));
+	visibility: hidden;
 }
 
 .menu-dropdown-item[data-checked="true"] .menu-item-check {
-  visibility: visible;
+	visibility: visible;
 }
 
 .menu-item-label {
-  display: flex;
-  align-items: center;
+	display: flex;
+	align-items: center;
 }
 
 /* ============================================

--- a/client/src/css/components/menu.css
+++ b/client/src/css/components/menu.css
@@ -193,13 +193,7 @@
 .menu-item-shortcut {
 	font-size: 11px;
 	color: var(--text-muted, #9ca3af);
-	font-family: var(
-		--font-code,
-		"Berkeley Mono",
-		"Fira Code",
-		"Consolas",
-		monospace
-	);
+	font-family: var(--font-code, "Berkeley Mono", "Fira Code", "Consolas", monospace);
 	margin-left: 24px;
 }
 

--- a/client/src/css/components/modal-dialog.css
+++ b/client/src/css/components/modal-dialog.css
@@ -1,495 +1,495 @@
 .modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(8, 13, 23, 0.7);
-  backdrop-filter: blur(4px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 32px;
-  z-index: 80;
+	position: fixed;
+	inset: 0;
+	background: rgba(8, 13, 23, 0.7);
+	backdrop-filter: blur(4px);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 32px;
+	z-index: 80;
 }
 
 .modal-dialog {
-  width: min(93vw, 780px);
-  background: #1a1f2a;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 14px;
-  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.45);
-  color: #f4f6fb;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
+	width: min(93vw, 780px);
+	background: #1a1f2a;
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	border-radius: 14px;
+	box-shadow: 0 20px 80px rgba(0, 0, 0, 0.45);
+	color: #f4f6fb;
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
 }
 
 .modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 20px 24px 16px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 20px 24px 16px;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .modal-title {
-  display: flex;
-  gap: 12px;
-  align-items: center;
+	display: flex;
+	gap: 12px;
+	align-items: center;
 }
 
 .modal-title h2 {
-  margin: 0;
-  font-size: 1.1rem;
+	margin: 0;
+	font-size: 1.1rem;
 }
 
 .modal-subtitle {
-  margin: 2px 0 0;
-  font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.65);
+	margin: 2px 0 0;
+	font-size: 0.85rem;
+	color: rgba(255, 255, 255, 0.65);
 }
 
 .modal-title-icon svg,
 .modal-title-icon {
-  width: 28px;
-  height: 28px;
-  color: #8ab4ff;
+	width: 28px;
+	height: 28px;
+	color: #8ab4ff;
 }
 
 .modal-body {
-  padding: 20px 24px 24px;
-  overflow-y: auto;
-  max-height: 70vh;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
+	padding: 20px 24px 24px;
+	overflow-y: auto;
+	max-height: 70vh;
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
 }
 
 .modal-footer {
-  padding: 16px 24px;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+	padding: 16px 24px;
+	border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .modal-footer-actions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
 }
 
 .modal-footer .btn {
-  min-width: 120px;
+	min-width: 120px;
 }
 
 .shortcuts-search input {
-  width: 100%;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 8px;
-  padding: 10px 12px;
-  color: inherit;
+	width: 100%;
+	background: rgba(255, 255, 255, 0.04);
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	border-radius: 8px;
+	padding: 10px 12px;
+	color: inherit;
 }
 
 .shortcuts-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+	gap: 16px;
 }
 
 .shortcut-group {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 10px;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+	background: rgba(255, 255, 255, 0.02);
+	border: 1px solid rgba(255, 255, 255, 0.05);
+	border-radius: 10px;
+	padding: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 
 .shortcut-group-header {
-  font-weight: 600;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.58);
+	font-weight: 600;
+	text-transform: uppercase;
+	font-size: 0.75rem;
+	color: rgba(255, 255, 255, 0.58);
 }
 
 .shortcut-card {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  border-radius: 8px;
-  padding: 10px;
+	background: rgba(255, 255, 255, 0.02);
+	border: 1px solid rgba(255, 255, 255, 0.04);
+	border-radius: 8px;
+	padding: 10px;
 }
 
 .shortcut-keys {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
 }
 
 .shortcut-details {
-  margin-top: 6px;
+	margin-top: 6px;
 }
 
 .shortcut-description {
-  font-size: 0.9rem;
+	font-size: 0.9rem;
 }
 
 .shortcut-scope {
-  display: inline-block;
-  margin-top: 2px;
-  font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.6);
+	display: inline-block;
+	margin-top: 2px;
+	font-size: 0.75rem;
+	color: rgba(255, 255, 255, 0.6);
 }
 
 .keycap {
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 6px;
-  padding: 4px 8px;
-  font-size: 0.85rem;
+	border: 1px solid rgba(255, 255, 255, 0.2);
+	background: rgba(255, 255, 255, 0.05);
+	border-radius: 6px;
+	padding: 4px 8px;
+	font-size: 0.85rem;
 }
 
 .shortcuts-empty {
-  grid-column: 1 / -1;
-  text-align: center;
-  padding: 16px;
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.04);
+	grid-column: 1 / -1;
+	text-align: center;
+	padding: 16px;
+	border-radius: 8px;
+	background: rgba(255, 255, 255, 0.04);
 }
 
 .about-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 16px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+	gap: 16px;
 }
 
 .about-card {
-  padding: 16px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  background: rgba(255, 255, 255, 0.02);
+	padding: 16px;
+	border-radius: 12px;
+	border: 1px solid rgba(255, 255, 255, 0.06);
+	background: rgba(255, 255, 255, 0.02);
 }
 
 .about-card h3 {
-  margin: 0 0 8px;
+	margin: 0 0 8px;
 }
 
 .about-metric {
-  font-size: 1.3rem;
-  margin: 0 0 8px;
+	font-size: 1.3rem;
+	margin: 0 0 8px;
 }
 
 .about-card dl {
-  margin: 0;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 6px 12px;
-  font-size: 0.85rem;
+	margin: 0;
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 6px 12px;
+	font-size: 0.85rem;
 }
 
 .about-card dt {
-  color: rgba(255, 255, 255, 0.6);
+	color: rgba(255, 255, 255, 0.6);
 }
 
 .about-card dd {
-  margin: 0;
+	margin: 0;
 }
 
 .about-tech-list {
-  list-style: none;
-  margin: 12px 0 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+	list-style: none;
+	margin: 12px 0 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 }
 
 .about-tech-list li strong {
-  display: block;
-  font-size: 0.85rem;
+	display: block;
+	font-size: 0.85rem;
 }
 
 .about-tech-list li span {
-  font-size: 0.78rem;
-  color: rgba(255, 255, 255, 0.65);
+	font-size: 0.78rem;
+	color: rgba(255, 255, 255, 0.65);
 }
 
 .about-links {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
+	display: flex;
+	gap: 12px;
+	flex-wrap: wrap;
 }
 
 .about-links a {
-  color: #8ab4ff;
-  text-decoration: none;
-  font-weight: 500;
+	color: #8ab4ff;
+	text-decoration: none;
+	font-weight: 500;
 }
 
 .project-manager {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
 }
 
 .project-manager-section {
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
-  padding: 16px;
-  background: rgba(0, 0, 0, 0.2);
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	border-radius: 12px;
+	padding: 16px;
+	background: rgba(0, 0, 0, 0.2);
 }
 
 .project-manager-section h3 {
-  margin: 0 0 8px;
+	margin: 0 0 8px;
 }
 
 .project-card {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 0;
-  gap: 16px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 12px 0;
+	gap: 16px;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .project-card:last-child {
-  border-bottom: none;
-  padding-bottom: 0;
+	border-bottom: none;
+	padding-bottom: 0;
 }
 
 .project-card strong {
-  display: block;
+	display: block;
 }
 
 .project-card .muted {
-  color: rgba(255, 255, 255, 0.65);
-  margin: 4px 0 0;
+	color: rgba(255, 255, 255, 0.65);
+	margin: 4px 0 0;
 }
 
 .project-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+	list-style: none;
+	margin: 0;
+	padding: 0;
 }
 
 .form-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 12px;
-  margin-bottom: 12px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+	gap: 12px;
+	margin-bottom: 12px;
 }
 
 .form-grid label,
 .project-manager-section label {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: 0.9rem;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	font-size: 0.9rem;
 }
 
 .project-manager input {
-  padding: 8px 10px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(0, 0, 0, 0.3);
-  color: inherit;
+	padding: 8px 10px;
+	border-radius: 8px;
+	border: 1px solid rgba(255, 255, 255, 0.2);
+	background: rgba(0, 0, 0, 0.3);
+	color: inherit;
 }
 
 .project-manager input:focus {
-  outline: 2px solid var(--accent);
+	outline: 2px solid var(--accent);
 }
 
 .project-manager .section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 8px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 8px;
 }
 
 .alert {
-  padding: 12px 16px;
-  border-radius: 10px;
-  margin-bottom: 8px;
+	padding: 12px 16px;
+	border-radius: 10px;
+	margin-bottom: 8px;
 }
 
 .alert-error {
-  border: 1px solid rgba(255, 99, 132, 0.4);
-  background: rgba(255, 99, 132, 0.1);
-  color: #ff6384;
+	border: 1px solid rgba(255, 99, 132, 0.4);
+	background: rgba(255, 99, 132, 0.1);
+	color: #ff6384;
 }
 
 .project-manager .btn-link {
-  padding: 0;
-  font-size: 0.9rem;
+	padding: 0;
+	font-size: 0.9rem;
 }
 
 .session-info-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 16px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+	gap: 16px;
 }
 
 .session-info-card {
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.07);
-  padding: 16px;
-  background: rgba(255, 255, 255, 0.02);
+	border-radius: 12px;
+	border: 1px solid rgba(255, 255, 255, 0.07);
+	padding: 16px;
+	background: rgba(255, 255, 255, 0.02);
 }
 
 .session-info-card dl {
-  margin: 0;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px 12px;
-  font-size: 0.85rem;
+	margin: 0;
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 8px 12px;
+	font-size: 0.85rem;
 }
 
 .session-info-card dt {
-  color: rgba(255, 255, 255, 0.6);
+	color: rgba(255, 255, 255, 0.6);
 }
 
 .session-info-card dd {
-  margin: 0;
-  font-weight: 600;
+	margin: 0;
+	font-weight: 600;
 }
 
 .package-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
 }
 
 .package-list li {
-  background: rgba(138, 180, 255, 0.12);
-  color: #e5edff;
-  padding: 6px 10px;
-  border-radius: 999px;
-  font-size: 0.78rem;
+	background: rgba(138, 180, 255, 0.12);
+	color: #e5edff;
+	padding: 6px 10px;
+	border-radius: 999px;
+	font-size: 0.78rem;
 }
 
 .package-version {
-  margin-left: 4px;
-  color: rgba(255, 255, 255, 0.8);
+	margin-left: 4px;
+	color: rgba(255, 255, 255, 0.8);
 }
 
 .package-more {
-  background: transparent;
-  border: 1px dashed rgba(255, 255, 255, 0.2);
+	background: transparent;
+	border: 1px dashed rgba(255, 255, 255, 0.2);
 }
 
 .session-info-empty {
-  margin: 8px 0 0;
-  color: rgba(255, 255, 255, 0.6);
-  font-size: 0.85rem;
+	margin: 8px 0 0;
+	color: rgba(255, 255, 255, 0.6);
+	font-size: 0.85rem;
 }
 
 .session-info-error {
-  padding: 12px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 99, 132, 0.4);
-  color: #ffc9d4;
-  background: rgba(255, 99, 132, 0.08);
+	padding: 12px;
+	border-radius: 8px;
+	border: 1px solid rgba(255, 99, 132, 0.4);
+	color: #ffc9d4;
+	background: rgba(255, 99, 132, 0.08);
 }
 
 .session-info-output {
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
-  background: rgba(0, 0, 0, 0.35);
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	border-radius: 12px;
+	background: rgba(0, 0, 0, 0.35);
 }
 
 .session-info-output-header {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-  padding: 10px 14px;
-  font-weight: 600;
-  font-size: 0.9rem;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+	padding: 10px 14px;
+	font-weight: 600;
+	font-size: 0.9rem;
 }
 
 .session-info-output pre {
-  margin: 0;
-  padding: 14px;
-  max-height: 220px;
-  overflow: auto;
-  font-size: 0.82rem;
-  line-height: 1.45;
+	margin: 0;
+	padding: 14px;
+	max-height: 220px;
+	overflow: auto;
+	font-size: 0.82rem;
+	line-height: 1.45;
 }
 
 .settings-form section {
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 12px;
-  padding: 16px;
-  background: rgba(255, 255, 255, 0.02);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+	border: 1px solid rgba(255, 255, 255, 0.06);
+	border-radius: 12px;
+	padding: 16px;
+	background: rgba(255, 255, 255, 0.02);
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 }
 
 .settings-form section h3 {
-  margin: 0 0 4px;
-  font-size: 1rem;
+	margin: 0 0 4px;
+	font-size: 1rem;
 }
 
 .settings-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  font-size: 0.95rem;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	font-size: 0.95rem;
 }
 
 .settings-row span {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
 }
 
 .settings-row small {
-  font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.6);
+	font-size: 0.75rem;
+	color: rgba(255, 255, 255, 0.6);
 }
 
 .settings-row input[type="text"],
 .settings-row select {
-  min-width: 160px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
-  padding: 8px 10px;
-  color: inherit;
+	min-width: 160px;
+	background: rgba(255, 255, 255, 0.05);
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	border-radius: 8px;
+	padding: 8px 10px;
+	color: inherit;
 }
 
 .settings-row input[type="checkbox"] {
-  width: 18px;
-  height: 18px;
+	width: 18px;
+	height: 18px;
 }
 
 .settings-number-input {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .settings-number-input input[type="range"] {
-  accent-color: #8ab4ff;
+	accent-color: #8ab4ff;
 }
 
 .settings-footer-spacer {
-  flex: 1;
+	flex: 1;
 }
 
 @media (max-width: 640px) {
-  .modal-body {
-    max-height: 80vh;
-  }
+	.modal-body {
+		max-height: 80vh;
+	}
 
-  .settings-row {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+	.settings-row {
+		flex-direction: column;
+		align-items: flex-start;
+	}
 
-  .modal-footer-actions {
-    flex-wrap: wrap;
-    justify-content: flex-end;
-  }
+	.modal-footer-actions {
+		flex-wrap: wrap;
+		justify-content: flex-end;
+	}
 }
 
 /* ============================================================
@@ -497,383 +497,383 @@
    ============================================================ */
 
 [data-theme="phylo"] .modal-overlay {
-  background: rgba(0, 0, 0, 0.25);
-  backdrop-filter: none;
+	background: rgba(0, 0, 0, 0.25);
+	backdrop-filter: none;
 }
 
 [data-theme="phylo"] .modal-dialog {
-  background: #ffffff;
-  border: 1px solid #cccccc;
-  border-radius: 3px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  color: #333333;
+	background: #ffffff;
+	border: 1px solid #cccccc;
+	border-radius: 3px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	color: #333333;
 }
 
 [data-theme="phylo"] .modal-header {
-  padding: 12px 16px;
-  border-bottom: 1px solid #e0e0e0;
+	padding: 12px 16px;
+	border-bottom: 1px solid #e0e0e0;
 }
 
 [data-theme="phylo"] .modal-title h2 {
-  font-size: 12px;
-  font-weight: 600;
-  color: #333333;
+	font-size: 12px;
+	font-weight: 600;
+	color: #333333;
 }
 
 [data-theme="phylo"] .modal-subtitle {
-  font-size: 11px;
-  color: #666666;
+	font-size: 11px;
+	color: #666666;
 }
 
 [data-theme="phylo"] .modal-title-icon svg,
 [data-theme="phylo"] .modal-title-icon {
-  width: 16px;
-  height: 16px;
-  color: #3b82f6;
+	width: 16px;
+	height: 16px;
+	color: #3b82f6;
 }
 
 [data-theme="phylo"] .modal-body {
-  padding: 16px;
-  font-size: 12px;
+	padding: 16px;
+	font-size: 12px;
 }
 
 [data-theme="phylo"] .modal-footer {
-  padding: 12px 16px;
-  border-top: 1px solid #e0e0e0;
-  background: #f5f5f5;
+	padding: 12px 16px;
+	border-top: 1px solid #e0e0e0;
+	background: #f5f5f5;
 }
 
 /* Shortcuts Modal */
 [data-theme="phylo"] .shortcuts-search input {
-  background: #ffffff;
-  border: 1px solid #cccccc;
-  border-radius: 3px;
-  padding: 6px 8px;
-  font-size: 12px;
-  color: #333333;
+	background: #ffffff;
+	border: 1px solid #cccccc;
+	border-radius: 3px;
+	padding: 6px 8px;
+	font-size: 12px;
+	color: #333333;
 }
 
 [data-theme="phylo"] .shortcuts-search input:focus {
-  outline: 1px solid #3b82f6;
-  outline-offset: -1px;
+	outline: 1px solid #3b82f6;
+	outline-offset: -1px;
 }
 
 [data-theme="phylo"] .shortcuts-grid {
-  gap: 12px;
+	gap: 12px;
 }
 
 [data-theme="phylo"] .shortcut-group {
-  background: #ffffff;
-  border: 1px solid #e0e0e0;
-  border-radius: 3px;
-  padding: 10px;
-  gap: 8px;
+	background: #ffffff;
+	border: 1px solid #e0e0e0;
+	border-radius: 3px;
+	padding: 10px;
+	gap: 8px;
 }
 
 [data-theme="phylo"] .shortcut-group-header {
-  font-size: 10px;
-  font-weight: 700;
-  color: #666666;
-  letter-spacing: 0.02em;
+	font-size: 10px;
+	font-weight: 700;
+	color: #666666;
+	letter-spacing: 0.02em;
 }
 
 [data-theme="phylo"] .shortcut-card {
-  background: #f5f5f5;
-  border: 1px solid #e8e8e8;
-  border-radius: 3px;
-  padding: 8px;
+	background: #f5f5f5;
+	border: 1px solid #e8e8e8;
+	border-radius: 3px;
+	padding: 8px;
 }
 
 [data-theme="phylo"] .shortcut-description {
-  font-size: 12px;
-  color: #333333;
+	font-size: 12px;
+	color: #333333;
 }
 
 [data-theme="phylo"] .shortcut-scope {
-  font-size: 10px;
-  color: #999999;
+	font-size: 10px;
+	color: #999999;
 }
 
 [data-theme="phylo"] .keycap {
-  border: 1px solid #cccccc;
-  background: #ffffff;
-  border-radius: 3px;
-  padding: 2px 6px;
-  font-size: 11px;
-  color: #333333;
-  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+	border: 1px solid #cccccc;
+	background: #ffffff;
+	border-radius: 3px;
+	padding: 2px 6px;
+	font-size: 11px;
+	color: #333333;
+	font-family: ui-monospace, "SF Mono", Consolas, monospace;
 }
 
 [data-theme="phylo"] .shortcuts-empty {
-  background: #f5f5f5;
-  border: 1px solid #e0e0e0;
-  border-radius: 3px;
-  color: #999999;
-  font-size: 12px;
+	background: #f5f5f5;
+	border: 1px solid #e0e0e0;
+	border-radius: 3px;
+	color: #999999;
+	font-size: 12px;
 }
 
 /* About Modal */
 [data-theme="phylo"] .about-grid {
-  gap: 12px;
+	gap: 12px;
 }
 
 [data-theme="phylo"] .about-card {
-  padding: 12px;
-  border-radius: 3px;
-  border: 1px solid #e0e0e0;
-  background: #f5f5f5;
+	padding: 12px;
+	border-radius: 3px;
+	border: 1px solid #e0e0e0;
+	background: #f5f5f5;
 }
 
 [data-theme="phylo"] .about-card h3 {
-  font-size: 12px;
-  font-weight: 700;
-  color: #333333;
-  margin: 0 0 6px;
+	font-size: 12px;
+	font-weight: 700;
+	color: #333333;
+	margin: 0 0 6px;
 }
 
 [data-theme="phylo"] .about-metric {
-  font-size: 14px;
-  font-weight: 600;
-  color: #333333;
-  margin: 0 0 6px;
+	font-size: 14px;
+	font-weight: 600;
+	color: #333333;
+	margin: 0 0 6px;
 }
 
 [data-theme="phylo"] .about-card dl {
-  font-size: 11px;
-  gap: 4px 10px;
+	font-size: 11px;
+	gap: 4px 10px;
 }
 
 [data-theme="phylo"] .about-card dt {
-  color: #666666;
-  font-weight: 500;
+	color: #666666;
+	font-weight: 500;
 }
 
 [data-theme="phylo"] .about-card dd {
-  color: #333333;
-  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+	color: #333333;
+	font-family: ui-monospace, "SF Mono", Consolas, monospace;
 }
 
 [data-theme="phylo"] .about-note {
-  font-size: 11px;
-  color: #666666;
-  line-height: 1.4;
+	font-size: 11px;
+	color: #666666;
+	line-height: 1.4;
 }
 
 [data-theme="phylo"] .about-tech-list li strong {
-  font-size: 11px;
-  color: #333333;
+	font-size: 11px;
+	color: #333333;
 }
 
 [data-theme="phylo"] .about-tech-list li span {
-  font-size: 10px;
-  color: #666666;
+	font-size: 10px;
+	color: #666666;
 }
 
 [data-theme="phylo"] .about-links a {
-  color: #3b82f6;
-  font-size: 12px;
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
+	color: #3b82f6;
+	font-size: 12px;
+	text-decoration: none;
+	border-bottom: 1px solid transparent;
 }
 
 [data-theme="phylo"] .about-links a:hover {
-  border-bottom-color: #3b82f6;
+	border-bottom-color: #3b82f6;
 }
 
 /* Session Info Modal */
 [data-theme="phylo"] .session-info-card {
-  border-radius: 3px;
-  border: 1px solid #e0e0e0;
-  padding: 12px;
-  background: #f5f5f5;
+	border-radius: 3px;
+	border: 1px solid #e0e0e0;
+	padding: 12px;
+	background: #f5f5f5;
 }
 
 [data-theme="phylo"] .session-info-card dl {
-  font-size: 11px;
-  gap: 6px 10px;
+	font-size: 11px;
+	gap: 6px 10px;
 }
 
 [data-theme="phylo"] .session-info-card dt {
-  color: #666666;
-  font-weight: 500;
+	color: #666666;
+	font-weight: 500;
 }
 
 [data-theme="phylo"] .session-info-card dd {
-  color: #333333;
-  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+	color: #333333;
+	font-family: ui-monospace, "SF Mono", Consolas, monospace;
 }
 
 [data-theme="phylo"] .package-list li {
-  background: rgba(59, 130, 246, 0.08);
-  color: #3b82f6;
-  padding: 4px 8px;
-  border-radius: 3px;
-  font-size: 10px;
-  border: 1px solid rgba(59, 130, 246, 0.2);
+	background: rgba(59, 130, 246, 0.08);
+	color: #3b82f6;
+	padding: 4px 8px;
+	border-radius: 3px;
+	font-size: 10px;
+	border: 1px solid rgba(59, 130, 246, 0.2);
 }
 
 [data-theme="phylo"] .package-version {
-  color: #666666;
+	color: #666666;
 }
 
 [data-theme="phylo"] .package-more {
-  background: transparent;
-  border: 1px dashed #cccccc;
-  color: #999999;
+	background: transparent;
+	border: 1px dashed #cccccc;
+	color: #999999;
 }
 
 [data-theme="phylo"] .session-info-empty {
-  color: #999999;
-  font-size: 11px;
+	color: #999999;
+	font-size: 11px;
 }
 
 [data-theme="phylo"] .session-info-error {
-  padding: 10px;
-  border-radius: 3px;
-  border: 1px solid #ef4444;
-  color: #991b1b;
-  background: #fee2e2;
-  font-size: 12px;
+	padding: 10px;
+	border-radius: 3px;
+	border: 1px solid #ef4444;
+	color: #991b1b;
+	background: #fee2e2;
+	font-size: 12px;
 }
 
 [data-theme="phylo"] .session-info-output {
-  border: 1px solid #cccccc;
-  border-radius: 3px;
-  background: #ffffff;
+	border: 1px solid #cccccc;
+	border-radius: 3px;
+	background: #ffffff;
 }
 
 [data-theme="phylo"] .session-info-output-header {
-  border-bottom: 1px solid #e0e0e0;
-  padding: 8px 12px;
-  font-weight: 600;
-  font-size: 11px;
-  background: #f5f5f5;
-  color: #333333;
+	border-bottom: 1px solid #e0e0e0;
+	padding: 8px 12px;
+	font-weight: 600;
+	font-size: 11px;
+	background: #f5f5f5;
+	color: #333333;
 }
 
 [data-theme="phylo"] .session-info-output pre {
-  padding: 12px;
-  font-size: 11px;
-  color: #333333;
-  line-height: 1.4;
+	padding: 12px;
+	font-size: 11px;
+	color: #333333;
+	line-height: 1.4;
 }
 
 /* Settings Modal */
 [data-theme="phylo"] .settings-form section {
-  border: 1px solid #e0e0e0;
-  border-radius: 3px;
-  padding: 12px;
-  background: #f5f5f5;
-  gap: 10px;
+	border: 1px solid #e0e0e0;
+	border-radius: 3px;
+	padding: 12px;
+	background: #f5f5f5;
+	gap: 10px;
 }
 
 [data-theme="phylo"] .settings-form section h3 {
-  font-size: 12px;
-  font-weight: 700;
-  color: #333333;
-  margin: 0 0 4px;
+	font-size: 12px;
+	font-weight: 700;
+	color: #333333;
+	margin: 0 0 4px;
 }
 
 [data-theme="phylo"] .settings-row {
-  font-size: 12px;
-  gap: 12px;
+	font-size: 12px;
+	gap: 12px;
 }
 
 [data-theme="phylo"] .settings-row small {
-  font-size: 10px;
-  color: #666666;
+	font-size: 10px;
+	color: #666666;
 }
 
 [data-theme="phylo"] .settings-row input[type="text"],
 [data-theme="phylo"] .settings-row select {
-  background: #ffffff;
-  border: 1px solid #cccccc;
-  border-radius: 3px;
-  padding: 6px 8px;
-  font-size: 12px;
-  color: #333333;
+	background: #ffffff;
+	border: 1px solid #cccccc;
+	border-radius: 3px;
+	padding: 6px 8px;
+	font-size: 12px;
+	color: #333333;
 }
 
 [data-theme="phylo"] .settings-row input[type="text"]:focus,
 [data-theme="phylo"] .settings-row select:focus {
-  outline: 1px solid #3b82f6;
-  outline-offset: -1px;
+	outline: 1px solid #3b82f6;
+	outline-offset: -1px;
 }
 
 [data-theme="phylo"] .settings-row input[type="checkbox"] {
-  width: 14px;
-  height: 14px;
-  accent-color: #3b82f6;
+	width: 14px;
+	height: 14px;
+	accent-color: #3b82f6;
 }
 
 [data-theme="phylo"] .settings-number-input span {
-  font-size: 11px;
-  color: #666666;
-  font-family: ui-monospace, 'SF Mono', Consolas, monospace;
+	font-size: 11px;
+	color: #666666;
+	font-family: ui-monospace, "SF Mono", Consolas, monospace;
 }
 
 [data-theme="phylo"] .settings-number-input input[type="range"] {
-  accent-color: #3b82f6;
+	accent-color: #3b82f6;
 }
 
 /* Project Manager Modal */
 [data-theme="phylo"] .project-manager-section {
-  background: #f5f5f5;
-  border: 1px solid #e0e0e0;
-  border-radius: 3px;
-  padding: 12px;
+	background: #f5f5f5;
+	border: 1px solid #e0e0e0;
+	border-radius: 3px;
+	padding: 12px;
 }
 
 [data-theme="phylo"] .project-manager-section h3 {
-  color: #333333;
-  font-size: 12px;
-  font-weight: 700;
+	color: #333333;
+	font-size: 12px;
+	font-weight: 700;
 }
 
 [data-theme="phylo"] .project-card {
-  border-bottom: 1px solid #e0e0e0;
-  padding: 8px 0;
+	border-bottom: 1px solid #e0e0e0;
+	padding: 8px 0;
 }
 
 [data-theme="phylo"] .project-card strong {
-  font-size: 12px;
-  color: #333333;
+	font-size: 12px;
+	color: #333333;
 }
 
 [data-theme="phylo"] .project-card .muted {
-  color: #666666;
-  font-size: 11px;
+	color: #666666;
+	font-size: 11px;
 }
 
 [data-theme="phylo"] .project-manager input {
-  background: #ffffff;
-  border: 1px solid #cccccc;
-  border-radius: 3px;
-  color: #333333;
-  padding: 6px 8px;
-  font-size: 12px;
+	background: #ffffff;
+	border: 1px solid #cccccc;
+	border-radius: 3px;
+	color: #333333;
+	padding: 6px 8px;
+	font-size: 12px;
 }
 
 [data-theme="phylo"] .project-manager input:focus {
-  outline: 1px solid #3b82f6;
-  outline-offset: -1px;
+	outline: 1px solid #3b82f6;
+	outline-offset: -1px;
 }
 
 [data-theme="phylo"] .alert-error {
-  background: #fee2e2;
-  border: 1px solid #ef4444;
-  color: #991b1b;
-  border-radius: 3px;
-  font-size: 12px;
-  padding: 8px 12px;
+	background: #fee2e2;
+	border: 1px solid #ef4444;
+	color: #991b1b;
+	border-radius: 3px;
+	font-size: 12px;
+	padding: 8px 12px;
 }
 
 [data-theme="phylo"] .project-manager .btn-link {
-  color: #3b82f6;
-  font-size: 11px;
-  text-decoration: none;
+	color: #3b82f6;
+	font-size: 11px;
+	text-decoration: none;
 }
 
 [data-theme="phylo"] .project-manager .btn-link:hover {
-  text-decoration: underline;
+	text-decoration: underline;
 }

--- a/client/src/css/components/right-pane.css
+++ b/client/src/css/components/right-pane.css
@@ -54,11 +54,7 @@
 	justify-content: center;
 	height: 100%;
 	padding: 18px;
-	background: linear-gradient(
-		160deg,
-		rgba(248, 249, 253, 0.95),
-		rgba(236, 240, 250, 0.95)
-	);
+	background: linear-gradient(160deg, rgba(248, 249, 253, 0.95), rgba(236, 240, 250, 0.95));
 }
 
 .plot-image {

--- a/client/src/css/components/right-pane.css
+++ b/client/src/css/components/right-pane.css
@@ -1,121 +1,125 @@
 .plot-counter {
-  font-size: 11px;
-  color: var(--text-secondary);
-  min-width: 56px;
-  text-align: center;
-  font-weight: 600;
+	font-size: 11px;
+	color: var(--text-secondary);
+	min-width: 56px;
+	text-align: center;
+	font-weight: 600;
 }
 
 .plots-container,
 .help-container,
 .timeline-container {
-  height: 100%;
-  overflow: auto;
-  background: var(--bg-primary);
+	height: 100%;
+	overflow: auto;
+	background: var(--bg-primary);
 }
 
 .empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  color: var(--text-secondary);
-  text-align: center;
-  padding: 36px;
-  gap: 12px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	color: var(--text-secondary);
+	text-align: center;
+	padding: 36px;
+	gap: 12px;
 }
 
 .empty-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .empty-icon svg {
-  width: 48px;
-  height: 48px;
-  color: var(--accent-blue);
+	width: 48px;
+	height: 48px;
+	color: var(--accent-blue);
 }
 
 .empty-state p {
-  font-size: 13px;
-  margin: 0;
+	font-size: 13px;
+	margin: 0;
 }
 
 .empty-hint {
-  color: var(--text-muted);
-  font-size: 12px;
+	color: var(--text-muted);
+	font-size: 12px;
 }
 
 .plot-viewer {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  padding: 18px;
-  background: linear-gradient(160deg, rgba(248, 249, 253, 0.95), rgba(236, 240, 250, 0.95));
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	padding: 18px;
+	background: linear-gradient(
+		160deg,
+		rgba(248, 249, 253, 0.95),
+		rgba(236, 240, 250, 0.95)
+	);
 }
 
 .plot-image {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
-  background-color: #ffffff;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+	max-width: 100%;
+	max-height: 100%;
+	object-fit: contain;
+	background-color: #ffffff;
+	border: 1px solid rgba(148, 163, 184, 0.3);
+	box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
 }
 
 .help-content {
-  padding: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
+	padding: 24px;
+	display: flex;
+	flex-direction: column;
+	gap: 18px;
 }
 
 .help-content h3 {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--text-primary);
 }
 
 .help-section {
-  padding: 16px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.78);
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.06);
+	padding: 16px;
+	border-radius: 14px;
+	background: rgba(255, 255, 255, 0.78);
+	border: 1px solid rgba(148, 163, 184, 0.22);
+	box-shadow: 0 10px 22px rgba(15, 23, 42, 0.06);
 }
 
 .help-section h4 {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 8px;
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--text-primary);
+	margin-bottom: 8px;
 }
 
 .help-section ul {
-  list-style: none;
-  padding: 0;
-  display: grid;
-  gap: 6px;
+	list-style: none;
+	padding: 0;
+	display: grid;
+	gap: 6px;
 }
 
 .help-section li {
-  font-size: 12px;
-  color: var(--text-secondary);
-  padding-left: 18px;
-  position: relative;
+	font-size: 12px;
+	color: var(--text-secondary);
+	padding-left: 18px;
+	position: relative;
 }
 
 .help-section li::before {
-  content: '';
-  position: absolute;
-  left: 4px;
-  top: 6px;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent-blue);
-  box-shadow: 0 0 0 3px rgba(47, 111, 237, 0.12);
+	content: "";
+	position: absolute;
+	left: 4px;
+	top: 6px;
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--accent-blue);
+	box-shadow: 0 0 0 3px rgba(47, 111, 237, 0.12);
 }

--- a/client/src/css/components/status-bar.css
+++ b/client/src/css/components/status-bar.css
@@ -1,37 +1,41 @@
 .statusbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  height: 28px;
-  padding: 0 16px;
-  background: linear-gradient(180deg, rgba(245, 247, 253, 0.88), rgba(236, 240, 250, 0.9));
-  border: 1px solid var(--border-color);
-  border-radius: var(--panel-radius);
-  font-size: 11px;
-  color: var(--text-secondary);
-  backdrop-filter: blur(12px);
-  box-shadow: var(--shadow-sm);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	height: 28px;
+	padding: 0 16px;
+	background: linear-gradient(
+		180deg,
+		rgba(245, 247, 253, 0.88),
+		rgba(236, 240, 250, 0.9)
+	);
+	border: 1px solid var(--border-color);
+	border-radius: var(--panel-radius);
+	font-size: 11px;
+	color: var(--text-secondary);
+	backdrop-filter: blur(12px);
+	box-shadow: var(--shadow-sm);
 }
 
 .statusbar-left,
 .statusbar-right {
-  display: flex;
-  align-items: center;
-  gap: 14px;
+	display: flex;
+	align-items: center;
+	gap: 14px;
 }
 
 .statusbar-item {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
 }
 
 .statusbar-modified {
-  color: var(--warning-color);
-  font-weight: 600;
+	color: var(--warning-color);
+	font-weight: 600;
 }
 
 .statusbar-running {
-  color: var(--accent-blue);
-  font-weight: 600;
+	color: var(--accent-blue);
+	font-weight: 600;
 }

--- a/client/src/css/components/status-bar.css
+++ b/client/src/css/components/status-bar.css
@@ -4,11 +4,7 @@
 	align-items: center;
 	height: 28px;
 	padding: 0 16px;
-	background: linear-gradient(
-		180deg,
-		rgba(245, 247, 253, 0.88),
-		rgba(236, 240, 250, 0.9)
-	);
+	background: linear-gradient(180deg, rgba(245, 247, 253, 0.88), rgba(236, 240, 250, 0.9));
 	border: 1px solid var(--border-color);
 	border-radius: var(--panel-radius);
 	font-size: 11px;

--- a/client/src/css/components/terminal.css
+++ b/client/src/css/components/terminal.css
@@ -1,84 +1,84 @@
 .terminal-pane {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  width: 100%;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	width: 100%;
 }
 
 .terminal-pane__header {
-  align-items: center;
-  border-bottom: 1px solid var(--border-color);
-  display: flex;
-  gap: 0.75rem;
-  padding-bottom: 0.6rem;
+	align-items: center;
+	border-bottom: 1px solid var(--border-color);
+	display: flex;
+	gap: 0.75rem;
+	padding-bottom: 0.6rem;
 }
 
 .terminal-pane__tabs {
-  flex: 1;
+	flex: 1;
 }
 
 .terminal-pane__actions {
-  display: inline-flex;
-  gap: 0.35rem;
+	display: inline-flex;
+	gap: 0.35rem;
 }
 
 .terminal-pane__content {
-  flex: 1;
-  min-height: 0;
-  padding: 0.75rem 0;
-  position: relative;
+	flex: 1;
+	min-height: 0;
+	padding: 0.75rem 0;
+	position: relative;
 }
 
 .terminal-pane__empty {
-  align-items: center;
-  border-radius: 0.5rem;
-  color: var(--text-secondary);
-  display: flex;
-  justify-content: center;
-  height: 100%;
-  text-align: center;
+	align-items: center;
+	border-radius: 0.5rem;
+	color: var(--text-secondary);
+	display: flex;
+	justify-content: center;
+	height: 100%;
+	text-align: center;
 }
 
 .terminal-pane__sessions {
-  height: 100%;
-  left: 0;
-  position: relative;
-  right: 0;
-  top: 0;
+	height: 100%;
+	left: 0;
+	position: relative;
+	right: 0;
+	top: 0;
 }
 
 .terminal-session {
-  height: 100%;
-  inset: 0;
-  position: absolute;
+	height: 100%;
+	inset: 0;
+	position: absolute;
 }
 
 .terminal-session--inactive {
-  pointer-events: none;
-  visibility: hidden;
+	pointer-events: none;
+	visibility: hidden;
 }
 
 .terminal-session--active {
-  visibility: visible;
+	visibility: visible;
 }
 
 .terminal-session__term {
-  height: 100%;
-  width: 100%;
+	height: 100%;
+	width: 100%;
 }
 
 .terminal-session__canvas {
-  height: 100%;
-  width: 100%;
+	height: 100%;
+	width: 100%;
 }
 
 /* Light theme for xterm */
 .terminal-session__term .xterm {
-  background-color: #f6f7fb;
-  color: #111827;
+	background-color: #f6f7fb;
+	color: #111827;
 }
 
 .terminal-session__term .xterm .xterm-viewport,
 .terminal-session__term .xterm .xterm-screen {
-  background-color: #f6f7fb;
+	background-color: #f6f7fb;
 }

--- a/client/src/css/components/timeline-dialog.css
+++ b/client/src/css/components/timeline-dialog.css
@@ -1,75 +1,75 @@
 /* Timeline Dialog Overlay */
 .timeline-dialog-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(15, 23, 42, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  backdrop-filter: blur(4px);
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(15, 23, 42, 0.6);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1000;
+	backdrop-filter: blur(4px);
 }
 
 /* Timeline Dialog */
 .timeline-dialog {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-color);
-  border-radius: var(--panel-radius);
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
-  width: 800px;
-  max-width: 90vw;
-  height: 80vh;
-  max-height: 80vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+	background: var(--bg-elevated);
+	border: 1px solid var(--border-color);
+	border-radius: var(--panel-radius);
+	box-shadow: 0 24px 48px rgba(15, 23, 42, 0.2);
+	width: 800px;
+	max-width: 90vw;
+	height: 80vh;
+	max-height: 80vh;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
 }
 
 /* Header */
 .timeline-dialog-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px;
-  background: var(--bg-toolbar);
-  border-bottom: 1px solid var(--border-light);
-  flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 16px;
+	background: var(--bg-toolbar);
+	border-bottom: 1px solid var(--border-light);
+	flex-shrink: 0;
 }
 
 .timeline-dialog-header h2 {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: var(--letter-spacing-base);
+	margin: 0;
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--text-primary);
+	letter-spacing: var(--letter-spacing-base);
 }
 
 /* Content */
 .timeline-dialog-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  background: var(--bg-primary);
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	background: var(--bg-primary);
 }
 
 /* Filter Section - 20-25% height */
 .timeline-dialog-filters {
-  flex: 0 0 auto;
-  max-height: 25%;
-  min-height: 20%;
-  padding: 16px;
-  border-bottom: 1px solid var(--border-light);
-  background: var(--bg-secondary);
-  overflow-y: auto;
+	flex: 0 0 auto;
+	max-height: 25%;
+	min-height: 20%;
+	padding: 16px;
+	border-bottom: 1px solid var(--border-light);
+	background: var(--bg-secondary);
+	overflow-y: auto;
 }
 
 /* History List - 75-80% height */
 .timeline-dialog-history {
-  flex: 1;
-  overflow-y: auto;
-  background: var(--bg-primary);
+	flex: 1;
+	overflow-y: auto;
+	background: var(--bg-primary);
 }

--- a/client/src/css/components/timeline.css
+++ b/client/src/css/components/timeline.css
@@ -1,417 +1,417 @@
 /* Timeline Panel */
 .timeline-panel {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  background: var(--bg-primary);
-  border: none;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	background: var(--bg-primary);
+	border: none;
 }
 
 .timeline-panel-header {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border-color);
-  background: var(--bg-toolbar);
+	padding: 12px 16px;
+	border-bottom: 1px solid var(--border-color);
+	background: var(--bg-toolbar);
 }
 
 .timeline-panel-header h2 {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: var(--letter-spacing-base);
+	margin: 0;
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--text-primary);
+	letter-spacing: var(--letter-spacing-base);
 }
 
 .timeline-panel-content {
-  flex: 1;
-  overflow-y: auto;
-  padding: 12px;
+	flex: 1;
+	overflow-y: auto;
+	padding: 12px;
 }
 
 .timeline-panel-controls {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border-color);
-  background: var(--bg-secondary);
+	padding: 12px 16px;
+	border-bottom: 1px solid var(--border-color);
+	background: var(--bg-secondary);
 }
 
 /* Timeline Stats */
 .timeline-stats {
-  padding: 12px 16px;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border-color);
+	padding: 12px 16px;
+	background: var(--bg-secondary);
+	border-bottom: 1px solid var(--border-color);
 }
 
 .timeline-stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-  gap: 12px;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+	gap: 12px;
 }
 
 .timeline-stat {
-  text-align: center;
-  padding: 8px;
-  background: var(--bg-primary);
-  border-radius: 8px;
-  border: 1px solid var(--border-light);
+	text-align: center;
+	padding: 8px;
+	background: var(--bg-primary);
+	border-radius: 8px;
+	border: 1px solid var(--border-light);
 }
 
 .timeline-stat-value {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 4px;
+	font-size: 18px;
+	font-weight: 600;
+	color: var(--text-primary);
+	margin-bottom: 4px;
 }
 
 .timeline-stat-label {
-  font-size: 11px;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
+	font-size: 11px;
+	color: var(--text-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
 }
 
 .timeline-stats-loading {
-  text-align: center;
-  color: var(--text-muted);
-  font-size: 12px;
-  padding: 12px;
+	text-align: center;
+	color: var(--text-muted);
+	font-size: 12px;
+	padding: 12px;
 }
 
 /* Timeline Filters */
 .timeline-filters {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 }
 
 .timeline-filters-row {
-  display: flex;
-  gap: 12px;
-  align-items: flex-end;
-  flex-wrap: wrap;
+	display: flex;
+	gap: 12px;
+	align-items: flex-end;
+	flex-wrap: wrap;
 }
 
 .timeline-filter {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
 }
 
 .timeline-filter label {
-  font-size: 11px;
-  color: var(--text-secondary);
-  font-weight: 500;
+	font-size: 11px;
+	color: var(--text-secondary);
+	font-weight: 500;
 }
 
 .timeline-filter select,
 .timeline-filter input[type="text"] {
-  padding: 6px 10px;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  font-size: 12px;
-  font-family: var(--font-family-base);
-  outline: none;
-  transition: border-color 0.15s ease;
+	padding: 6px 10px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	font-size: 12px;
+	font-family: var(--font-family-base);
+	outline: none;
+	transition: border-color 0.15s ease;
 }
 
 .timeline-filter select:focus,
 .timeline-filter input[type="text"]:focus {
-  border-color: var(--accent-blue);
+	border-color: var(--accent-blue);
 }
 
 .timeline-filter-checkbox {
-  flex-direction: row;
-  align-items: center;
-  gap: 6px;
-  padding-top: 14px;
+	flex-direction: row;
+	align-items: center;
+	gap: 6px;
+	padding-top: 14px;
 }
 
 .timeline-filter-checkbox input[type="checkbox"] {
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
+	width: 16px;
+	height: 16px;
+	cursor: pointer;
 }
 
 .timeline-filter-checkbox label {
-  cursor: pointer;
-  font-size: 12px;
-  margin: 0;
+	cursor: pointer;
+	font-size: 12px;
+	margin: 0;
 }
 
 .timeline-filter-search {
-  flex: 1;
-  min-width: 200px;
+	flex: 1;
+	min-width: 200px;
 }
 
 .timeline-filter-search input {
-  width: 100%;
+	width: 100%;
 }
 
 .timeline-filter-clear {
-  padding: 6px 12px;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  color: var(--text-secondary);
-  font-size: 12px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  margin-top: 14px;
+	padding: 6px 12px;
+	background: var(--bg-primary);
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	color: var(--text-secondary);
+	font-size: 12px;
+	cursor: pointer;
+	transition: all 0.15s ease;
+	margin-top: 14px;
 }
 
 .timeline-filter-clear:hover {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
 }
 
 /* Timeline Sort */
 .timeline-sort {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 8px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 8px;
 }
 
 .timeline-sort label {
-  font-size: 11px;
-  color: var(--text-secondary);
-  font-weight: 500;
+	font-size: 11px;
+	color: var(--text-secondary);
+	font-weight: 500;
 }
 
 .timeline-sort select {
-  padding: 6px 10px;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  font-size: 12px;
-  outline: none;
-  transition: border-color 0.15s ease;
+	padding: 6px 10px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	font-size: 12px;
+	outline: none;
+	transition: border-color 0.15s ease;
 }
 
 .timeline-sort select:focus {
-  border-color: var(--accent-blue);
+	border-color: var(--accent-blue);
 }
 
 /* Timeline List */
 .timeline {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 }
 
 .timeline-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 }
 
 .timeline-empty {
-  text-align: center;
-  padding: 48px 24px;
-  color: var(--text-muted);
+	text-align: center;
+	padding: 48px 24px;
+	color: var(--text-muted);
 }
 
 .timeline-empty-message {
-  font-size: 14px;
-  font-weight: 500;
-  margin-bottom: 8px;
+	font-size: 14px;
+	font-weight: 500;
+	margin-bottom: 8px;
 }
 
 .timeline-empty-hint {
-  font-size: 12px;
+	font-size: 12px;
 }
 
 .timeline-loading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  padding: 24px;
-  color: var(--text-muted);
-  font-size: 12px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	padding: 24px;
+	color: var(--text-muted);
+	font-size: 12px;
 }
 
 .timeline-spinner {
-  width: 16px;
-  height: 16px;
-  border: 2px solid var(--border-color);
-  border-top-color: var(--accent-blue);
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
+	width: 16px;
+	height: 16px;
+	border: 2px solid var(--border-color);
+	border-top-color: var(--accent-blue);
+	border-radius: 50%;
+	animation: spin 0.8s linear infinite;
 }
 
 @keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+	to {
+		transform: rotate(360deg);
+	}
 }
 
 .timeline-load-more {
-  padding: 10px 16px;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-  color: var(--accent-blue);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  margin-top: 8px;
+	padding: 10px 16px;
+	background: var(--bg-primary);
+	border: 1px solid var(--border-color);
+	border-radius: 8px;
+	color: var(--accent-blue);
+	font-size: 12px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: all 0.15s ease;
+	margin-top: 8px;
 }
 
 .timeline-load-more:hover {
-  background: var(--accent-blue-light);
-  border-color: var(--accent-blue);
+	background: var(--accent-blue-light);
+	border-color: var(--accent-blue);
 }
 
 .timeline-end {
-  text-align: center;
-  padding: 16px;
-  color: var(--text-muted);
-  font-size: 11px;
-  margin-top: 8px;
+	text-align: center;
+	padding: 16px;
+	color: var(--text-muted);
+	font-size: 11px;
+	margin-top: 8px;
 }
 
 /* Timeline Event Card */
 .timeline-event {
-  padding: 14px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--panel-radius);
-  box-shadow: 0 12px 18px rgba(15, 23, 42, 0.06);
-  transition: all 0.15s ease;
-  cursor: pointer;
+	padding: 14px;
+	background: var(--bg-secondary);
+	border: 1px solid var(--border-color);
+	border-radius: var(--panel-radius);
+	box-shadow: 0 12px 18px rgba(15, 23, 42, 0.06);
+	transition: all 0.15s ease;
+	cursor: pointer;
 }
 
 .timeline-event:hover {
-  background: var(--bg-tertiary);
-  border-color: var(--border-strong);
-  box-shadow: var(--shadow-sm);
-  transform: translateY(-1px);
+	background: var(--bg-tertiary);
+	border-color: var(--border-strong);
+	box-shadow: var(--shadow-sm);
+	transform: translateY(-1px);
 }
 
 .timeline-event-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 10px;
-  font-size: 11px;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 10px;
+	font-size: 11px;
 }
 
 .timeline-event-actor {
-  font-weight: 600;
-  color: var(--text-primary);
+	font-weight: 600;
+	color: var(--text-primary);
 }
 
 .timeline-event-time {
-  color: var(--text-muted);
-  font-family: Monaco, Menlo, Consolas, monospace;
+	color: var(--text-muted);
+	font-family: Monaco, Menlo, Consolas, monospace;
 }
 
 .timeline-event-source {
-  color: var(--text-secondary);
-  background: var(--bg-primary);
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-weight: 500;
+	color: var(--text-secondary);
+	background: var(--bg-primary);
+	padding: 2px 8px;
+	border-radius: 4px;
+	font-weight: 500;
 }
 
 .timeline-event-divider {
-  height: 1px;
-  background: var(--border-light);
-  margin-bottom: 10px;
+	height: 1px;
+	background: var(--border-light);
+	margin-bottom: 10px;
 }
 
 .timeline-event-code {
-  position: relative;
-  margin-bottom: 10px;
+	position: relative;
+	margin-bottom: 10px;
 }
 
 .timeline-event-code pre {
-  margin: 0;
-  padding: 10px;
-  background: var(--bg-code);
-  border-radius: 6px;
-  overflow-x: auto;
-  font-family: Monaco, Menlo, Consolas, monospace;
-  font-size: 11px;
-  line-height: 1.5;
-  color: var(--text-primary);
+	margin: 0;
+	padding: 10px;
+	background: var(--bg-code);
+	border-radius: 6px;
+	overflow-x: auto;
+	font-family: Monaco, Menlo, Consolas, monospace;
+	font-size: 11px;
+	line-height: 1.5;
+	color: var(--text-primary);
 }
 
 .timeline-event-code code {
-  font-family: inherit;
+	font-family: inherit;
 }
 
 .timeline-event-more {
-  display: block;
-  text-align: center;
-  color: var(--text-muted);
-  font-size: 10px;
-  margin-top: 4px;
+	display: block;
+	text-align: center;
+	color: var(--text-muted);
+	font-size: 10px;
+	margin-top: 4px;
 }
 
 .timeline-event-footer {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 11px;
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	font-size: 11px;
 }
 
 .timeline-event-status {
-  font-weight: 500;
-  color: var(--text-primary);
+	font-weight: 500;
+	color: var(--text-primary);
 }
 
 .timeline-event-duration {
-  color: var(--text-muted);
-  font-family: Monaco, Menlo, Consolas, monospace;
+	color: var(--text-muted);
+	font-family: Monaco, Menlo, Consolas, monospace;
 }
 
 .timeline-event-plots {
-  color: var(--accent-blue);
-  font-weight: 500;
+	color: var(--accent-blue);
+	font-weight: 500;
 }
 
 .timeline-event-error {
-  margin-top: 10px;
-  padding: 10px;
-  background: rgba(220, 76, 63, 0.1);
-  border-radius: 6px;
-  border: 1px solid rgba(220, 76, 63, 0.2);
-  font-size: 11px;
+	margin-top: 10px;
+	padding: 10px;
+	background: rgba(220, 76, 63, 0.1);
+	border-radius: 6px;
+	border: 1px solid rgba(220, 76, 63, 0.2);
+	font-size: 11px;
 }
 
 .timeline-event-error-label {
-  font-weight: 600;
-  color: var(--error-color);
-  margin-right: 6px;
+	font-weight: 600;
+	color: var(--error-color);
+	margin-right: 6px;
 }
 
 .timeline-event-error-message {
-  color: var(--text-primary);
-  font-family: Monaco, Menlo, Consolas, monospace;
+	color: var(--text-primary);
+	font-family: Monaco, Menlo, Consolas, monospace;
 }
 
 /* Error Display */
 .timeline-error {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 16px;
-  background: rgba(220, 76, 63, 0.1);
-  border: 1px solid rgba(220, 76, 63, 0.2);
-  border-radius: 8px;
-  margin: 12px;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 12px 16px;
+	background: rgba(220, 76, 63, 0.1);
+	border: 1px solid rgba(220, 76, 63, 0.2);
+	border-radius: 8px;
+	margin: 12px;
 }
 
 .timeline-error-icon {
-  font-size: 16px;
+	font-size: 16px;
 }
 
 .timeline-error-message {
-  flex: 1;
-  color: var(--text-primary);
-  font-size: 12px;
+	flex: 1;
+	color: var(--text-primary);
+	font-size: 12px;
 }

--- a/client/src/css/design-phylo-rstudio.css
+++ b/client/src/css/design-phylo-rstudio.css
@@ -17,364 +17,366 @@
    CSS VARIABLES OVERRIDE
    ============================================ */
 :root {
-  /* Base colors - Monochrome */
-  --phylo-bg-primary: #ffffff;
-  --phylo-bg-secondary: #f5f5f5;
-  --phylo-bg-tertiary: #e8e8e8;
-  --phylo-bg-toolbar: #fafafa;
-  --phylo-bg-code: #f9f9f9;
-  --phylo-bg-ai: #fffef5; /* Slightly yellowish like lab notebook */
+	/* Base colors - Monochrome */
+	--phylo-bg-primary: #ffffff;
+	--phylo-bg-secondary: #f5f5f5;
+	--phylo-bg-tertiary: #e8e8e8;
+	--phylo-bg-toolbar: #fafafa;
+	--phylo-bg-code: #f9f9f9;
+	--phylo-bg-ai: #fffef5; /* Slightly yellowish like lab notebook */
 
-  /* Typography */
-  --phylo-text-primary: #1a1a1a;
-  --phylo-text-secondary: #4a4a4a;
-  --phylo-text-muted: #7a7a7a;
+	/* Typography */
+	--phylo-text-primary: #1a1a1a;
+	--phylo-text-secondary: #4a4a4a;
+	--phylo-text-muted: #7a7a7a;
 
-  /* Borders - 1px everywhere */
-  --phylo-border: 1px solid #cccccc;
-  --phylo-border-light: 1px solid #e0e0e0;
-  --phylo-border-strong: 1px solid #999999;
+	/* Borders - 1px everywhere */
+	--phylo-border: 1px solid #cccccc;
+	--phylo-border-light: 1px solid #e0e0e0;
+	--phylo-border-strong: 1px solid #999999;
 
-  /* DNA Base Colors - Use sparingly for accents */
-  --phylo-adenine: #22c55e;   /* A: Green */
-  --phylo-thymine: #ef4444;   /* T: Red */
-  --phylo-cytosine: #3b82f6;  /* C: Blue */
-  --phylo-guanine: #eab308;   /* G: Yellow */
+	/* DNA Base Colors - Use sparingly for accents */
+	--phylo-adenine: #22c55e; /* A: Green */
+	--phylo-thymine: #ef4444; /* T: Red */
+	--phylo-cytosine: #3b82f6; /* C: Blue */
+	--phylo-guanine: #eab308; /* G: Yellow */
 
-  /* State colors */
-  --phylo-success: #22c55e;
-  --phylo-error: #ef4444;
-  --phylo-warning: #f59e0b;
+	/* State colors */
+	--phylo-success: #22c55e;
+	--phylo-error: #ef4444;
+	--phylo-warning: #f59e0b;
 
-  /* Typography tokens */
-  --phylo-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', 'Helvetica Neue', Arial, sans-serif;
-  --phylo-font-size-base: 12px;
-  --phylo-line-height-base: 1.5;
-  --phylo-font-weight-base: 400;
+	/* Typography tokens */
+	--phylo-font-family:
+		-apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", "Helvetica Neue",
+		Arial, sans-serif;
+	--phylo-font-size-base: 12px;
+	--phylo-line-height-base: 1.5;
+	--phylo-font-weight-base: 400;
 
-  /* Layout */
-  --phylo-panel-radius: 3px;
-  --phylo-panel-gap: 1px; /* Serves as border */
+	/* Layout */
+	--phylo-panel-radius: 3px;
+	--phylo-panel-gap: 1px; /* Serves as border */
 }
 
 /* ============================================
    GLOBAL OVERRIDES
    ============================================ */
 :root[data-theme="phylo"] {
-  background: #e8e8e8;
-  font-family: var(--phylo-font-family);
-  font-size: var(--phylo-font-size-base);
-  line-height: var(--phylo-line-height-base);
-  /* Map theme tokens to app variables */
-  --bg-primary: var(--phylo-bg-primary);
-  --bg-secondary: var(--phylo-bg-secondary);
-  --bg-tertiary: var(--phylo-bg-tertiary);
-  --bg-toolbar: var(--phylo-bg-toolbar);
-  --bg-elevated: var(--phylo-bg-primary);
-  --bg-code: var(--phylo-bg-code);
-  --text-primary: var(--phylo-text-primary);
-  --text-secondary: var(--phylo-text-secondary);
-  --text-muted: var(--phylo-text-muted);
-  --border-color: #cccccc;
-  --border-light: #e0e0e0;
-  --border-strong: #999999;
-  --panel-radius: var(--phylo-panel-radius);
-  --shadow-sm: none;
-  --shadow-md: none;
-  --shadow-inset: none;
-  --panel-header-min-height: 32px;
-  --panel-header-padding: 0 12px;
-  --panel-header-shadow: none;
-  --panel-actions-gap: 6px;
-  --panel-title-font-size: 12px;
-  --panel-title-gap: 6px;
-  --panel-title-letter-spacing: 0;
-  --accent-blue: var(--phylo-cytosine);
-  --accent-blue-hover: #2563eb;
-  --accent-blue-light: rgba(59, 130, 246, 0.18);
-  --success-color: var(--phylo-success);
-  --error-color: var(--phylo-error);
-  --warning-color: var(--phylo-warning);
-  --font-family-base: var(--phylo-font-family);
-  --font-size-base: var(--phylo-font-size-base);
-  --line-height-base: var(--phylo-line-height-base);
-  --letter-spacing-base: 0;
-  --btn-padding: 5px 12px;
-  --btn-font-size: 11px;
-  --btn-radius: 3px;
-  --btn-border: var(--phylo-border);
-  --btn-bg: var(--phylo-bg-secondary);
-  --btn-color: var(--phylo-text-primary);
-  --btn-shadow: none;
-  --btn-height: 24px;
-  --btn-transition: background 0.1s ease, border-color 0.1s ease;
-  --btn-hover-bg: var(--phylo-bg-tertiary);
-  --btn-hover-shadow: none;
-  --btn-hover-transform: none;
-  --btn-hover-border-color: #999999;
-  --btn-active-bg: #d8d8d8;
-  --btn-active-shadow: none;
-  --btn-active-transform: none;
-  --btn-primary-bg: var(--phylo-cytosine);
-  --btn-primary-color: #ffffff;
-  --btn-primary-border: transparent;
-  --btn-primary-shadow: none;
-  --btn-primary-hover-bg: #2563eb;
-  --btn-primary-hover-shadow: none;
-  --btn-icon-padding: 4px;
-  --btn-icon-size: 24px;
-  --btn-icon-height: 24px;
-  --btn-icon-radius: 3px;
-  --tabs-gap: 0;
-  --tabs-padding: 0;
-  --tabs-background: var(--phylo-bg-tertiary);
-  --tabs-border-bottom: var(--phylo-border);
-  --tab-padding: 6px 12px;
-  --tab-font-size: 11px;
-  --tab-color: var(--phylo-text-secondary);
-  --tab-bg: var(--phylo-bg-secondary);
-  --tab-radius: 0;
-  --tab-border: none;
-  --tab-divider: var(--phylo-border-light);
-  --tab-transition: background 0.1s ease;
-  --tab-shadow: none;
-  --tab-active-color: var(--phylo-text-primary);
-  --tab-active-bg: var(--phylo-bg-primary);
-  --tab-active-border: transparent;
-  --tab-active-shadow: none;
-  --tab-active-underline: 2px solid var(--phylo-cytosine);
-  --menu-height: 32px;
-  --menu-padding: 0 12px;
-  --menu-gap: 20px;
-  --menu-bg: var(--phylo-bg-tertiary);
-  --menu-border-color: var(--phylo-border);
-  --menu-border-radius: 0;
-  --menu-shadow: none;
-  --menu-item-gap: 2px;
-  --menu-item-padding: 4px 10px;
-  --menu-item-font-size: 12px;
-  --menu-item-border-radius: 3px;
-  --menu-item-hover-bg: var(--phylo-bg-secondary);
-  --menu-item-active-bg: var(--phylo-bg-tertiary);
-  --menu-dropdown-bg: var(--phylo-bg-primary);
-  --menu-dropdown-border: var(--phylo-border);
-  --menu-dropdown-shadow: none;
-  --menu-dropdown-hover-bg: var(--phylo-bg-secondary);
-  --menu-dropdown-active-bg: var(--phylo-bg-tertiary);
-  --menu-dropdown-separator: var(--phylo-border-light);
-  --menu-connection-bg: var(--phylo-bg-primary);
-  --menu-connection-border: var(--phylo-border);
-  --menu-connection-padding: 4px 8px;
-  --menu-connection-gap: 6px;
-  --menu-connection-font-size: 11px;
-  --menu-ai-bg: var(--phylo-bg-primary);
-  --menu-ai-border: var(--phylo-guanine);
-  --menu-ai-hover-bg: var(--phylo-bg-secondary);
-  --menu-info-color: var(--phylo-cytosine);
-  --menu-success-color: var(--phylo-success);
-  --menu-error-color: var(--phylo-error);
+	background: #e8e8e8;
+	font-family: var(--phylo-font-family);
+	font-size: var(--phylo-font-size-base);
+	line-height: var(--phylo-line-height-base);
+	/* Map theme tokens to app variables */
+	--bg-primary: var(--phylo-bg-primary);
+	--bg-secondary: var(--phylo-bg-secondary);
+	--bg-tertiary: var(--phylo-bg-tertiary);
+	--bg-toolbar: var(--phylo-bg-toolbar);
+	--bg-elevated: var(--phylo-bg-primary);
+	--bg-code: var(--phylo-bg-code);
+	--text-primary: var(--phylo-text-primary);
+	--text-secondary: var(--phylo-text-secondary);
+	--text-muted: var(--phylo-text-muted);
+	--border-color: #cccccc;
+	--border-light: #e0e0e0;
+	--border-strong: #999999;
+	--panel-radius: var(--phylo-panel-radius);
+	--shadow-sm: none;
+	--shadow-md: none;
+	--shadow-inset: none;
+	--panel-header-min-height: 32px;
+	--panel-header-padding: 0 12px;
+	--panel-header-shadow: none;
+	--panel-actions-gap: 6px;
+	--panel-title-font-size: 12px;
+	--panel-title-gap: 6px;
+	--panel-title-letter-spacing: 0;
+	--accent-blue: var(--phylo-cytosine);
+	--accent-blue-hover: #2563eb;
+	--accent-blue-light: rgba(59, 130, 246, 0.18);
+	--success-color: var(--phylo-success);
+	--error-color: var(--phylo-error);
+	--warning-color: var(--phylo-warning);
+	--font-family-base: var(--phylo-font-family);
+	--font-size-base: var(--phylo-font-size-base);
+	--line-height-base: var(--phylo-line-height-base);
+	--letter-spacing-base: 0;
+	--btn-padding: 5px 12px;
+	--btn-font-size: 11px;
+	--btn-radius: 3px;
+	--btn-border: var(--phylo-border);
+	--btn-bg: var(--phylo-bg-secondary);
+	--btn-color: var(--phylo-text-primary);
+	--btn-shadow: none;
+	--btn-height: 24px;
+	--btn-transition: background 0.1s ease, border-color 0.1s ease;
+	--btn-hover-bg: var(--phylo-bg-tertiary);
+	--btn-hover-shadow: none;
+	--btn-hover-transform: none;
+	--btn-hover-border-color: #999999;
+	--btn-active-bg: #d8d8d8;
+	--btn-active-shadow: none;
+	--btn-active-transform: none;
+	--btn-primary-bg: var(--phylo-cytosine);
+	--btn-primary-color: #ffffff;
+	--btn-primary-border: transparent;
+	--btn-primary-shadow: none;
+	--btn-primary-hover-bg: #2563eb;
+	--btn-primary-hover-shadow: none;
+	--btn-icon-padding: 4px;
+	--btn-icon-size: 24px;
+	--btn-icon-height: 24px;
+	--btn-icon-radius: 3px;
+	--tabs-gap: 0;
+	--tabs-padding: 0;
+	--tabs-background: var(--phylo-bg-tertiary);
+	--tabs-border-bottom: var(--phylo-border);
+	--tab-padding: 6px 12px;
+	--tab-font-size: 11px;
+	--tab-color: var(--phylo-text-secondary);
+	--tab-bg: var(--phylo-bg-secondary);
+	--tab-radius: 0;
+	--tab-border: none;
+	--tab-divider: var(--phylo-border-light);
+	--tab-transition: background 0.1s ease;
+	--tab-shadow: none;
+	--tab-active-color: var(--phylo-text-primary);
+	--tab-active-bg: var(--phylo-bg-primary);
+	--tab-active-border: transparent;
+	--tab-active-shadow: none;
+	--tab-active-underline: 2px solid var(--phylo-cytosine);
+	--menu-height: 32px;
+	--menu-padding: 0 12px;
+	--menu-gap: 20px;
+	--menu-bg: var(--phylo-bg-tertiary);
+	--menu-border-color: var(--phylo-border);
+	--menu-border-radius: 0;
+	--menu-shadow: none;
+	--menu-item-gap: 2px;
+	--menu-item-padding: 4px 10px;
+	--menu-item-font-size: 12px;
+	--menu-item-border-radius: 3px;
+	--menu-item-hover-bg: var(--phylo-bg-secondary);
+	--menu-item-active-bg: var(--phylo-bg-tertiary);
+	--menu-dropdown-bg: var(--phylo-bg-primary);
+	--menu-dropdown-border: var(--phylo-border);
+	--menu-dropdown-shadow: none;
+	--menu-dropdown-hover-bg: var(--phylo-bg-secondary);
+	--menu-dropdown-active-bg: var(--phylo-bg-tertiary);
+	--menu-dropdown-separator: var(--phylo-border-light);
+	--menu-connection-bg: var(--phylo-bg-primary);
+	--menu-connection-border: var(--phylo-border);
+	--menu-connection-padding: 4px 8px;
+	--menu-connection-gap: 6px;
+	--menu-connection-font-size: 11px;
+	--menu-ai-bg: var(--phylo-bg-primary);
+	--menu-ai-border: var(--phylo-guanine);
+	--menu-ai-hover-bg: var(--phylo-bg-secondary);
+	--menu-info-color: var(--phylo-cytosine);
+	--menu-success-color: var(--phylo-success);
+	--menu-error-color: var(--phylo-error);
 }
 
 /* ============================================
    APP LAYOUT
    ============================================ */
 [data-theme="phylo"] .app {
-  padding: 0;
-  gap: 0;
-  background: var(--phylo-bg-tertiary);
+	padding: 0;
+	gap: 0;
+	background: var(--phylo-bg-tertiary);
 }
 
 [data-theme="phylo"] .workspace-shell {
-  padding: 0;
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
+	padding: 0;
+	background: transparent;
+	border: none;
+	border-radius: 0;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .workspace-shell .allotment__layout {
-  gap: var(--phylo-panel-gap) !important;
+	gap: var(--phylo-panel-gap) !important;
 }
 
 /* ============================================
    AI PANEL - Lab Notebook Style
    ============================================ */
 [data-theme="phylo"] .ai-panel .panel-content {
-  background: var(--phylo-bg-ai);
+	background: var(--phylo-bg-ai);
 }
 
 [data-theme="phylo"] .ai-messages {
-  padding: 12px;
-  gap: 12px;
-  background: var(--phylo-bg-ai);
+	padding: 12px;
+	gap: 12px;
+	background: var(--phylo-bg-ai);
 }
 
 [data-theme="phylo"] .ai-welcome {
-  padding: 24px;
-  border-radius: var(--phylo-panel-radius);
-  background: var(--phylo-bg-primary);
-  border: 1px dashed #cccccc;
-  box-shadow: none;
+	padding: 24px;
+	border-radius: var(--phylo-panel-radius);
+	background: var(--phylo-bg-primary);
+	border: 1px dashed #cccccc;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .ai-welcome-icon svg {
-  width: 40px;
-  height: 40px;
+	width: 40px;
+	height: 40px;
 }
 
 [data-theme="phylo"] .ai-welcome h3 {
-  font-size: 14px;
-  margin-bottom: 6px;
+	font-size: 14px;
+	margin-bottom: 6px;
 }
 
 [data-theme="phylo"] .ai-welcome p {
-  font-size: 11px;
-  margin-bottom: 12px;
+	font-size: 11px;
+	margin-bottom: 12px;
 }
 
 [data-theme="phylo"] .suggestion {
-  padding: 8px 12px;
-  border-radius: var(--phylo-panel-radius);
-  background-color: var(--phylo-bg-primary);
-  border: var(--phylo-border);
-  font-size: 11px;
-  transition: background 0.1s ease;
-  box-shadow: none;
+	padding: 8px 12px;
+	border-radius: var(--phylo-panel-radius);
+	background-color: var(--phylo-bg-primary);
+	border: var(--phylo-border);
+	font-size: 11px;
+	transition: background 0.1s ease;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .suggestion:hover {
-  background: var(--phylo-bg-secondary);
-  transform: none;
-  box-shadow: none;
+	background: var(--phylo-bg-secondary);
+	transform: none;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .message-user {
-  background: var(--phylo-cytosine);
-  color: white;
-  padding: 8px 12px;
-  border-radius: var(--phylo-panel-radius);
-  box-shadow: none;
+	background: var(--phylo-cytosine);
+	color: white;
+	padding: 8px 12px;
+	border-radius: var(--phylo-panel-radius);
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .message-assistant {
-  background: transparent;
-  padding: 10px 12px;
-  border-radius: var(--phylo-panel-radius);
-  border: var(--phylo-border);
-  box-shadow: none;
+	background: transparent;
+	padding: 10px 12px;
+	border-radius: var(--phylo-panel-radius);
+	border: var(--phylo-border);
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .message-header {
-  font-size: 10px;
-  margin-bottom: 4px;
+	font-size: 10px;
+	margin-bottom: 4px;
 }
 
 [data-theme="phylo"] .message-content {
-  font-size: 11px;
-  line-height: 1.5;
-  gap: 6px;
+	font-size: 11px;
+	line-height: 1.5;
+	gap: 6px;
 }
 
 [data-theme="phylo"] .message-code {
-  margin-top: 6px;
-  padding: 8px;
-  background-color: var(--phylo-bg-code);
-  border-radius: var(--phylo-panel-radius);
-  border: var(--phylo-border-light);
+	margin-top: 6px;
+	padding: 8px;
+	background-color: var(--phylo-bg-code);
+	border-radius: var(--phylo-panel-radius);
+	border: var(--phylo-border-light);
 }
 
 [data-theme="phylo"] .message-code pre {
-  font-size: 10px;
+	font-size: 10px;
 }
 
 [data-theme="phylo"] .ai-input-container-wrapper {
-  padding: 12px;
-  border-top: var(--phylo-border);
-  background: var(--phylo-bg-toolbar);
+	padding: 12px;
+	border-top: var(--phylo-border);
+	background: var(--phylo-bg-toolbar);
 }
 
 [data-theme="phylo"] .ai-input-container {
-  gap: 8px;
-  background: transparent;
+	gap: 8px;
+	background: transparent;
 }
 
 [data-theme="phylo"] .ai-input {
-  padding: 8px 10px;
-  border: var(--phylo-border);
-  border-radius: var(--phylo-panel-radius);
-  background-color: var(--phylo-bg-primary);
-  font-size: 11px;
-  min-height: 60px;
-  max-height: 240px;
-  box-shadow: none;
+	padding: 8px 10px;
+	border: var(--phylo-border);
+	border-radius: var(--phylo-panel-radius);
+	background-color: var(--phylo-bg-primary);
+	font-size: 11px;
+	min-height: 60px;
+	max-height: 240px;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .ai-input:focus {
-  outline: 1px solid var(--phylo-cytosine);
-  border-color: var(--phylo-cytosine);
+	outline: 1px solid var(--phylo-cytosine);
+	border-color: var(--phylo-cytosine);
 }
 
 [data-theme="phylo"] .send-btn {
-  background: var(--phylo-cytosine);
-  font-size: 11px;
-  height: 24px;
-  padding: 0 10px;
+	background: var(--phylo-cytosine);
+	font-size: 11px;
+	height: 24px;
+	padding: 0 10px;
 }
 
 [data-theme="phylo"] .send-btn:hover:not(:disabled) {
-  background: #2563eb;
+	background: #2563eb;
 }
 
 [data-theme="phylo"] .send-btn:disabled {
-  background: var(--phylo-bg-secondary);
-  color: var(--phylo-text-muted);
-  border: var(--phylo-border);
+	background: var(--phylo-bg-secondary);
+	color: var(--phylo-text-muted);
+	border: var(--phylo-border);
 }
 
 /* ============================================
    CODE BLOCKS
    ============================================ */
 [data-theme="phylo"] .code-block-container {
-  margin: 12px 0;
-  border: var(--phylo-border);
-  border-radius: var(--phylo-panel-radius);
-  background: var(--phylo-bg-primary);
-  box-shadow: none;
-  backdrop-filter: none;
+	margin: 12px 0;
+	border: var(--phylo-border);
+	border-radius: var(--phylo-panel-radius);
+	background: var(--phylo-bg-primary);
+	box-shadow: none;
+	backdrop-filter: none;
 }
 
 [data-theme="phylo"] .code-explanation {
-  gap: 6px;
-  padding: 10px 12px;
-  background: var(--phylo-bg-secondary);
-  border-bottom: var(--phylo-border-light);
-  font-size: 11px;
+	gap: 6px;
+	padding: 10px 12px;
+	background: var(--phylo-bg-secondary);
+	border-bottom: var(--phylo-border-light);
+	font-size: 11px;
 }
 
 [data-theme="phylo"] .code-header {
-  padding: 8px 12px;
-  background: var(--phylo-bg-toolbar);
-  border-bottom: var(--phylo-border-light);
-  font-size: 10px;
+	padding: 8px 12px;
+	background: var(--phylo-bg-toolbar);
+	border-bottom: var(--phylo-border-light);
+	font-size: 10px;
 }
 
 [data-theme="phylo"] .code-content {
-  padding: 12px;
-  font-size: 11px;
-  line-height: 1.5;
-  background: var(--phylo-bg-code);
-  border-bottom: var(--phylo-border-light);
+	padding: 12px;
+	font-size: 11px;
+	line-height: 1.5;
+	background: var(--phylo-bg-code);
+	border-bottom: var(--phylo-border-light);
 }
 
 [data-theme="phylo"] .code-actions {
-  gap: 8px;
-  padding: 10px 12px;
-  background: var(--phylo-bg-toolbar);
+	gap: 8px;
+	padding: 10px 12px;
+	background: var(--phylo-bg-toolbar);
 }
 
 [data-theme="phylo"] .code-actions .btn {
-  font-size: 10px;
-  padding: 5px 10px;
+	font-size: 10px;
+	padding: 5px 10px;
 }
 
 /* ============================================
@@ -383,358 +385,358 @@
 [data-theme="phylo"] .timeline-panel-header,
 [data-theme="phylo"] .timeline-panel-controls,
 [data-theme="phylo"] .timeline-stats {
-  background: var(--phylo-bg-toolbar);
-  border-bottom: var(--phylo-border-light);
+	background: var(--phylo-bg-toolbar);
+	border-bottom: var(--phylo-border-light);
 }
 
 [data-theme="phylo"] .timeline-panel-content {
-  padding: 10px;
+	padding: 10px;
 }
 
 [data-theme="phylo"] .timeline-list {
-  font-family: 'Monaco', 'Menlo', 'Consolas', 'Courier New', monospace;
-  font-size: 11px;
-  line-height: 1.4;
-  gap: 8px;
+	font-family: "Monaco", "Menlo", "Consolas", "Courier New", monospace;
+	font-size: 11px;
+	line-height: 1.4;
+	gap: 8px;
 }
 
 [data-theme="phylo"] .timeline-event {
-  padding: 10px 12px;
-  background: var(--phylo-bg-secondary);
-  border: var(--phylo-border);
-  border-radius: var(--phylo-panel-radius);
-  box-shadow: none;
-  transition: background 0.1s ease;
+	padding: 10px 12px;
+	background: var(--phylo-bg-secondary);
+	border: var(--phylo-border);
+	border-radius: var(--phylo-panel-radius);
+	box-shadow: none;
+	transition: background 0.1s ease;
 }
 
 [data-theme="phylo"] .timeline-event:hover {
-  background: var(--phylo-bg-tertiary);
-  transform: none;
-  box-shadow: none;
+	background: var(--phylo-bg-tertiary);
+	transform: none;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .timeline-event-header {
-  gap: 8px;
-  margin-bottom: 8px;
-  font-size: 10px;
+	gap: 8px;
+	margin-bottom: 8px;
+	font-size: 10px;
 }
 
 [data-theme="phylo"] .timeline-event-code pre {
-  padding: 8px;
-  background: var(--phylo-bg-code);
-  border-radius: var(--phylo-panel-radius);
-  font-size: 10px;
-  line-height: 1.4;
+	padding: 8px;
+	background: var(--phylo-bg-code);
+	border-radius: var(--phylo-panel-radius);
+	font-size: 10px;
+	line-height: 1.4;
 }
 
 [data-theme="phylo"] .timeline-stat {
-  padding: 6px;
-  background: var(--phylo-bg-primary);
-  border-radius: var(--phylo-panel-radius);
-  border: var(--phylo-border);
+	padding: 6px;
+	background: var(--phylo-bg-primary);
+	border-radius: var(--phylo-panel-radius);
+	border: var(--phylo-border);
 }
 
 [data-theme="phylo"] .timeline-stat-value {
-  font-size: 16px;
+	font-size: 16px;
 }
 
 [data-theme="phylo"] .timeline-stat-label {
-  font-size: 10px;
+	font-size: 10px;
 }
 
 [data-theme="phylo"] .timeline-filter select,
 [data-theme="phylo"] .timeline-filter input[type="text"],
 [data-theme="phylo"] .timeline-sort select {
-  padding: 4px 8px;
-  border: var(--phylo-border);
-  border-radius: var(--phylo-panel-radius);
-  font-size: 11px;
+	padding: 4px 8px;
+	border: var(--phylo-border);
+	border-radius: var(--phylo-panel-radius);
+	font-size: 11px;
 }
 
 [data-theme="phylo"] .timeline-filter-clear,
 [data-theme="phylo"] .timeline-load-more {
-  padding: 6px 10px;
-  background: var(--phylo-bg-secondary);
-  border: var(--phylo-border);
-  border-radius: var(--phylo-panel-radius);
-  font-size: 11px;
-  box-shadow: none;
+	padding: 6px 10px;
+	background: var(--phylo-bg-secondary);
+	border: var(--phylo-border);
+	border-radius: var(--phylo-panel-radius);
+	font-size: 11px;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .timeline-filter-clear:hover,
 [data-theme="phylo"] .timeline-load-more:hover {
-  background: var(--phylo-bg-tertiary);
+	background: var(--phylo-bg-tertiary);
 }
 
 /* ============================================
    CONSOLE - Phylogenetic Tree Style
    ============================================ */
 [data-theme="phylo"] .console-output {
-  font-family: 'Monaco', 'Menlo', 'Consolas', 'Courier New', monospace;
-  font-size: 11px;
-  line-height: 1.4;
-  padding: 12px;
+	font-family: "Monaco", "Menlo", "Consolas", "Courier New", monospace;
+	font-size: 11px;
+	line-height: 1.4;
+	padding: 12px;
 }
 
 [data-theme="phylo"] .console-entry {
-  margin-bottom: 12px;
-  padding: 10px 12px;
-  border-radius: var(--phylo-panel-radius);
-  background: var(--phylo-bg-secondary);
-  border: var(--phylo-border);
-  box-shadow: none;
+	margin-bottom: 12px;
+	padding: 10px 12px;
+	border-radius: var(--phylo-panel-radius);
+	background: var(--phylo-bg-secondary);
+	border: var(--phylo-border);
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .console-meta {
-  gap: 8px;
-  margin-bottom: 8px;
-  font-size: 10px;
+	gap: 8px;
+	margin-bottom: 8px;
+	font-size: 10px;
 }
 
 [data-theme="phylo"] .console-stdout,
 [data-theme="phylo"] .console-stderr {
-  margin: 8px 0;
-  padding: 8px 10px;
-  border-radius: var(--phylo-panel-radius);
-  font-size: 11px;
-  line-height: 1.4;
-  background: var(--phylo-bg-code);
-  border: var(--phylo-border-light);
+	margin: 8px 0;
+	padding: 8px 10px;
+	border-radius: var(--phylo-panel-radius);
+	font-size: 11px;
+	line-height: 1.4;
+	background: var(--phylo-bg-code);
+	border: var(--phylo-border-light);
 }
 
 [data-theme="phylo"] .console-stdout {
-  border-left: 3px solid var(--phylo-success);
+	border-left: 3px solid var(--phylo-success);
 }
 
 [data-theme="phylo"] .console-stderr {
-  color: var(--phylo-error);
-  border-left: 3px solid var(--phylo-error);
-  background: rgba(239, 68, 68, 0.05);
+	color: var(--phylo-error);
+	border-left: 3px solid var(--phylo-error);
+	background: rgba(239, 68, 68, 0.05);
 }
 
 [data-theme="phylo"] .console-error-badge {
-  background: rgba(239, 68, 68, 0.1);
-  color: var(--phylo-error);
-  padding: 2px 6px;
-  border-radius: var(--phylo-panel-radius);
-  font-size: 9px;
+	background: rgba(239, 68, 68, 0.1);
+	color: var(--phylo-error);
+	padding: 2px 6px;
+	border-radius: var(--phylo-panel-radius);
+	font-size: 9px;
 }
 
 [data-theme="phylo"] .console-plots-info {
-  padding: 8px 10px;
-  background-color: rgba(59, 130, 246, 0.08);
-  border-left: 3px solid var(--phylo-cytosine);
-  border-radius: var(--phylo-panel-radius);
-  margin-top: 8px;
-  font-size: 10px;
-  box-shadow: none;
+	padding: 8px 10px;
+	background-color: rgba(59, 130, 246, 0.08);
+	border-left: 3px solid var(--phylo-cytosine);
+	border-radius: var(--phylo-panel-radius);
+	margin-top: 8px;
+	font-size: 10px;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .console-plots-info.clickable:hover {
-  background-color: rgba(59, 130, 246, 0.12);
-  transform: none;
+	background-color: rgba(59, 130, 246, 0.12);
+	transform: none;
 }
 
 [data-theme="phylo"] .console-plots-info.clickable:active {
-  transform: none;
-  background-color: rgba(59, 130, 246, 0.15);
+	transform: none;
+	background-color: rgba(59, 130, 246, 0.15);
 }
 
 [data-theme="phylo"] .console-history {
-  padding: 12px;
+	padding: 12px;
 }
 
 [data-theme="phylo"] .history-list {
-  gap: 8px;
+	gap: 8px;
 }
 
 [data-theme="phylo"] .history-item {
-  padding: 10px 12px;
-  background-color: var(--phylo-bg-secondary);
-  border-radius: var(--phylo-panel-radius);
-  border: var(--phylo-border);
-  transition: background 0.1s ease;
-  box-shadow: none;
+	padding: 10px 12px;
+	background-color: var(--phylo-bg-secondary);
+	border-radius: var(--phylo-panel-radius);
+	border: var(--phylo-border);
+	transition: background 0.1s ease;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .history-item:hover {
-  background: var(--phylo-bg-tertiary);
-  transform: none;
-  box-shadow: none;
+	background: var(--phylo-bg-tertiary);
+	transform: none;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .history-header {
-  gap: 8px;
-  margin-bottom: 6px;
-  font-size: 10px;
+	gap: 8px;
+	margin-bottom: 6px;
+	font-size: 10px;
 }
 
 [data-theme="phylo"] .history-summary {
-  font-size: 10px;
+	font-size: 10px;
 }
 
 /* ============================================
    SASH (SPLIT PANE) OVERRIDES
    ============================================ */
 [data-theme="phylo"] .sash {
-  background-color: var(--phylo-bg-tertiary) !important;
+	background-color: var(--phylo-bg-tertiary) !important;
 }
 
 [data-theme="phylo"] .sash:hover {
-  background-color: var(--phylo-cytosine) !important;
+	background-color: var(--phylo-cytosine) !important;
 }
 
 [data-theme="phylo"] .sash-vertical {
-  width: 1px !important;
+	width: 1px !important;
 }
 
 [data-theme="phylo"] .sash-horizontal {
-  height: 1px !important;
+	height: 1px !important;
 }
 
 /* ============================================
    SCROLLBARS
    ============================================ */
 [data-theme="phylo"] ::-webkit-scrollbar {
-  width: 12px;
-  height: 12px;
+	width: 12px;
+	height: 12px;
 }
 
 [data-theme="phylo"] ::-webkit-scrollbar-track {
-  background: var(--phylo-bg-secondary);
+	background: var(--phylo-bg-secondary);
 }
 
 [data-theme="phylo"] ::-webkit-scrollbar-thumb {
-  background: #cccccc;
-  border-radius: 0;
-  border: 2px solid var(--phylo-bg-secondary);
+	background: #cccccc;
+	border-radius: 0;
+	border: 2px solid var(--phylo-bg-secondary);
 }
 
 [data-theme="phylo"] ::-webkit-scrollbar-thumb:hover {
-  background: #999999;
+	background: #999999;
 }
 
 /* ============================================
    MENU BAR
    ============================================ */
 [data-theme="phylo"] .menubar {
-  background: var(--phylo-bg-toolbar);
-  border: var(--phylo-border);
-  border-radius: 0;
-  padding: 0 12px;
-  height: 36px;
-  box-shadow: none;
-  backdrop-filter: none;
+	background: var(--phylo-bg-toolbar);
+	border: var(--phylo-border);
+	border-radius: 0;
+	padding: 0 12px;
+	height: 36px;
+	box-shadow: none;
+	backdrop-filter: none;
 }
 
 [data-theme="phylo"] .menubar::after {
-  display: none;
+	display: none;
 }
 
 [data-theme="phylo"] .menubar-brand {
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--phylo-text-primary);
-  letter-spacing: 0;
+	font-size: 13px;
+	font-weight: 700;
+	color: var(--phylo-text-primary);
+	letter-spacing: 0;
 }
 
 [data-theme="phylo"] .menu-item {
-  padding: 6px 12px;
-  font-size: 12px;
-  font-weight: 500;
-  border-radius: 3px;
-  background: transparent;
-  border: none;
+	padding: 6px 12px;
+	font-size: 12px;
+	font-weight: 500;
+	border-radius: 3px;
+	background: transparent;
+	border: none;
 }
 
 [data-theme="phylo"] .menu-item:hover {
-  background: var(--phylo-bg-secondary);
-  color: var(--phylo-text-primary);
+	background: var(--phylo-bg-secondary);
+	color: var(--phylo-text-primary);
 }
 
 [data-theme="phylo"] .connection-indicator {
-  padding: 4px 10px;
-  border-radius: 3px;
-  background: var(--phylo-bg-secondary);
-  border: var(--phylo-border);
-  box-shadow: none;
+	padding: 4px 10px;
+	border-radius: 3px;
+	background: var(--phylo-bg-secondary);
+	border: var(--phylo-border);
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .connection-dot {
-  width: 8px;
-  height: 8px;
-  box-shadow: none;
+	width: 8px;
+	height: 8px;
+	box-shadow: none;
 }
 
 /* ============================================
    STATUS BAR
    ============================================ */
 [data-theme="phylo"] .statusbar {
-  background: var(--phylo-bg-toolbar);
-  border: var(--phylo-border);
-  border-radius: 0;
-  padding: 0 12px;
-  height: 24px;
-  font-size: 11px;
-  box-shadow: none;
-  backdrop-filter: none;
+	background: var(--phylo-bg-toolbar);
+	border: var(--phylo-border);
+	border-radius: 0;
+	padding: 0 12px;
+	height: 24px;
+	font-size: 11px;
+	box-shadow: none;
+	backdrop-filter: none;
 }
 
 [data-theme="phylo"] .statusbar-item {
-  gap: 4px;
+	gap: 4px;
 }
 
 [data-theme="phylo"] .statusbar-modified {
-  color: var(--phylo-warning);
+	color: var(--phylo-warning);
 }
 
 [data-theme="phylo"] .statusbar-running {
-  color: var(--phylo-cytosine);
+	color: var(--phylo-cytosine);
 }
 
 /* ============================================
    SPINNER
    ============================================ */
 [data-theme="phylo"] .spinner {
-  width: 12px;
-  height: 12px;
-  border: 2px solid var(--phylo-bg-tertiary);
-  border-top-color: var(--phylo-cytosine);
-  border-radius: 50%;
+	width: 12px;
+	height: 12px;
+	border: 2px solid var(--phylo-bg-tertiary);
+	border-top-color: var(--phylo-cytosine);
+	border-radius: 50%;
 }
 
 /* ============================================
    STOP BUTTON
    ============================================ */
 [data-theme="phylo"] .btn-stop {
-  background: var(--phylo-thymine);
-  color: white;
-  border-color: transparent;
-  box-shadow: none;
+	background: var(--phylo-thymine);
+	color: white;
+	border-color: transparent;
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .btn-stop:hover:not(:disabled) {
-  background: #dc2626;
+	background: #dc2626;
 }
 
 /* ============================================
    EDITOR
    ============================================ */
 [data-theme="phylo"] .editor-panel {
-  background: var(--phylo-bg-primary);
+	background: var(--phylo-bg-primary);
 }
 
 [data-theme="phylo"] .dirty-marker {
-  color: var(--phylo-warning);
+	color: var(--phylo-warning);
 }
 
 [data-theme="phylo"] .cell-boundary-decoration {
-  background: rgba(59, 130, 246, 0.1);
-  border-left: 2px solid var(--phylo-cytosine);
+	background: rgba(59, 130, 246, 0.1);
+	border-left: 2px solid var(--phylo-cytosine);
 }
 
 [data-theme="phylo"] .executing-cell-background {
-  background-color: rgba(59, 130, 246, 0.05);
+	background-color: rgba(59, 130, 246, 0.05);
 }
 
 /* ============================================
@@ -742,97 +744,97 @@
    ============================================ */
 [data-theme="phylo"] .plots-panel,
 [data-theme="phylo"] .plots-panel .panel-header {
-  background: transparent;
+	background: transparent;
 }
 
 [data-theme="phylo"] .plot-counter {
-  font-size: 10px;
+	font-size: 10px;
 }
 
 [data-theme="phylo"] .plots-container,
 [data-theme="phylo"] .viewer-container,
 [data-theme="phylo"] .help-container {
-  background: var(--phylo-bg-primary);
+	background: var(--phylo-bg-primary);
 }
 
 [data-theme="phylo"] .empty-state {
-  padding: 24px;
-  gap: 10px;
+	padding: 24px;
+	gap: 10px;
 }
 
 [data-theme="phylo"] .empty-icon svg {
-  width: 40px;
-  height: 40px;
-  color: var(--phylo-text-muted);
+	width: 40px;
+	height: 40px;
+	color: var(--phylo-text-muted);
 }
 
 [data-theme="phylo"] .empty-state p {
-  font-size: 12px;
+	font-size: 12px;
 }
 
 [data-theme="phylo"] .empty-hint {
-  font-size: 11px;
+	font-size: 11px;
 }
 
 [data-theme="phylo"] .plot-viewer {
-  padding: 12px;
-  background: var(--phylo-bg-secondary);
+	padding: 12px;
+	background: var(--phylo-bg-secondary);
 }
 
 [data-theme="phylo"] .plot-image {
-  border: var(--phylo-border);
-  box-shadow: none;
+	border: var(--phylo-border);
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .help-content {
-  padding: 18px;
-  gap: 14px;
+	padding: 18px;
+	gap: 14px;
 }
 
 [data-theme="phylo"] .help-content h3 {
-  font-size: 14px;
+	font-size: 14px;
 }
 
 [data-theme="phylo"] .help-section {
-  padding: 12px;
-  border-radius: var(--phylo-panel-radius);
-  background: var(--phylo-bg-secondary);
-  border: var(--phylo-border);
-  box-shadow: none;
+	padding: 12px;
+	border-radius: var(--phylo-panel-radius);
+	background: var(--phylo-bg-secondary);
+	border: var(--phylo-border);
+	box-shadow: none;
 }
 
 [data-theme="phylo"] .help-section h4 {
-  font-size: 12px;
-  margin-bottom: 6px;
+	font-size: 12px;
+	margin-bottom: 6px;
 }
 
 [data-theme="phylo"] .help-section li {
-  font-size: 11px;
-  padding-left: 14px;
+	font-size: 11px;
+	padding-left: 14px;
 }
 
 [data-theme="phylo"] .help-section li::before {
-  width: 4px;
-  height: 4px;
-  background: var(--phylo-cytosine);
-  box-shadow: none;
+	width: 4px;
+	height: 4px;
+	background: var(--phylo-cytosine);
+	box-shadow: none;
 }
 
 /* ============================================
    UTILITIES
    ============================================ */
 [data-theme="phylo"] .phylo-success-text {
-  color: var(--phylo-success);
+	color: var(--phylo-success);
 }
 
 [data-theme="phylo"] .phylo-error-text {
-  color: var(--phylo-error);
+	color: var(--phylo-error);
 }
 
 [data-theme="phylo"] .phylo-warning-text {
-  color: var(--phylo-warning);
+	color: var(--phylo-warning);
 }
 
 [data-theme="phylo"] .phylo-muted-text {
-  color: var(--phylo-text-muted);
+	color: var(--phylo-text-muted);
 }

--- a/client/src/css/design-phylo-rstudio.css
+++ b/client/src/css/design-phylo-rstudio.css
@@ -48,8 +48,7 @@
 
 	/* Typography tokens */
 	--phylo-font-family:
-		-apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", "Helvetica Neue",
-		Arial, sans-serif;
+		-apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", "Helvetica Neue", Arial, sans-serif;
 	--phylo-font-size-base: 12px;
 	--phylo-line-height-base: 1.5;
 	--phylo-font-weight-base: 400;

--- a/client/src/css/globals.css
+++ b/client/src/css/globals.css
@@ -1,119 +1,119 @@
-@import './variables.css';
+@import "./variables.css";
 
 /* CSS Reset */
 * {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+	box-sizing: border-box;
 }
 
 /* Accessibility: Focus visible styles for keyboard navigation */
 *:focus-visible {
-  outline: 2px solid var(--accent-blue);
-  outline-offset: 2px;
+	outline: 2px solid var(--accent-blue);
+	outline-offset: 2px;
 }
 
 html,
 body,
 #root {
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
 }
 
 html {
-  font-size: calc(var(--font-size-base) * var(--app-zoom));
+	font-size: calc(var(--font-size-base) * var(--app-zoom));
 }
 
 body {
-  margin: 0;
-  background: #f5f6f8;
-  color: var(--text-primary);
-  font-family: var(--font-family-base);
-  font-size: inherit;
-  line-height: var(--line-height-base);
-  font-weight: var(--font-weight-base);
-  letter-spacing: var(--letter-spacing-base);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+	margin: 0;
+	background: #f5f6f8;
+	color: var(--text-primary);
+	font-family: var(--font-family-base);
+	font-size: inherit;
+	line-height: var(--line-height-base);
+	font-weight: var(--font-weight-base);
+	letter-spacing: var(--letter-spacing-base);
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: 'Monaco', 'Menlo', 'Consolas', 'Courier New', monospace;
+	font-family: "Monaco", "Menlo", "Consolas", "Courier New", monospace;
 }
 
 button {
-  font-family: inherit;
-  font-size: inherit;
-  cursor: pointer;
-  border: none;
-  background: none;
-  padding: 0;
+	font-family: inherit;
+	font-size: inherit;
+	cursor: pointer;
+	border: none;
+	background: none;
+	padding: 0;
 }
 
 button:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
+	cursor: not-allowed;
+	opacity: 0.6;
 }
 
 input,
 textarea {
-  font-family: inherit;
-  font-size: inherit;
-  border: 1px solid var(--border-color);
-  background-color: var(--bg-primary);
-  color: var(--text-primary);
+	font-family: inherit;
+	font-size: inherit;
+	border: 1px solid var(--border-color);
+	background-color: var(--bg-primary);
+	color: var(--text-primary);
 }
 
 input:focus,
 textarea:focus {
-  outline: 2px solid var(--accent-blue-light);
-  outline-offset: 1px;
-  border-color: var(--accent-blue);
+	outline: 2px solid var(--accent-blue-light);
+	outline-offset: 1px;
+	border-color: var(--accent-blue);
 }
 
 /* Scrollbars */
 ::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
+	width: 10px;
+	height: 10px;
 }
 
 ::-webkit-scrollbar-track {
-  background: transparent;
+	background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(100, 116, 139, 0.3);
-  border-radius: 8px;
-  border: 2px solid transparent;
-  background-clip: padding-box;
+	background: rgba(100, 116, 139, 0.3);
+	border-radius: 8px;
+	border: 2px solid transparent;
+	background-clip: padding-box;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(100, 116, 139, 0.45);
+	background: rgba(100, 116, 139, 0.45);
 }
 
 ::-webkit-scrollbar-corner {
-  background: transparent;
+	background: transparent;
 }
 
 /* Allotment (split pane) overrides */
 .split-view-view {
-  background: transparent;
+	background: transparent;
 }
 
 .sash {
-  background-color: rgba(148, 163, 184, 0.35) !important;
+	background-color: rgba(148, 163, 184, 0.35) !important;
 }
 
 .sash:hover {
-  background-color: rgba(47, 111, 237, 0.45) !important;
+	background-color: rgba(47, 111, 237, 0.45) !important;
 }
 
 .sash-vertical {
-  width: 2px !important;
+	width: 2px !important;
 }
 
 .sash-horizontal {
-  height: 2px !important;
+	height: 2px !important;
 }

--- a/client/src/css/index.css
+++ b/client/src/css/index.css
@@ -1,22 +1,22 @@
 /* Main CSS entry point */
-@import './globals.css';
-@import './utils.css';
+@import "./globals.css";
+@import "./utils.css";
 
 /* Component styles */
-@import './components/editor.css';
-@import './components/ai-panel/index.css';
-@import './components/right-pane.css';
-@import './components/console.css';
-@import './components/terminal.css';
-@import './components/timeline.css';
-@import './components/timeline-dialog.css';
-@import './components/menu.css';
-@import './components/status-bar.css';
-@import './components/layout.css';
-@import './components/file-browser.css';
-@import './components/export-dialog.css';
-@import './components/confirm-dialog.css';
-@import './components/modal-dialog.css';
+@import "./components/editor.css";
+@import "./components/ai-panel/index.css";
+@import "./components/right-pane.css";
+@import "./components/console.css";
+@import "./components/terminal.css";
+@import "./components/timeline.css";
+@import "./components/timeline-dialog.css";
+@import "./components/menu.css";
+@import "./components/status-bar.css";
+@import "./components/layout.css";
+@import "./components/file-browser.css";
+@import "./components/export-dialog.css";
+@import "./components/confirm-dialog.css";
+@import "./components/modal-dialog.css";
 
 /* Design themes */
-@import './design-phylo-rstudio.css';
+@import "./design-phylo-rstudio.css";

--- a/client/src/css/utils.css
+++ b/client/src/css/utils.css
@@ -1,37 +1,37 @@
 /* Flexbox utilities */
 .flex-center {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .flex-between {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
 }
 
 /* Text utilities */
 .truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 /* Accessibility */
 .sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
 }
 
 /* Visibility */
 .hidden {
-  display: none !important;
+	display: none !important;
 }

--- a/client/src/css/variables.css
+++ b/client/src/css/variables.css
@@ -57,29 +57,16 @@
 	--btn-font-size: 12px;
 	--btn-radius: 6px; /* Standard border radius (was 999px pill shape) */
 	--btn-border: 1px solid rgba(148, 163, 184, 0.4);
-	--btn-bg: linear-gradient(
-		180deg,
-		rgba(255, 255, 255, 0.85),
-		rgba(244, 246, 251, 0.85)
-	);
+	--btn-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(244, 246, 251, 0.85));
 	--btn-color: var(--text-primary);
 	--btn-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 	--btn-height: 28px;
-	--btn-transition:
-		transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
-	--btn-hover-bg: linear-gradient(
-		180deg,
-		rgba(255, 255, 255, 0.95),
-		rgba(236, 240, 248, 0.95)
-	);
+	--btn-transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+	--btn-hover-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(236, 240, 248, 0.95));
 	--btn-hover-shadow: 0 6px 14px rgba(47, 111, 237, 0.08);
 	--btn-hover-transform: translateY(-1px);
 	--btn-hover-border-color: rgba(148, 163, 184, 0.4);
-	--btn-active-bg: linear-gradient(
-		180deg,
-		rgba(255, 255, 255, 0.95),
-		rgba(236, 240, 248, 0.95)
-	);
+	--btn-active-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(236, 240, 248, 0.95));
 	--btn-active-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.12);
 	--btn-active-transform: translateY(0);
 	--btn-primary-bg: linear-gradient(180deg, #2f6fed, #2756ca);
@@ -105,8 +92,7 @@
 	--tab-radius: 0; /* Standard tabs without border radius (was 10px 10px 0 0) */
 	--tab-border: 1px solid transparent;
 	--tab-divider: none;
-	--tab-transition:
-		transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+	--tab-transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
 	--tab-shadow: none;
 	--tab-active-color: var(--accent-blue);
 	--tab-active-bg: rgba(47, 111, 237, 0.16);

--- a/client/src/css/variables.css
+++ b/client/src/css/variables.css
@@ -1,134 +1,148 @@
 :root,
 :root[data-theme="default"] {
-  /* Surface palette */
-  --bg-primary: #ffffff;
-  --bg-secondary: #f4f6fb;
-  --bg-tertiary: #e8ecf7;
-  --bg-toolbar: rgba(250, 252, 255, 0.86);
-  --bg-elevated: rgba(255, 255, 255, 0.92);
-  --bg-code: #f9fafc;
+	/* Surface palette */
+	--bg-primary: #ffffff;
+	--bg-secondary: #f4f6fb;
+	--bg-tertiary: #e8ecf7;
+	--bg-toolbar: rgba(250, 252, 255, 0.86);
+	--bg-elevated: rgba(255, 255, 255, 0.92);
+	--bg-code: #f9fafc;
 
-  /* Typography */
-  --text-primary: #1f2937;
-  --text-secondary: #4b5565;
-  --text-muted: #6b7280; /* Improved contrast for accessibility (was #8a93a4) */
+	/* Typography */
+	--text-primary: #1f2937;
+	--text-secondary: #4b5565;
+	--text-muted: #6b7280; /* Improved contrast for accessibility (was #8a93a4) */
 
-  /* Borders & depth */
-  --border-color: rgba(30, 41, 59, 0.12);
-  --border-light: rgba(148, 163, 184, 0.2);
-  --border-strong: rgba(15, 23, 42, 0.22);
-  --panel-radius: 12px;
-  --shadow-sm: 0 8px 18px rgba(15, 23, 42, 0.08);
-  --shadow-md: 0 18px 40px rgba(15, 23, 42, 0.12);
-  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.65);
-  --panel-header-min-height: 38px;
-  --panel-header-padding: 0 16px; /* Standardized padding (was 0 18px) */
-  --panel-header-shadow: var(--shadow-inset);
-  --panel-actions-gap: 8px;
-  --panel-title-font-size: 13px;
-  --panel-title-font-weight: 600;
-  --panel-title-gap: 8px;
-  --panel-title-letter-spacing: var(--letter-spacing-base);
+	/* Borders & depth */
+	--border-color: rgba(30, 41, 59, 0.12);
+	--border-light: rgba(148, 163, 184, 0.2);
+	--border-strong: rgba(15, 23, 42, 0.22);
+	--panel-radius: 12px;
+	--shadow-sm: 0 8px 18px rgba(15, 23, 42, 0.08);
+	--shadow-md: 0 18px 40px rgba(15, 23, 42, 0.12);
+	--shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+	--panel-header-min-height: 38px;
+	--panel-header-padding: 0 16px; /* Standardized padding (was 0 18px) */
+	--panel-header-shadow: var(--shadow-inset);
+	--panel-actions-gap: 8px;
+	--panel-title-font-size: 13px;
+	--panel-title-font-weight: 600;
+	--panel-title-gap: 8px;
+	--panel-title-letter-spacing: var(--letter-spacing-base);
 
-  /* Brand accents */
-  --accent-blue: #2f6fed;
-  --accent-blue-hover: #2556c8;
-  --accent-blue-light: rgba(47, 111, 237, 0.16);
+	/* Brand accents */
+	--accent-blue: #2f6fed;
+	--accent-blue-hover: #2556c8;
+	--accent-blue-light: rgba(47, 111, 237, 0.16);
 
-  /* State colors */
-  --success-color: #1f9254;
-  --error-color: #dc4c3f;
-  --warning-color: #f59e0b;
+	/* State colors */
+	--success-color: #1f9254;
+	--error-color: #dc4c3f;
+	--warning-color: #f59e0b;
 
-  /* Typography tokens */
-  --font-family-base: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-  --font-ui: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-  --font-code: 'Berkeley Mono', 'Fira Code', 'Consolas', monospace;
-  --font-size-base: 13px;
-  --line-height-base: 1.55;
-  --font-weight-base: 400;
-  --letter-spacing-base: -0.01em;
+	/* Typography tokens */
+	--font-family-base: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+	--font-ui: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+	--font-code: "Berkeley Mono", "Fira Code", "Consolas", monospace;
+	--font-size-base: 13px;
+	--line-height-base: 1.55;
+	--font-weight-base: 400;
+	--letter-spacing-base: -0.01em;
 
-  /* Application layout */
-  --app-zoom: 1;
+	/* Application layout */
+	--app-zoom: 1;
 
-  /* Button system */
-  --btn-padding: 6px 14px;
-  --btn-font-size: 12px;
-  --btn-radius: 6px; /* Standard border radius (was 999px pill shape) */
-  --btn-border: 1px solid rgba(148, 163, 184, 0.4);
-  --btn-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(244, 246, 251, 0.85));
-  --btn-color: var(--text-primary);
-  --btn-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
-  --btn-height: 28px;
-  --btn-transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
-  --btn-hover-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(236, 240, 248, 0.95));
-  --btn-hover-shadow: 0 6px 14px rgba(47, 111, 237, 0.08);
-  --btn-hover-transform: translateY(-1px);
-  --btn-hover-border-color: rgba(148, 163, 184, 0.4);
-  --btn-active-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(236, 240, 248, 0.95));
-  --btn-active-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.12);
-  --btn-active-transform: translateY(0);
-  --btn-primary-bg: linear-gradient(180deg, #2f6fed, #2756ca);
-  --btn-primary-color: #ffffff;
-  --btn-primary-border: transparent;
-  --btn-primary-shadow: 0 10px 20px rgba(47, 111, 237, 0.25);
-  --btn-primary-hover-bg: linear-gradient(180deg, #2f6fed, #244fc1);
-  --btn-primary-hover-shadow: 0 12px 24px rgba(47, 111, 237, 0.35);
-  --btn-icon-padding: 6px;
-  --btn-icon-size: 28px;
-  --btn-icon-height: 28px;
-  --btn-icon-radius: 8px;
+	/* Button system */
+	--btn-padding: 6px 14px;
+	--btn-font-size: 12px;
+	--btn-radius: 6px; /* Standard border radius (was 999px pill shape) */
+	--btn-border: 1px solid rgba(148, 163, 184, 0.4);
+	--btn-bg: linear-gradient(
+		180deg,
+		rgba(255, 255, 255, 0.85),
+		rgba(244, 246, 251, 0.85)
+	);
+	--btn-color: var(--text-primary);
+	--btn-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+	--btn-height: 28px;
+	--btn-transition:
+		transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+	--btn-hover-bg: linear-gradient(
+		180deg,
+		rgba(255, 255, 255, 0.95),
+		rgba(236, 240, 248, 0.95)
+	);
+	--btn-hover-shadow: 0 6px 14px rgba(47, 111, 237, 0.08);
+	--btn-hover-transform: translateY(-1px);
+	--btn-hover-border-color: rgba(148, 163, 184, 0.4);
+	--btn-active-bg: linear-gradient(
+		180deg,
+		rgba(255, 255, 255, 0.95),
+		rgba(236, 240, 248, 0.95)
+	);
+	--btn-active-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.12);
+	--btn-active-transform: translateY(0);
+	--btn-primary-bg: linear-gradient(180deg, #2f6fed, #2756ca);
+	--btn-primary-color: #ffffff;
+	--btn-primary-border: transparent;
+	--btn-primary-shadow: 0 10px 20px rgba(47, 111, 237, 0.25);
+	--btn-primary-hover-bg: linear-gradient(180deg, #2f6fed, #244fc1);
+	--btn-primary-hover-shadow: 0 12px 24px rgba(47, 111, 237, 0.35);
+	--btn-icon-padding: 6px;
+	--btn-icon-size: 28px;
+	--btn-icon-height: 28px;
+	--btn-icon-radius: 8px;
 
-  /* Tabs */
-  --tabs-gap: 6px;
-  --tabs-padding: 0 12px;
-  --tabs-background: transparent;
-  --tabs-border-bottom: none;
-  --tab-padding: 6px 14px;
-  --tab-font-size: 14px; /* Improved readability (was 12px) */
-  --tab-color: var(--text-secondary);
-  --tab-bg: rgba(255, 255, 255, 0.65);
-  --tab-radius: 0; /* Standard tabs without border radius (was 10px 10px 0 0) */
-  --tab-border: 1px solid transparent;
-  --tab-divider: none;
-  --tab-transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
-  --tab-shadow: none;
-  --tab-active-color: var(--accent-blue);
-  --tab-active-bg: rgba(47, 111, 237, 0.16);
-  --tab-active-border: rgba(47, 111, 237, 0.32);
-  --tab-active-shadow: none; /* Removed shadow for cleaner look (was 0 10px 24px rgba(47, 111, 237, 0.18)) */
-  --tab-active-underline: none;
+	/* Tabs */
+	--tabs-gap: 6px;
+	--tabs-padding: 0 12px;
+	--tabs-background: transparent;
+	--tabs-border-bottom: none;
+	--tab-padding: 6px 14px;
+	--tab-font-size: 14px; /* Improved readability (was 12px) */
+	--tab-color: var(--text-secondary);
+	--tab-bg: rgba(255, 255, 255, 0.65);
+	--tab-radius: 0; /* Standard tabs without border radius (was 10px 10px 0 0) */
+	--tab-border: 1px solid transparent;
+	--tab-divider: none;
+	--tab-transition:
+		transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+	--tab-shadow: none;
+	--tab-active-color: var(--accent-blue);
+	--tab-active-bg: rgba(47, 111, 237, 0.16);
+	--tab-active-border: rgba(47, 111, 237, 0.32);
+	--tab-active-shadow: none; /* Removed shadow for cleaner look (was 0 10px 24px rgba(47, 111, 237, 0.18)) */
+	--tab-active-underline: none;
 
-  /* Menu system */
-  --menu-height: 32px;
-  --menu-padding: 0 12px;
-  --menu-gap: 20px;
-  --menu-bg: #f6f8fa;
-  --menu-border-color: #d0d7de;
-  --menu-border-radius: 0;
-  --menu-shadow: none;
-  --menu-item-gap: 2px;
-  --menu-item-padding: 4px 10px;
-  --menu-item-font-size: 12px;
-  --menu-item-border-radius: 3px;
-  --menu-item-hover-bg: #e5e7eb;
-  --menu-item-active-bg: #d1d5db;
-  --menu-dropdown-bg: #ffffff;
-  --menu-dropdown-border: #d0d7de;
-  --menu-dropdown-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  --menu-dropdown-hover-bg: #f6f8fa;
-  --menu-dropdown-active-bg: #e5e7eb;
-  --menu-dropdown-separator: #e5e7eb;
-  --menu-connection-bg: #ffffff;
-  --menu-connection-border: #d0d7de;
-  --menu-connection-padding: 4px 8px;
-  --menu-connection-gap: 6px;
-  --menu-connection-font-size: 11px;
-  --menu-ai-bg: #fefce8;
-  --menu-ai-border: #f59e0b;
-  --menu-ai-hover-bg: #fef9c3;
-  --menu-info-color: #3b82f6;
-  --menu-success-color: var(--success-color);
-  --menu-error-color: var(--error-color);
+	/* Menu system */
+	--menu-height: 32px;
+	--menu-padding: 0 12px;
+	--menu-gap: 20px;
+	--menu-bg: #f6f8fa;
+	--menu-border-color: #d0d7de;
+	--menu-border-radius: 0;
+	--menu-shadow: none;
+	--menu-item-gap: 2px;
+	--menu-item-padding: 4px 10px;
+	--menu-item-font-size: 12px;
+	--menu-item-border-radius: 3px;
+	--menu-item-hover-bg: #e5e7eb;
+	--menu-item-active-bg: #d1d5db;
+	--menu-dropdown-bg: #ffffff;
+	--menu-dropdown-border: #d0d7de;
+	--menu-dropdown-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+	--menu-dropdown-hover-bg: #f6f8fa;
+	--menu-dropdown-active-bg: #e5e7eb;
+	--menu-dropdown-separator: #e5e7eb;
+	--menu-connection-bg: #ffffff;
+	--menu-connection-border: #d0d7de;
+	--menu-connection-padding: 4px 8px;
+	--menu-connection-gap: 6px;
+	--menu-connection-font-size: 11px;
+	--menu-ai-bg: #fefce8;
+	--menu-ai-border: #f59e0b;
+	--menu-ai-hover-bg: #fef9c3;
+	--menu-info-color: #3b82f6;
+	--menu-success-color: var(--success-color);
+	--menu-error-color: var(--error-color);
 }

--- a/client/src/hooks/useAICodeApplication.ts
+++ b/client/src/hooks/useAICodeApplication.ts
@@ -1,55 +1,55 @@
-import { useCallback } from 'react';
-import { useStore } from '@/core';
-import { applyCodeChangeFile } from '@/services/fileService';
-import { REMOTE_FILE_ACTIONS } from '@/core/ai/promptUtils';
-import type { AIMessage, CodeBlock } from '@shared/types';
+import type { AIMessage, CodeBlock } from "@shared/types";
+import { useCallback } from "react";
+import { useStore } from "@/core";
+import { REMOTE_FILE_ACTIONS } from "@/core/ai/promptUtils";
+import { applyCodeChangeFile } from "@/services/fileService";
 
 type PostAssistantMessage = (content: string, extras?: Partial<AIMessage>) => void;
 
 export function useAICodeApplication(postAssistantMessage: PostAssistantMessage) {
-  const applyCodeChange = useStore((state) => state.applyCodeChange);
-  const editorFilepath = useStore((state) => state.editor.filepath);
+	const applyCodeChange = useStore((state) => state.applyCodeChange);
+	const editorFilepath = useStore((state) => state.editor.filepath);
 
-  const handleApplyCode = useCallback(
-    async (codeBlock: CodeBlock): Promise<void> => {
-      const targetFile = codeBlock.filepath;
+	const handleApplyCode = useCallback(
+		async (codeBlock: CodeBlock): Promise<void> => {
+			const targetFile = codeBlock.filepath;
 
-      const isCurrentEditor =
-        !targetFile ||
-        targetFile === '<current editor buffer>' ||
-        targetFile === 'current editor buffer' ||
-        targetFile.includes('current_editor_buffer') ||
-        targetFile.includes('current editor buffer') ||
-        targetFile.startsWith('<') ||
-        (!editorFilepath && targetFile);
+			const isCurrentEditor =
+				!targetFile ||
+				targetFile === "<current editor buffer>" ||
+				targetFile === "current editor buffer" ||
+				targetFile.includes("current_editor_buffer") ||
+				targetFile.includes("current editor buffer") ||
+				targetFile.startsWith("<") ||
+				(!editorFilepath && targetFile);
 
-      const shouldUseRemote =
-        Boolean(targetFile) &&
-        !isCurrentEditor &&
-        targetFile !== editorFilepath &&
-        REMOTE_FILE_ACTIONS.has(codeBlock.action);
+			const shouldUseRemote =
+				Boolean(targetFile) &&
+				!isCurrentEditor &&
+				targetFile !== editorFilepath &&
+				REMOTE_FILE_ACTIONS.has(codeBlock.action);
 
-      if (shouldUseRemote) {
-        try {
-          await applyCodeChangeFile(codeBlock);
-          postAssistantMessage(`Applied ${codeBlock.action} to ${targetFile}`);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : 'unknown error';
-          postAssistantMessage(`Failed to apply remote change: ${message}`);
-          console.error('Remote code change failed', error);
-        }
-        return;
-      }
+			if (shouldUseRemote) {
+				try {
+					await applyCodeChangeFile(codeBlock);
+					postAssistantMessage(`Applied ${codeBlock.action} to ${targetFile}`);
+				} catch (error) {
+					const message = error instanceof Error ? error.message : "unknown error";
+					postAssistantMessage(`Failed to apply remote change: ${message}`);
+					console.error("Remote code change failed", error);
+				}
+				return;
+			}
 
-      if (applyCodeChange) {
-        await applyCodeChange(codeBlock);
-        return;
-      }
+			if (applyCodeChange) {
+				await applyCodeChange(codeBlock);
+				return;
+			}
 
-      console.warn('applyCodeChange not available, falling back to append mode');
-    },
-    [applyCodeChange, editorFilepath, postAssistantMessage],
-  );
+			console.warn("applyCodeChange not available, falling back to append mode");
+		},
+		[applyCodeChange, editorFilepath, postAssistantMessage],
+	);
 
-  return { handleApplyCode };
+	return { handleApplyCode };
 }

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -1,172 +1,184 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useStore } from '@/core';
-import { socketService } from '@/services/socket';
-import { buildPromptWithContext, createRequestId } from '@/core/ai/promptUtils';
-import type { AIMessage, AIMode } from '@shared/types';
-import { useAIStreaming } from './useAIStreaming';
-import { useAICodeApplication } from './useAICodeApplication';
-import { useAITimeout } from './useAITimeout';
+import type { AIMessage, AIMode } from "@shared/types";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useStore } from "@/core";
+import { buildPromptWithContext, createRequestId } from "@/core/ai/promptUtils";
+import { socketService } from "@/services/socket";
+import { useAICodeApplication } from "./useAICodeApplication";
+import { useAIStreaming } from "./useAIStreaming";
+import { useAITimeout } from "./useAITimeout";
 
 const STREAM_TIMEOUT_MS = 45000;
 
 export function useAIConversation() {
-  const messages = useStore((state) => state.ai.messages);
-  const isLoading = useStore((state) => state.ai.isLoading);
+	const messages = useStore((state) => state.ai.messages);
+	const isLoading = useStore((state) => state.ai.isLoading);
 
-  const addAIMessage = useStore((state) => state.addAIMessage);
-  const startStreamingMessage = useStore((state) => state.startStreamingMessage);
-  const setAILoading = useStore((state) => state.setAILoading);
-  const completeStreamingMessage = useStore((state) => state.completeStreamingMessage);
-  const editorContent = useStore((state) => state.editor.content);
-  const editorFilepath = useStore((state) => state.editor.filepath);
-  const consoleHistory = useStore((state) => state.execution.results);
+	const addAIMessage = useStore((state) => state.addAIMessage);
+	const startStreamingMessage = useStore((state) => state.startStreamingMessage);
+	const setAILoading = useStore((state) => state.setAILoading);
+	const completeStreamingMessage = useStore((state) => state.completeStreamingMessage);
+	const editorContent = useStore((state) => state.editor.content);
+	const editorFilepath = useStore((state) => state.editor.filepath);
+	const consoleHistory = useStore((state) => state.execution.results);
 
-  const { clearTimeoutRef, startTimeout } = useAITimeout();
-  const { registerStreamingHandlers } = useAIStreaming();
+	const { clearTimeoutRef, startTimeout } = useAITimeout();
+	const { registerStreamingHandlers } = useAIStreaming();
 
-  const [input, setInput] = useState('');
-  const activeRequestRef = useRef<{ id: string; dispose: () => void } | null>(null);
+	const [input, setInput] = useState("");
+	const activeRequestRef = useRef<{ id: string; dispose: () => void } | null>(null);
 
-  const postAssistantMessage = useCallback(
-    (content: string, extras?: Partial<AIMessage>) => {
-      const timestamp = Date.now();
-      addAIMessage({
-        id: timestamp.toString(),
-        role: 'assistant',
-        content,
-        timestamp,
-        ...extras,
-      });
-    },
-    [addAIMessage],
-  );
+	const postAssistantMessage = useCallback(
+		(content: string, extras?: Partial<AIMessage>) => {
+			const timestamp = Date.now();
+			addAIMessage({
+				id: timestamp.toString(),
+				role: "assistant",
+				content,
+				timestamp,
+				...extras,
+			});
+		},
+		[addAIMessage],
+	);
 
-  const { handleApplyCode } = useAICodeApplication(postAssistantMessage);
+	const { handleApplyCode } = useAICodeApplication(postAssistantMessage);
 
-  const clearActiveRequest = useCallback((options: { dispose?: boolean } = {}) => {
-    if (!activeRequestRef.current) {
-      return;
-    }
+	const clearActiveRequest = useCallback((options: { dispose?: boolean } = {}) => {
+		if (!activeRequestRef.current) {
+			return;
+		}
 
-    if (options.dispose !== false) {
-      activeRequestRef.current.dispose();
-    }
-    activeRequestRef.current = null;
-  }, []);
+		if (options.dispose !== false) {
+			activeRequestRef.current.dispose();
+		}
+		activeRequestRef.current = null;
+	}, []);
 
-  useEffect(() => {
-    return () => {
-      clearTimeoutRef();
-      clearActiveRequest();
-    };
-  }, [clearActiveRequest, clearTimeoutRef]);
+	useEffect(() => {
+		return () => {
+			clearTimeoutRef();
+			clearActiveRequest();
+		};
+	}, [clearActiveRequest, clearTimeoutRef]);
 
-  const handleStop = useCallback(() => {
-    clearTimeoutRef();
-    setAILoading(false);
-    const streamingId = activeRequestRef.current?.id;
-    if (streamingId) {
-      completeStreamingMessage(streamingId);
-      clearActiveRequest();
-    } else {
-      postAssistantMessage('Request stopped by user.');
-    }
-  }, [clearActiveRequest, clearTimeoutRef, completeStreamingMessage, postAssistantMessage, setAILoading]);
+	const handleStop = useCallback(() => {
+		clearTimeoutRef();
+		setAILoading(false);
+		const streamingId = activeRequestRef.current?.id;
+		if (streamingId) {
+			completeStreamingMessage(streamingId);
+			clearActiveRequest();
+		} else {
+			postAssistantMessage("Request stopped by user.");
+		}
+	}, [
+		clearActiveRequest,
+		clearTimeoutRef,
+		completeStreamingMessage,
+		postAssistantMessage,
+		setAILoading,
+	]);
 
-  const handleAsk = useCallback(
-    (mode: AIMode = 'agent') => {
-      if (!input.trim()) {
-        return;
-      }
+	const handleAsk = useCallback(
+		(mode: AIMode = "agent") => {
+			if (!input.trim()) {
+				return;
+			}
 
-      const userMessage: AIMessage = {
-        id: Date.now().toString(),
-        role: 'user',
-        content: input,
-        timestamp: Date.now(),
-        mode,
-      };
+			const userMessage: AIMessage = {
+				id: Date.now().toString(),
+				role: "user",
+				content: input,
+				timestamp: Date.now(),
+				mode,
+			};
 
-      const requestMessages = [
-        ...messages.map((message) => ({ role: message.role, content: message.content })),
-        {
-          role: 'user' as const,
-          content: buildPromptWithContext(editorFilepath, editorContent, input, consoleHistory),
-        },
-      ];
+			const requestMessages = [
+				...messages.map((message) => ({
+					role: message.role,
+					content: message.content,
+				})),
+				{
+					role: "user" as const,
+					content: buildPromptWithContext(editorFilepath, editorContent, input, consoleHistory),
+				},
+			];
 
-      const requestId = createRequestId();
+			const requestId = createRequestId();
 
-      addAIMessage(userMessage);
-      startStreamingMessage(requestId, mode);
-      setAILoading(true);
-      setInput('');
+			addAIMessage(userMessage);
+			startStreamingMessage(requestId, mode);
+			setAILoading(true);
+			setInput("");
 
-      startTimeout(() => {
-        completeStreamingMessage(requestId, 'Request timed out. The AI service took too long to respond. Please try again.');
-        setAILoading(false);
-        clearActiveRequest();
-      }, STREAM_TIMEOUT_MS);
+			startTimeout(() => {
+				completeStreamingMessage(
+					requestId,
+					"Request timed out. The AI service took too long to respond. Please try again.",
+				);
+				setAILoading(false);
+				clearActiveRequest();
+			}, STREAM_TIMEOUT_MS);
 
-      const cleanup = registerStreamingHandlers(requestId, {
-        isRequestActive: () => activeRequestRef.current?.id === requestId,
-        onComplete: () => {
-          clearTimeoutRef();
-          clearActiveRequest({ dispose: false });
-        },
-        onStreamingProgress: clearTimeoutRef,
-      });
+			const cleanup = registerStreamingHandlers(requestId, {
+				isRequestActive: () => activeRequestRef.current?.id === requestId,
+				onComplete: () => {
+					clearTimeoutRef();
+					clearActiveRequest({ dispose: false });
+				},
+				onStreamingProgress: clearTimeoutRef,
+			});
 
-      const enableTools = mode === 'agent';
+			const enableTools = mode === "agent";
 
-      const sent = socketService.send({
-        type: 'ai_message',
-        request_id: requestId,
-        stream: true,
-        messages: requestMessages,
-        enable_tools: enableTools,
-        mode,
-      });
+			const sent = socketService.send({
+				type: "ai_message",
+				request_id: requestId,
+				stream: true,
+				messages: requestMessages,
+				enable_tools: enableTools,
+				mode,
+			});
 
-      if (!sent) {
-        cleanup();
-        clearTimeoutRef();
-        completeStreamingMessage(requestId, 'AI request failed: not connected to backend service.');
-        setAILoading(false);
-        return;
-      }
+			if (!sent) {
+				cleanup();
+				clearTimeoutRef();
+				completeStreamingMessage(requestId, "AI request failed: not connected to backend service.");
+				setAILoading(false);
+				return;
+			}
 
-      clearActiveRequest();
+			clearActiveRequest();
 
-      activeRequestRef.current = {
-        id: requestId,
-        dispose: cleanup,
-      };
-    },
-    [
-      addAIMessage,
-      clearActiveRequest,
-      clearTimeoutRef,
-      completeStreamingMessage,
-      consoleHistory,
-      editorContent,
-      editorFilepath,
-      input,
-      messages,
-      registerStreamingHandlers,
-      setAILoading,
-      startStreamingMessage,
-      startTimeout,
-    ],
-  );
+			activeRequestRef.current = {
+				id: requestId,
+				dispose: cleanup,
+			};
+		},
+		[
+			addAIMessage,
+			clearActiveRequest,
+			clearTimeoutRef,
+			completeStreamingMessage,
+			consoleHistory,
+			editorContent,
+			editorFilepath,
+			input,
+			messages,
+			registerStreamingHandlers,
+			setAILoading,
+			startStreamingMessage,
+			startTimeout,
+		],
+	);
 
-  return {
-    input,
-    setInput,
-    messages,
-    isLoading,
-    handleAsk,
-    handleStop,
-    handleApplyCode,
-  };
+	return {
+		input,
+		setInput,
+		messages,
+		isLoading,
+		handleAsk,
+		handleStop,
+		handleApplyCode,
+	};
 }

--- a/client/src/hooks/useAIStreaming.ts
+++ b/client/src/hooks/useAIStreaming.ts
@@ -1,153 +1,167 @@
-import { useCallback } from 'react';
-import { useStore } from '@/core';
-import { socketService } from '@/services/socket';
-import { extractCodeBlocks } from '@/core/ai/codeBlockUtils';
-import type { CodeBlock } from '@shared/types';
+import type { CodeBlock } from "@shared/types";
+import { useCallback } from "react";
+import { useStore } from "@/core";
+import { extractCodeBlocks } from "@/core/ai/codeBlockUtils";
+import { socketService } from "@/services/socket";
 
 type RegisterStreamingHandlersOptions = {
-  isRequestActive?: () => boolean;
-  onComplete?: (requestId: string) => void;
-  onStreamingProgress?: () => void;
+	isRequestActive?: () => boolean;
+	onComplete?: (requestId: string) => void;
+	onStreamingProgress?: () => void;
 };
 
 export function useAIStreaming() {
-  const appendStreamingChunk = useStore((state) => state.appendStreamingChunk);
-  const updateStreamingPlan = useStore((state) => state.updateStreamingPlan);
-  const recordToolEvent = useStore((state) => state.recordToolEvent);
-  const completeStreamingMessage = useStore((state) => state.completeStreamingMessage);
-  const setAILoading = useStore((state) => state.setAILoading);
+	const appendStreamingChunk = useStore((state) => state.appendStreamingChunk);
+	const updateStreamingPlan = useStore((state) => state.updateStreamingPlan);
+	const recordToolEvent = useStore((state) => state.recordToolEvent);
+	const completeStreamingMessage = useStore((state) => state.completeStreamingMessage);
+	const setAILoading = useStore((state) => state.setAILoading);
 
-  const registerStreamingHandlers = useCallback(
-    (requestId: string, options: RegisterStreamingHandlersOptions = {}) => {
-      const { isRequestActive, onComplete, onStreamingProgress } = options;
-      const disposers: Array<() => void> = [];
-      let disposed = false;
+	const registerStreamingHandlers = useCallback(
+		(requestId: string, options: RegisterStreamingHandlersOptions = {}) => {
+			const { isRequestActive, onComplete, onStreamingProgress } = options;
+			const disposers: Array<() => void> = [];
+			let disposed = false;
 
-      const cleanup = () => {
-        if (disposed) {
-          return;
-        }
-        disposed = true;
-        disposers.forEach((dispose) => {
-          try {
-            dispose();
-          } catch (error) {
-            console.error('Failed to cleanup WebSocket listener', error);
-          }
-        });
-      };
+			const cleanup = () => {
+				if (disposed) {
+					return;
+				}
+				disposed = true;
+				disposers.forEach((dispose) => {
+					try {
+						dispose();
+					} catch (error) {
+						console.error("Failed to cleanup WebSocket listener", error);
+					}
+				});
+			};
 
-      const finalize = (finalContent: string, extras?: { codeBlocks?: CodeBlock[] }) => {
-        completeStreamingMessage(requestId, finalContent, extras);
-        setAILoading(false);
-        cleanup();
-        onComplete?.(requestId);
-      };
+			const finalize = (finalContent: string, extras?: { codeBlocks?: CodeBlock[] }) => {
+				completeStreamingMessage(requestId, finalContent, extras);
+				setAILoading(false);
+				cleanup();
+				onComplete?.(requestId);
+			};
 
-      const shouldProcess = (messageId?: string) => {
-        if (messageId && messageId !== requestId) {
-          return false;
-        }
-        if (isRequestActive && !isRequestActive()) {
-          return false;
-        }
-        return true;
-      };
+			const shouldProcess = (messageId?: string) => {
+				if (messageId && messageId !== requestId) {
+					return false;
+				}
+				if (isRequestActive && !isRequestActive()) {
+					return false;
+				}
+				return true;
+			};
 
-      disposers.push(
-        socketService.on('ai_response_chunk', (message) => {
-        if (message.type !== 'ai_response_chunk' || !shouldProcess(message.id)) {
-          return;
-        }
-        onStreamingProgress?.();
-          appendStreamingChunk(requestId, message.chunk);
-        }),
-      );
+			disposers.push(
+				socketService.on("ai_response_chunk", (message) => {
+					if (message.type !== "ai_response_chunk" || !shouldProcess(message.id)) {
+						return;
+					}
+					onStreamingProgress?.();
+					appendStreamingChunk(requestId, message.chunk);
+				}),
+			);
 
-      disposers.push(
-        socketService.on('ai_plan_updated', (message) => {
-        if (message.type !== 'ai_plan_updated' || !shouldProcess(message.id)) {
-          return;
-        }
-        updateStreamingPlan(requestId, message.plan);
-        }),
-      );
+			disposers.push(
+				socketService.on("ai_plan_updated", (message) => {
+					if (message.type !== "ai_plan_updated" || !shouldProcess(message.id)) {
+						return;
+					}
+					updateStreamingPlan(requestId, message.plan);
+				}),
+			);
 
-      disposers.push(
-        socketService.on('ai_tool_started', (message) => {
-        if (message.type !== 'ai_tool_started' || !shouldProcess(message.id)) {
-          return;
-        }
-        recordToolEvent(requestId, message.tool);
-        }),
-      );
+			disposers.push(
+				socketService.on("ai_tool_started", (message) => {
+					if (message.type !== "ai_tool_started" || !shouldProcess(message.id)) {
+						return;
+					}
+					recordToolEvent(requestId, message.tool);
+				}),
+			);
 
-      disposers.push(
-        socketService.on('ai_tool_finished', (message) => {
-        if (message.type !== 'ai_tool_finished' || !shouldProcess(message.id)) {
-          return;
-        }
-        recordToolEvent(requestId, message.tool);
-        }),
-      );
+			disposers.push(
+				socketService.on("ai_tool_finished", (message) => {
+					if (message.type !== "ai_tool_finished" || !shouldProcess(message.id)) {
+						return;
+					}
+					recordToolEvent(requestId, message.tool);
+				}),
+			);
 
-      disposers.push(
-        socketService.on('ai_response_complete', (message) => {
-        if (message.type !== 'ai_response_complete' || !shouldProcess(message.id)) {
-          return;
-        }
-        const codeBlocks = message.codeBlocks ?? extractCodeBlocks(message.final);
-          finalize(message.final, { codeBlocks });
-        }),
-      );
+			disposers.push(
+				socketService.on("ai_response_complete", (message) => {
+					if (message.type !== "ai_response_complete" || !shouldProcess(message.id)) {
+						return;
+					}
+					const codeBlocks = message.codeBlocks ?? extractCodeBlocks(message.final);
+					finalize(message.final, { codeBlocks });
+				}),
+			);
 
-      disposers.push(
-        socketService.on('ai_response', (message) => {
-        if (message.type !== 'ai_response' || !shouldProcess()) {
-          return;
-        }
-        const codeBlocks = extractCodeBlocks(message.response);
-          finalize(message.response, { codeBlocks });
-        }),
-      );
+			disposers.push(
+				socketService.on("ai_response", (message) => {
+					if (message.type !== "ai_response" || !shouldProcess()) {
+						return;
+					}
+					const codeBlocks = extractCodeBlocks(message.response);
+					finalize(message.response, { codeBlocks });
+				}),
+			);
 
-      disposers.push(
-        socketService.on('ai_response_with_tools', (message) => {
-        if (message.type !== 'ai_response_with_tools' || !shouldProcess()) {
-          return;
-        }
+			disposers.push(
+				socketService.on("ai_response_with_tools", (message) => {
+					if (message.type !== "ai_response_with_tools" || !shouldProcess()) {
+						return;
+					}
 
-          let content: string | undefined;
-          if (typeof message.response === 'string') {
-            content = message.response;
-          } else if (typeof message.response?.content === 'string' && message.response.content.length) {
-            content = message.response.content;
-          } else if (Array.isArray(message.response?.tool_calls) && message.response.tool_calls.length > 0) {
-            content = message.response.tool_calls
-              .map((call, index) => `${index + 1}. ${call.name}\nInput: ${JSON.stringify(call.input)}`)
-              .join('\n\n');
-          }
+					let content: string | undefined;
+					if (typeof message.response === "string") {
+						content = message.response;
+					} else if (
+						typeof message.response?.content === "string" &&
+						message.response.content.length
+					) {
+						content = message.response.content;
+					} else if (
+						Array.isArray(message.response?.tool_calls) &&
+						message.response.tool_calls.length > 0
+					) {
+						content = message.response.tool_calls
+							.map(
+								(call, index) => `${index + 1}. ${call.name}\nInput: ${JSON.stringify(call.input)}`,
+							)
+							.join("\n\n");
+					}
 
-          const codeBlocks = extractCodeBlocks(content ?? '');
-          finalize(content ?? 'AI response received (no content)', {
-            codeBlocks,
-          });
-        }),
-      );
+					const codeBlocks = extractCodeBlocks(content ?? "");
+					finalize(content ?? "AI response received (no content)", {
+						codeBlocks,
+					});
+				}),
+			);
 
-      disposers.push(
-        socketService.on('error', (message) => {
-          if (message.type !== 'error' || !shouldProcess()) {
-            return;
-          }
-          finalize(`AI request failed: ${message.message}`);
-        }),
-      );
+			disposers.push(
+				socketService.on("error", (message) => {
+					if (message.type !== "error" || !shouldProcess()) {
+						return;
+					}
+					finalize(`AI request failed: ${message.message}`);
+				}),
+			);
 
-      return cleanup;
-    },
-    [appendStreamingChunk, completeStreamingMessage, recordToolEvent, setAILoading, updateStreamingPlan],
-  );
+			return cleanup;
+		},
+		[
+			appendStreamingChunk,
+			completeStreamingMessage,
+			recordToolEvent,
+			setAILoading,
+			updateStreamingPlan,
+		],
+	);
 
-  return { registerStreamingHandlers };
+	return { registerStreamingHandlers };
 }

--- a/client/src/hooks/useAITimeout.ts
+++ b/client/src/hooks/useAITimeout.ts
@@ -1,29 +1,29 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from "react";
 
 export function useAITimeout() {
-  const timeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const timeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const clearTimeoutRef = useCallback(() => {
-    if (timeoutIdRef.current) {
-      clearTimeout(timeoutIdRef.current);
-      timeoutIdRef.current = null;
-    }
-  }, []);
+	const clearTimeoutRef = useCallback(() => {
+		if (timeoutIdRef.current) {
+			clearTimeout(timeoutIdRef.current);
+			timeoutIdRef.current = null;
+		}
+	}, []);
 
-  const startTimeout = useCallback(
-    (callback: () => void, delay: number) => {
-      clearTimeoutRef();
-      timeoutIdRef.current = setTimeout(callback, delay);
-    },
-    [clearTimeoutRef],
-  );
+	const startTimeout = useCallback(
+		(callback: () => void, delay: number) => {
+			clearTimeoutRef();
+			timeoutIdRef.current = setTimeout(callback, delay);
+		},
+		[clearTimeoutRef],
+	);
 
-  useEffect(
-    () => () => {
-      clearTimeoutRef();
-    },
-    [clearTimeoutRef],
-  );
+	useEffect(
+		() => () => {
+			clearTimeoutRef();
+		},
+		[clearTimeoutRef],
+	);
 
-  return { clearTimeoutRef, startTimeout };
+	return { clearTimeoutRef, startTimeout };
 }

--- a/client/src/hooks/useBottomPaneState.ts
+++ b/client/src/hooks/useBottomPaneState.ts
@@ -1,128 +1,126 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useStore } from '@/core';
-import type { PanelTabItem } from '@/components/shared';
+import type { ExecutionLogPlot } from "@shared/types";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { PanelTabItem } from "@/components/shared";
+import { useStore } from "@/core";
 import type {
-  BottomPanePlotTab,
-  BottomPaneTab,
-  PlotFocusCustomEvent,
-  PlotNavigationState,
-} from '@/types/panels';
-import type { ExecutionLogPlot } from '@shared/types';
+	BottomPanePlotTab,
+	BottomPaneTab,
+	PlotFocusCustomEvent,
+	PlotNavigationState,
+} from "@/types/panels";
 
 interface UseBottomPaneStateResult {
-  tabs: PanelTabItem<BottomPaneTab>[];
-  activeTab: BottomPaneTab;
-  setActiveTab: (tab: BottomPaneTab) => void;
-  navigation: PlotNavigationState;
-  allPlots: ExecutionLogPlot[];
-  currentPlot: ExecutionLogPlot | null;
-  selectPreviousPlot: () => void;
-  selectNextPlot: () => void;
-  clearExecutionResults: () => void;
+	tabs: PanelTabItem<BottomPaneTab>[];
+	activeTab: BottomPaneTab;
+	setActiveTab: (tab: BottomPaneTab) => void;
+	navigation: PlotNavigationState;
+	allPlots: ExecutionLogPlot[];
+	currentPlot: ExecutionLogPlot | null;
+	selectPreviousPlot: () => void;
+	selectNextPlot: () => void;
+	clearExecutionResults: () => void;
 }
 
-const DEFAULT_TAB: BottomPaneTab = 'console';
-const TERMINAL_FOCUS_EVENT = 'terminal:focus';
+const DEFAULT_TAB: BottomPaneTab = "console";
+const TERMINAL_FOCUS_EVENT = "terminal:focus";
 
 export function useBottomPaneState(): UseBottomPaneStateResult {
-  const execution = useStore((state) => state.execution);
-  const clearExecutionResults = useStore((state) => state.clearExecutionResults);
+	const execution = useStore((state) => state.execution);
+	const clearExecutionResults = useStore((state) => state.clearExecutionResults);
 
-  const [activeTab, setActiveTab] = useState<BottomPaneTab>(DEFAULT_TAB);
-  const [selectedPlotIndex, setSelectedPlotIndex] = useState(0);
-  const previousPlotCount = useRef(0);
+	const [activeTab, setActiveTab] = useState<BottomPaneTab>(DEFAULT_TAB);
+	const [selectedPlotIndex, setSelectedPlotIndex] = useState(0);
+	const previousPlotCount = useRef(0);
 
-  const allPlots = useMemo<ExecutionLogPlot[]>(
-    () => execution.results.flatMap((result) => result.plots),
-    [execution.results]
-  );
+	const allPlots = useMemo<ExecutionLogPlot[]>(
+		() => execution.results.flatMap((result) => result.plots),
+		[execution.results],
+	);
 
-  const currentPlot = allPlots[selectedPlotIndex] ?? null;
+	const currentPlot = allPlots[selectedPlotIndex] ?? null;
 
-  const tabs = useMemo<PanelTabItem<BottomPaneTab>[]>(() => {
-    const list: PanelTabItem<BottomPaneTab>[] = [
-      { id: 'console', label: 'Console' },
-      { id: 'history', label: 'History' },
-      { id: 'terminal', label: 'Terminal' },
-      { id: 'plots', label: 'Plots' },
-    ];
-    list.push({ id: 'help', label: 'Help' });
-    return list;
-  }, []);
+	const tabs = useMemo<PanelTabItem<BottomPaneTab>[]>(() => {
+		const list: PanelTabItem<BottomPaneTab>[] = [
+			{ id: "console", label: "Console" },
+			{ id: "history", label: "History" },
+			{ id: "terminal", label: "Terminal" },
+			{ id: "plots", label: "Plots" },
+		];
+		list.push({ id: "help", label: "Help" });
+		return list;
+	}, []);
 
-  useEffect(() => {
-    const handleFocusPlot = (event: Event) => {
-      const detail = (event as PlotFocusCustomEvent).detail;
-      if (typeof detail?.plotIndex !== 'number') {
-        return;
-      }
+	useEffect(() => {
+		const handleFocusPlot = (event: Event) => {
+			const detail = (event as PlotFocusCustomEvent).detail;
+			if (typeof detail?.plotIndex !== "number") {
+				return;
+			}
 
-      setActiveTab('plots');
-      setSelectedPlotIndex(Math.max(0, Math.min(detail.plotIndex, allPlots.length - 1)));
-    };
+			setActiveTab("plots");
+			setSelectedPlotIndex(Math.max(0, Math.min(detail.plotIndex, allPlots.length - 1)));
+		};
 
-    window.addEventListener('focusPlot', handleFocusPlot);
-    return () => {
-      window.removeEventListener('focusPlot', handleFocusPlot);
-    };
-  }, [allPlots.length]);
+		window.addEventListener("focusPlot", handleFocusPlot);
+		return () => {
+			window.removeEventListener("focusPlot", handleFocusPlot);
+		};
+	}, [allPlots.length]);
 
-  useEffect(() => {
-    const previousCount = previousPlotCount.current;
-    if (allPlots.length > previousCount) {
-      setActiveTab('plots');
-      setSelectedPlotIndex(allPlots.length - 1);
-    }
-    previousPlotCount.current = allPlots.length;
-  }, [allPlots.length]);
+	useEffect(() => {
+		const previousCount = previousPlotCount.current;
+		if (allPlots.length > previousCount) {
+			setActiveTab("plots");
+			setSelectedPlotIndex(allPlots.length - 1);
+		}
+		previousPlotCount.current = allPlots.length;
+	}, [allPlots.length]);
 
-  useEffect(() => {
-    if (selectedPlotIndex >= allPlots.length && allPlots.length > 0) {
-      setSelectedPlotIndex(allPlots.length - 1);
-    }
-  }, [allPlots.length, selectedPlotIndex]);
+	useEffect(() => {
+		if (selectedPlotIndex >= allPlots.length && allPlots.length > 0) {
+			setSelectedPlotIndex(allPlots.length - 1);
+		}
+	}, [allPlots.length, selectedPlotIndex]);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
+	useEffect(() => {
+		if (typeof window === "undefined") {
+			return;
+		}
 
-    const handleFocus = () => {
-      setActiveTab('terminal');
-    };
+		const handleFocus = () => {
+			setActiveTab("terminal");
+		};
 
-    window.addEventListener(TERMINAL_FOCUS_EVENT, handleFocus);
-    return () => {
-      window.removeEventListener(TERMINAL_FOCUS_EVENT, handleFocus);
-    };
-  }, []);
+		window.addEventListener(TERMINAL_FOCUS_EVENT, handleFocus);
+		return () => {
+			window.removeEventListener(TERMINAL_FOCUS_EVENT, handleFocus);
+		};
+	}, []);
 
-  const selectPreviousPlot = useCallback(() => {
-    setSelectedPlotIndex((current) => Math.max(0, current - 1));
-  }, []);
+	const selectPreviousPlot = useCallback(() => {
+		setSelectedPlotIndex((current) => Math.max(0, current - 1));
+	}, []);
 
-  const selectNextPlot = useCallback(() => {
-    setSelectedPlotIndex((current) => Math.min(allPlots.length - 1, current + 1));
-  }, [allPlots.length]);
+	const selectNextPlot = useCallback(() => {
+		setSelectedPlotIndex((current) => Math.min(allPlots.length - 1, current + 1));
+	}, [allPlots.length]);
 
-  const navigation: PlotNavigationState = {
-    activeTab:
-      activeTab === 'plots' || activeTab === 'help'
-        ? (activeTab as BottomPanePlotTab)
-        : 'help',
-    selectedPlotIndex,
-    totalPlots: allPlots.length,
-  };
+	const navigation: PlotNavigationState = {
+		activeTab:
+			activeTab === "plots" || activeTab === "help" ? (activeTab as BottomPanePlotTab) : "help",
+		selectedPlotIndex,
+		totalPlots: allPlots.length,
+	};
 
-  return {
-    tabs,
-    activeTab,
-    setActiveTab,
-    navigation,
-    allPlots,
-    currentPlot,
-    selectPreviousPlot,
-    selectNextPlot,
-    clearExecutionResults,
-  };
+	return {
+		tabs,
+		activeTab,
+		setActiveTab,
+		navigation,
+		allPlots,
+		currentPlot,
+		selectPreviousPlot,
+		selectNextPlot,
+		clearExecutionResults,
+	};
 }

--- a/client/src/hooks/useConfirmDialog.ts
+++ b/client/src/hooks/useConfirmDialog.ts
@@ -1,66 +1,63 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useState } from "react";
 
 interface ConfirmDialogState {
-  open: boolean;
-  title: string;
-  message: string;
-  onConfirm: () => void;
+	open: boolean;
+	title: string;
+	message: string;
+	onConfirm: () => void;
 }
 
 interface UseConfirmDialogReturn {
-  dialogState: ConfirmDialogState;
-  showConfirm: (title: string, message: string) => Promise<boolean>;
-  handleConfirm: () => void;
-  handleCancel: () => void;
+	dialogState: ConfirmDialogState;
+	showConfirm: (title: string, message: string) => Promise<boolean>;
+	handleConfirm: () => void;
+	handleCancel: () => void;
 }
 
 export function useConfirmDialog(): UseConfirmDialogReturn {
-  const [dialogState, setDialogState] = useState<ConfirmDialogState>({
-    open: false,
-    title: '',
-    message: '',
-    onConfirm: () => {},
-  });
+	const [dialogState, setDialogState] = useState<ConfirmDialogState>({
+		open: false,
+		title: "",
+		message: "",
+		onConfirm: () => {},
+	});
 
-  const showConfirm = useCallback(
-    (title: string, message: string): Promise<boolean> => {
-      return new Promise((resolve) => {
-        setDialogState({
-          open: true,
-          title,
-          message,
-          onConfirm: () => {
-            setDialogState((prev) => ({ ...prev, open: false }));
-            resolve(true);
-          },
-        });
+	const showConfirm = useCallback((title: string, message: string): Promise<boolean> => {
+		return new Promise((resolve) => {
+			setDialogState({
+				open: true,
+				title,
+				message,
+				onConfirm: () => {
+					setDialogState((prev) => ({ ...prev, open: false }));
+					resolve(true);
+				},
+			});
 
-        // Store the reject callback to call on cancel
-        (setDialogState as any)._reject = () => {
-          setDialogState((prev) => ({ ...prev, open: false }));
-          resolve(false);
-        };
-      });
-    },
-    []
-  );
+			// Store the reject callback to call on cancel
+			(setDialogState as any)._reject = () => {
+				setDialogState((prev) => ({ ...prev, open: false }));
+				resolve(false);
+			};
+		});
+	}, []);
 
-  const handleConfirm = useCallback(() => {
-    dialogState.onConfirm();
-  }, [dialogState]);
+	const handleConfirm = useCallback(() => {
+		dialogState.onConfirm();
+	}, [dialogState]);
 
-  const handleCancel = useCallback(() => {
-    setDialogState((prev) => ({ ...prev, open: false }));
-    if ((setDialogState as any)._reject) {
-      (setDialogState as any)._reject();
-      delete (setDialogState as any)._reject;
-    }
-  }, []);
+	const handleCancel = useCallback(() => {
+		setDialogState((prev) => ({ ...prev, open: false }));
+		if ((setDialogState as any)._reject) {
+			(setDialogState as any)._reject();
+			delete (setDialogState as any)._reject;
+		}
+	}, []);
 
-  return {
-    dialogState,
-    showConfirm,
-    handleConfirm,
-    handleCancel,
-  };
+	return {
+		dialogState,
+		showConfirm,
+		handleConfirm,
+		handleCancel,
+	};
 }

--- a/client/src/hooks/useConsolePanelState.ts
+++ b/client/src/hooks/useConsolePanelState.ts
@@ -1,24 +1,24 @@
-import { type RefObject, useEffect, useRef } from 'react';
-import { useStore, type StoreState } from '@/core';
+import { type RefObject, useEffect, useRef } from "react";
+import { type StoreState, useStore } from "@/core";
 
 interface UseConsolePanelStateResult {
-  execution: StoreState['execution'];
-  consoleEndRef: RefObject<HTMLDivElement>;
-  clearExecutionResults: () => void;
+	execution: StoreState["execution"];
+	consoleEndRef: RefObject<HTMLDivElement>;
+	clearExecutionResults: () => void;
 }
 
 export function useConsolePanelState(): UseConsolePanelStateResult {
-  const execution = useStore((state) => state.execution);
-  const clearExecutionResults = useStore((state) => state.clearExecutionResults);
-  const consoleEndRef = useRef<HTMLDivElement>(null);
+	const execution = useStore((state) => state.execution);
+	const clearExecutionResults = useStore((state) => state.clearExecutionResults);
+	const consoleEndRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    consoleEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [execution.results]);
+	useEffect(() => {
+		consoleEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [execution.results]);
 
-  return {
-    execution,
-    consoleEndRef,
-    clearExecutionResults,
-  };
+	return {
+		execution,
+		consoleEndRef,
+		clearExecutionResults,
+	};
 }

--- a/client/src/hooks/useEditorCells.ts
+++ b/client/src/hooks/useEditorCells.ts
@@ -1,14 +1,14 @@
-import { useEffect, useState } from 'react';
-import type { Cell } from '@/core/execution/cellParser';
-import { parseCells } from '@/core';
+import { useEffect, useState } from "react";
+import { parseCells } from "@/core";
+import type { Cell } from "@/core/execution/cellParser";
 
 export function useEditorCells(content: string, filepath?: string): Cell[] {
-  const [cells, setCells] = useState<Cell[]>([]);
+	const [cells, setCells] = useState<Cell[]>([]);
 
-  useEffect(() => {
-    const filename = filepath || 'Untitled.R';
-    setCells(parseCells(content, filename));
-  }, [content, filepath]);
+	useEffect(() => {
+		const filename = filepath || "Untitled.R";
+		setCells(parseCells(content, filename));
+	}, [content, filepath]);
 
-  return cells;
+	return cells;
 }

--- a/client/src/hooks/useEditorDecorations.ts
+++ b/client/src/hooks/useEditorDecorations.ts
@@ -1,78 +1,72 @@
-import { useEffect, useRef } from 'react';
-import type { MutableRefObject } from 'react';
-import type { editor as MonacoEditor } from 'monaco-editor';
-import type { Cell } from '@/core/execution/cellParser';
+import type { editor as MonacoEditor } from "monaco-editor";
+import type { MutableRefObject } from "react";
+import { useEffect, useRef } from "react";
+import type { Cell } from "@/core/execution/cellParser";
 
 interface UseEditorDecorationsOptions {
-  showCellDecorations: boolean;
-  highlightExecutingCell: boolean;
-  executingCellIndex: number | null;
+	showCellDecorations: boolean;
+	highlightExecutingCell: boolean;
+	executingCellIndex: number | null;
 }
 
 export function useEditorDecorations(
-  editorRef: MutableRefObject<MonacoEditor.IStandaloneCodeEditor | null>,
-  cells: Cell[],
-  options: UseEditorDecorationsOptions,
+	editorRef: MutableRefObject<MonacoEditor.IStandaloneCodeEditor | null>,
+	cells: Cell[],
+	options: UseEditorDecorationsOptions,
 ) {
-  const { showCellDecorations, highlightExecutingCell, executingCellIndex } = options;
-  const decorationsRef = useRef<string[]>([]);
+	const { showCellDecorations, highlightExecutingCell, executingCellIndex } = options;
+	const decorationsRef = useRef<string[]>([]);
 
-  useEffect(() => {
-    const monacoEditor = editorRef.current;
-    if (!monacoEditor) {
-      return;
-    }
+	useEffect(() => {
+		const monacoEditor = editorRef.current;
+		if (!monacoEditor) {
+			return;
+		}
 
-    decorationsRef.current = monacoEditor.deltaDecorations(decorationsRef.current, []);
+		decorationsRef.current = monacoEditor.deltaDecorations(decorationsRef.current, []);
 
-    if (!showCellDecorations) {
-      return;
-    }
+		if (!showCellDecorations) {
+			return;
+		}
 
-    const newDecorations: MonacoEditor.IModelDeltaDecoration[] = [];
+		const newDecorations: MonacoEditor.IModelDeltaDecoration[] = [];
 
-    cells.forEach((cell, index) => {
-      if (cell.startLine > 1) {
-        newDecorations.push({
-          range: {
-            startLineNumber: cell.startLine,
-            startColumn: 1,
-            endLineNumber: cell.startLine,
-            endColumn: 1,
-          },
-          options: {
-            isWholeLine: true,
-            linesDecorationsClassName: 'cell-boundary-decoration',
-            overviewRuler: {
-              color: '#4285f4',
-              position: 4,
-            },
-          },
-        });
-      }
+		cells.forEach((cell, index) => {
+			if (cell.startLine > 1) {
+				newDecorations.push({
+					range: {
+						startLineNumber: cell.startLine,
+						startColumn: 1,
+						endLineNumber: cell.startLine,
+						endColumn: 1,
+					},
+					options: {
+						isWholeLine: true,
+						linesDecorationsClassName: "cell-boundary-decoration",
+						overviewRuler: {
+							color: "#4285f4",
+							position: 4,
+						},
+					},
+				});
+			}
 
-      if (highlightExecutingCell && executingCellIndex === index) {
-        newDecorations.push({
-          range: {
-            startLineNumber: cell.startLine,
-            startColumn: 1,
-            endLineNumber: cell.endLine,
-            endColumn: 1,
-          },
-          options: {
-            isWholeLine: true,
-            className: 'executing-cell-background',
-          },
-        });
-      }
-    });
+			if (highlightExecutingCell && executingCellIndex === index) {
+				newDecorations.push({
+					range: {
+						startLineNumber: cell.startLine,
+						startColumn: 1,
+						endLineNumber: cell.endLine,
+						endColumn: 1,
+					},
+					options: {
+						isWholeLine: true,
+						className: "executing-cell-background",
+					},
+				});
+			}
+		});
 
-    decorationsRef.current = monacoEditor.deltaDecorations(decorationsRef.current, newDecorations);
-  }, [
-    cells,
-    editorRef,
-    executingCellIndex,
-    highlightExecutingCell,
-    showCellDecorations,
-  ]);
+		decorationsRef.current = monacoEditor.deltaDecorations(decorationsRef.current, newDecorations);
+	}, [cells, editorRef, executingCellIndex, highlightExecutingCell, showCellDecorations]);
 }

--- a/client/src/hooks/useEditorExecution.ts
+++ b/client/src/hooks/useEditorExecution.ts
@@ -1,131 +1,131 @@
-import { useCallback, useState } from 'react';
-import type { MutableRefObject } from 'react';
-import type { Cell } from '@/core/execution/cellParser';
-import type { ExecutionTarget } from '@/core';
+import type { ExecutionLogEntry, ExecutionResultPayload } from "@shared/types";
+import type { editor as MonacoEditor } from "monaco-editor";
+import type { MutableRefObject } from "react";
+import { useCallback, useState } from "react";
+import type { ExecutionTarget } from "@/core";
 import {
-  buildExecutionRequest,
-  getAllCode,
-  getExecutionTarget,
-  getExecutionTargetAndNext,
-} from '@/core';
-import { executeRequest, ExecutionServiceError } from '@/services/executionService';
-import { useStore } from '@/core';
-import type { editor as MonacoEditor } from 'monaco-editor';
-import type { ExecutionLogEntry, ExecutionResultPayload } from '@shared/types';
+	buildExecutionRequest,
+	getAllCode,
+	getExecutionTarget,
+	getExecutionTargetAndNext,
+	useStore,
+} from "@/core";
+import type { Cell } from "@/core/execution/cellParser";
+import { ExecutionServiceError, executeRequest } from "@/services/executionService";
 
 interface UseEditorExecutionProps {
-  editorRef: MutableRefObject<MonacoEditor.IStandaloneCodeEditor | null>;
-  cells: Cell[];
+	editorRef: MutableRefObject<MonacoEditor.IStandaloneCodeEditor | null>;
+	cells: Cell[];
 }
 
 const normalizeResult = (result: ExecutionResultPayload): ExecutionLogEntry => ({
-  stdout: result.output,
-  stderr: result.error || '',
-  plots: result.plots.map((plot) => ({
-    id: plot.filename || `plot-${plot.index}`,
-    path: plot.filename,
-    data: `data:image/png;base64,${plot.base64_data}`,
-    timestamp: Date.now(),
-  })),
-  timestamp: Date.now(),
-  duration: result.execution_time_ms,
-  success: result.success,
+	stdout: result.output,
+	stderr: result.error || "",
+	plots: result.plots.map((plot) => ({
+		id: plot.filename || `plot-${plot.index}`,
+		path: plot.filename,
+		data: `data:image/png;base64,${plot.base64_data}`,
+		timestamp: Date.now(),
+	})),
+	timestamp: Date.now(),
+	duration: result.execution_time_ms,
+	success: result.success,
 });
 
 const normalizeFailure = (message: string): ExecutionLogEntry => ({
-  stdout: '',
-  stderr: message,
-  plots: [],
-  timestamp: Date.now(),
-  duration: 0,
-  success: false,
+	stdout: "",
+	stderr: message,
+	plots: [],
+	timestamp: Date.now(),
+	duration: 0,
+	success: false,
 });
 
 export function useEditorExecution({ editorRef, cells }: UseEditorExecutionProps) {
-  const editorContent = useStore((state) => state.editor.content);
-  const editorFilepath = useStore((state) => state.editor.filepath);
-  const cursorLine = useStore((state) => state.editor.cursorPosition.line);
-  const setIsRunning = useStore((state) => state.setIsRunning);
-  const addExecutionResult = useStore((state) => state.addExecutionResult);
+	const editorContent = useStore((state) => state.editor.content);
+	const editorFilepath = useStore((state) => state.editor.filepath);
+	const cursorLine = useStore((state) => state.editor.cursorPosition.line);
+	const setIsRunning = useStore((state) => state.setIsRunning);
+	const addExecutionResult = useStore((state) => state.addExecutionResult);
 
-  const [executingCellIndex, setExecutingCellIndex] = useState<number | null>(null);
+	const [executingCellIndex, setExecutingCellIndex] = useState<number | null>(null);
 
-  const executeCode = useCallback(
-    async (target: ExecutionTarget, cellIndex?: number | null) => {
-      setIsRunning(true);
-      if (cellIndex !== undefined && cellIndex !== null) {
-        setExecutingCellIndex(cellIndex);
-      }
+	const executeCode = useCallback(
+		async (target: ExecutionTarget, cellIndex?: number | null) => {
+			setIsRunning(true);
+			if (cellIndex !== undefined && cellIndex !== null) {
+				setExecutingCellIndex(cellIndex);
+			}
 
-      const request = buildExecutionRequest({
-        target,
-        cells,
-        documentContent: editorContent,
-        filepath: editorFilepath ?? undefined,
-      });
+			const request = buildExecutionRequest({
+				target,
+				cells,
+				documentContent: editorContent,
+				filepath: editorFilepath ?? undefined,
+			});
 
-      try {
-        const { result } = await executeRequest(request);
-        addExecutionResult(normalizeResult(result));
-      } catch (error) {
-        const message =
-          error instanceof ExecutionServiceError
-            ? error.message
-            : 'Execution failed due to an unexpected error.';
-        addExecutionResult(normalizeFailure(message));
-      } finally {
-        setExecutingCellIndex(null);
-        setIsRunning(false);
-      }
-    },
-    [addExecutionResult, cells, editorContent, editorFilepath, setIsRunning],
-  );
+			try {
+				const { result } = await executeRequest(request);
+				addExecutionResult(normalizeResult(result));
+			} catch (error) {
+				const message =
+					error instanceof ExecutionServiceError
+						? error.message
+						: "Execution failed due to an unexpected error.";
+				addExecutionResult(normalizeFailure(message));
+			} finally {
+				setExecutingCellIndex(null);
+				setIsRunning(false);
+			}
+		},
+		[addExecutionResult, cells, editorContent, editorFilepath, setIsRunning],
+	);
 
-  const handleRunAll = useCallback(() => {
-    const monacoEditor = editorRef.current;
-    const code = getAllCode(monacoEditor);
-    if (!code) {
-      return;
-    }
+	const handleRunAll = useCallback(() => {
+		const monacoEditor = editorRef.current;
+		const code = getAllCode(monacoEditor);
+		if (!code) {
+			return;
+		}
 
-    void executeCode({
-      code,
-      source: 'whole-document',
-    });
-  }, [editorRef, executeCode]);
+		void executeCode({
+			code,
+			source: "whole-document",
+		});
+	}, [editorRef, executeCode]);
 
-  const handleRunCurrentCell = useCallback(() => {
-    const monacoEditor = editorRef.current;
-    const target = getExecutionTarget(monacoEditor, cells, cursorLine);
-    if (!target) {
-      return;
-    }
+	const handleRunCurrentCell = useCallback(() => {
+		const monacoEditor = editorRef.current;
+		const target = getExecutionTarget(monacoEditor, cells, cursorLine);
+		if (!target) {
+			return;
+		}
 
-    void executeCode(target, target.cellIndex);
-  }, [cells, cursorLine, editorRef, executeCode]);
+		void executeCode(target, target.cellIndex);
+	}, [cells, cursorLine, editorRef, executeCode]);
 
-  const handleRunCellAndMoveNext = useCallback(() => {
-    const monacoEditor = editorRef.current;
-    const result = getExecutionTargetAndNext(monacoEditor, cells, cursorLine);
-    if (!result) {
-      return;
-    }
+	const handleRunCellAndMoveNext = useCallback(() => {
+		const monacoEditor = editorRef.current;
+		const result = getExecutionTargetAndNext(monacoEditor, cells, cursorLine);
+		if (!result) {
+			return;
+		}
 
-    void executeCode(result.target, result.target.cellIndex);
+		void executeCode(result.target, result.target.cellIndex);
 
-    if (result.nextCell && monacoEditor) {
-      monacoEditor.setPosition({
-        lineNumber: result.nextCell.startLine,
-        column: 1,
-      });
-      monacoEditor.revealLineInCenter(result.nextCell.startLine);
-    }
-  }, [cells, cursorLine, editorRef, executeCode]);
+		if (result.nextCell && monacoEditor) {
+			monacoEditor.setPosition({
+				lineNumber: result.nextCell.startLine,
+				column: 1,
+			});
+			monacoEditor.revealLineInCenter(result.nextCell.startLine);
+		}
+	}, [cells, cursorLine, editorRef, executeCode]);
 
-  return {
-    executingCellIndex,
-    handleRunAll,
-    handleRunCurrentCell,
-    handleRunCellAndMoveNext,
-  };
+	return {
+		executingCellIndex,
+		handleRunAll,
+		handleRunCurrentCell,
+		handleRunCellAndMoveNext,
+	};
 }

--- a/client/src/hooks/useExportDialog.ts
+++ b/client/src/hooks/useExportDialog.ts
@@ -1,150 +1,156 @@
-import { useCallback, useEffect, useReducer } from 'react';
-import { exportRMarkdown, ExportServiceError } from '@/services/exportService';
+import { useCallback, useEffect, useReducer } from "react";
+import type { ExportRMarkdownRequestPayload } from "shared";
+import { ExportServiceError, exportRMarkdown } from "@/services/exportService";
 import type {
-  ExportDialogAction,
-  ExportDialogOptions,
-  ExportFormat,
-  ExportDialogState,
-  ExportOptionKey,
-} from '@/types/exportDialog';
-import { exportDialogInitialState } from '@/types/exportDialog';
-import type { ExportRMarkdownRequestPayload } from 'shared';
+	ExportDialogAction,
+	ExportDialogOptions,
+	ExportDialogState,
+	ExportFormat,
+	ExportOptionKey,
+} from "@/types/exportDialog";
+import { exportDialogInitialState } from "@/types/exportDialog";
 
 function reducer(state: ExportDialogState, action: ExportDialogAction): ExportDialogState {
-  switch (action.type) {
-    case 'set-format':
-      return { ...state, format: action.payload };
-    case 'set-mode':
-      return { ...state, mode: action.payload };
-    case 'set-option':
-      return {
-        ...state,
-        options: { ...state.options, [action.key]: action.value },
-      };
-    case 'set-document-path':
-      return { ...state, documentPath: action.payload };
-    case 'set-output-path':
-      return { ...state, outputPath: action.payload };
-    case 'set-exporting':
-      return { ...state, exporting: action.payload };
-    case 'set-error':
-      return { ...state, error: action.payload };
-    case 'reset':
-      return { ...exportDialogInitialState };
-    default:
-      return state;
-  }
+	switch (action.type) {
+		case "set-format":
+			return { ...state, format: action.payload };
+		case "set-mode":
+			return { ...state, mode: action.payload };
+		case "set-option":
+			return {
+				...state,
+				options: { ...state.options, [action.key]: action.value },
+			};
+		case "set-document-path":
+			return { ...state, documentPath: action.payload };
+		case "set-output-path":
+			return { ...state, outputPath: action.payload };
+		case "set-exporting":
+			return { ...state, exporting: action.payload };
+		case "set-error":
+			return { ...state, error: action.payload };
+		case "reset":
+			return { ...exportDialogInitialState };
+		default:
+			return state;
+	}
 }
 
 interface UseExportDialogReturn {
-  format: ExportFormat;
-  setFormat: (next: ExportFormat) => void;
-  mode: ExportRMarkdownRequestPayload['mode'];
-  setMode: (next: ExportRMarkdownRequestPayload['mode']) => void;
-  options: ExportDialogOptions;
-  setOption: (key: ExportOptionKey, value: boolean) => void;
-  documentPath: string;
-  setDocumentPath: (value: string) => void;
-  outputPath: string;
-  setOutputPath: (value: string) => void;
-  exporting: boolean;
-  error: string;
-  handleExport: () => Promise<void>;
+	format: ExportFormat;
+	setFormat: (next: ExportFormat) => void;
+	mode: ExportRMarkdownRequestPayload["mode"];
+	setMode: (next: ExportRMarkdownRequestPayload["mode"]) => void;
+	options: ExportDialogOptions;
+	setOption: (key: ExportOptionKey, value: boolean) => void;
+	documentPath: string;
+	setDocumentPath: (value: string) => void;
+	outputPath: string;
+	setOutputPath: (value: string) => void;
+	exporting: boolean;
+	error: string;
+	handleExport: () => Promise<void>;
 }
 
 interface UseExportDialogProps {
-  open: boolean;
-  onClose: () => void;
+	open: boolean;
+	onClose: () => void;
 }
 
 export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExportDialogReturn {
-  const [state, dispatch] = useReducer(reducer, exportDialogInitialState);
-  const { format, mode, options, documentPath, outputPath, exporting, error } = state;
+	const [state, dispatch] = useReducer(reducer, exportDialogInitialState);
+	const { format, mode, options, documentPath, outputPath, exporting, error } = state;
 
-  useEffect(() => {
-    if (!open) {
-      dispatch({ type: 'reset' });
-    }
-  }, [open]);
+	useEffect(() => {
+		if (!open) {
+			dispatch({ type: "reset" });
+		}
+	}, [open]);
 
-  useEffect(() => {
-    if (!open || exporting || typeof document === 'undefined') {
-      return undefined;
-    }
+	useEffect(() => {
+		if (!open || exporting || typeof document === "undefined") {
+			return undefined;
+		}
 
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && !exporting) {
-        onClose();
-      }
-    };
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape" && !exporting) {
+				onClose();
+			}
+		};
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [open, exporting, onClose]);
+		document.addEventListener("keydown", handleKeyDown);
+		return () => {
+			document.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [open, exporting, onClose]);
 
-  const setOption = useCallback((key: ExportOptionKey, value: boolean) => {
-    dispatch({ type: 'set-option', key, value });
-  }, []);
+	const setOption = useCallback((key: ExportOptionKey, value: boolean) => {
+		dispatch({ type: "set-option", key, value });
+	}, []);
 
-  const handleExport = useCallback(async (): Promise<void> => {
-    dispatch({ type: 'set-exporting', payload: true });
-    dispatch({ type: 'set-error', payload: '' });
+	const handleExport = useCallback(async (): Promise<void> => {
+		dispatch({ type: "set-exporting", payload: true });
+		dispatch({ type: "set-error", payload: "" });
 
-    if (format === 'bundle') {
-      dispatch({ type: 'set-error', payload: 'Bundle export is not supported yet.' });
-      dispatch({ type: 'set-exporting', payload: false });
-      return;
-    }
+		if (format === "bundle") {
+			dispatch({
+				type: "set-error",
+				payload: "Bundle export is not supported yet.",
+			});
+			dispatch({ type: "set-exporting", payload: false });
+			return;
+		}
 
-    const trimmedDocumentPath = documentPath.trim();
+		const trimmedDocumentPath = documentPath.trim();
 
-    if (mode === 'document' && !trimmedDocumentPath) {
-      dispatch({ type: 'set-error', payload: 'Document path is required for document-based export' });
-      dispatch({ type: 'set-exporting', payload: false });
-      return;
-    }
+		if (mode === "document" && !trimmedDocumentPath) {
+			dispatch({
+				type: "set-error",
+				payload: "Document path is required for document-based export",
+			});
+			dispatch({ type: "set-exporting", payload: false });
+			return;
+		}
 
-    const payload: ExportRMarkdownRequestPayload = {
-      mode,
-      outputPath,
-      documentPath: mode === 'document' ? trimmedDocumentPath : undefined,
-      includeTimestamps: options.includeTimestamps,
-      showActor: options.showActor,
-      embedPlots: options.embedPlots,
-      includeOutputs: options.includeOutputs,
-      includeErrors: options.includeErrors,
-      includeSummary: options.includeSummary,
-    };
+		const payload: ExportRMarkdownRequestPayload = {
+			mode,
+			outputPath,
+			documentPath: mode === "document" ? trimmedDocumentPath : undefined,
+			includeTimestamps: options.includeTimestamps,
+			showActor: options.showActor,
+			embedPlots: options.embedPlots,
+			includeOutputs: options.includeOutputs,
+			includeErrors: options.includeErrors,
+			includeSummary: options.includeSummary,
+		};
 
-    try {
-      await exportRMarkdown(payload);
-      onClose();
-    } catch (err) {
-      if (err instanceof ExportServiceError || err instanceof Error) {
-        dispatch({ type: 'set-error', payload: err.message });
-      } else {
-        dispatch({ type: 'set-error', payload: 'Export failed' });
-      }
-    } finally {
-      dispatch({ type: 'set-exporting', payload: false });
-    }
-  }, [format, mode, options, documentPath, outputPath, onClose]);
+		try {
+			await exportRMarkdown(payload);
+			onClose();
+		} catch (err) {
+			if (err instanceof ExportServiceError || err instanceof Error) {
+				dispatch({ type: "set-error", payload: err.message });
+			} else {
+				dispatch({ type: "set-error", payload: "Export failed" });
+			}
+		} finally {
+			dispatch({ type: "set-exporting", payload: false });
+		}
+	}, [format, mode, options, documentPath, outputPath, onClose]);
 
-  return {
-    format,
-    setFormat: (next) => dispatch({ type: 'set-format', payload: next }),
-    mode,
-    setMode: (next) => dispatch({ type: 'set-mode', payload: next }),
-    options,
-    setOption,
-    documentPath,
-    setDocumentPath: (value) => dispatch({ type: 'set-document-path', payload: value }),
-    outputPath,
-    setOutputPath: (value) => dispatch({ type: 'set-output-path', payload: value }),
-    exporting,
-    error,
-    handleExport,
-  };
+	return {
+		format,
+		setFormat: (next) => dispatch({ type: "set-format", payload: next }),
+		mode,
+		setMode: (next) => dispatch({ type: "set-mode", payload: next }),
+		options,
+		setOption,
+		documentPath,
+		setDocumentPath: (value) => dispatch({ type: "set-document-path", payload: value }),
+		outputPath,
+		setOutputPath: (value) => dispatch({ type: "set-output-path", payload: value }),
+		exporting,
+		error,
+		handleExport,
+	};
 }

--- a/client/src/hooks/useFileSystemData.ts
+++ b/client/src/hooks/useFileSystemData.ts
@@ -1,37 +1,37 @@
-import { useEffect } from 'react';
-import type { ExtractServerMessage } from 'shared';
-import { socketService } from '@/services/socket';
-import { useFileSystemStore } from '@/core/fileSystemStore';
+import { useEffect } from "react";
+import type { ExtractServerMessage } from "shared";
+import { useFileSystemStore } from "@/core/fileSystemStore";
+import { socketService } from "@/services/socket";
 
 export function useFileSystemData(): void {
-  const loadRoot = useFileSystemStore((state) => state.loadRoot);
-  const handleFsEvent = useFileSystemStore((state) => state.handleFsEvent);
+	const loadRoot = useFileSystemStore((state) => state.loadRoot);
+	const handleFsEvent = useFileSystemStore((state) => state.handleFsEvent);
 
-  useEffect(() => {
-    const triggerLoad = (): void => {
-      loadRoot().catch((error) => {
-        console.error('Failed to load workspace tree', error);
-      });
-    };
+	useEffect(() => {
+		const triggerLoad = (): void => {
+			loadRoot().catch((error) => {
+				console.error("Failed to load workspace tree", error);
+			});
+		};
 
-    if (socketService.isConnected()) {
-      triggerLoad();
-    }
+		if (socketService.isConnected()) {
+			triggerLoad();
+		}
 
-    const unsubscribeConnection = socketService.onConnectionChange((status) => {
-      if (status === 'connected') {
-        triggerLoad();
-      }
-    });
+		const unsubscribeConnection = socketService.onConnectionChange((status) => {
+			if (status === "connected") {
+				triggerLoad();
+			}
+		});
 
-    const unsubscribeFsEvent = socketService.on('fs_event', (message) => {
-      const fsMessage = message as ExtractServerMessage<'fs_event'>;
-      handleFsEvent(fsMessage.event);
-    });
+		const unsubscribeFsEvent = socketService.on("fs_event", (message) => {
+			const fsMessage = message as ExtractServerMessage<"fs_event">;
+			handleFsEvent(fsMessage.event);
+		});
 
-    return () => {
-      unsubscribeConnection();
-      unsubscribeFsEvent();
-    };
-  }, [loadRoot, handleFsEvent]);
+		return () => {
+			unsubscribeConnection();
+			unsubscribeFsEvent();
+		};
+	}, [loadRoot, handleFsEvent]);
 }

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -5,129 +5,129 @@
  * Handles platform differences (Mac vs Windows/Linux) and conflicts.
  */
 
-import { useEffect } from 'react';
-import { menuActions } from '@/services/menuActions';
+import { useEffect } from "react";
+import { menuActions } from "@/services/menuActions";
 
 /**
  * Normalize keyboard event to shortcut string
  * Uses "Mod" for cross-platform Cmd/Ctrl
  */
 function eventToShortcut(e: KeyboardEvent): string {
-  const parts: string[] = [];
+	const parts: string[] = [];
 
-  // Use "Mod" for cross-platform Cmd/Ctrl
-  if (e.ctrlKey || e.metaKey) parts.push('Mod');
-  if (e.shiftKey) parts.push('Shift');
-  if (e.altKey) parts.push('Alt');
+	// Use "Mod" for cross-platform Cmd/Ctrl
+	if (e.ctrlKey || e.metaKey) parts.push("Mod");
+	if (e.shiftKey) parts.push("Shift");
+	if (e.altKey) parts.push("Alt");
 
-  // Normalize key names
-  let key = e.key;
-  if (key === 'Enter') key = 'Enter';
-  else if (key === 'Escape') key = 'Esc';
-  else if (key === '`' || key === '~') key = 'Backquote';
-  else if (key === ' ') key = 'Space';
-  else key = key.toUpperCase();
+	// Normalize key names
+	let key = e.key;
+	if (key === "Enter") key = "Enter";
+	else if (key === "Escape") key = "Esc";
+	else if (key === "`" || key === "~") key = "Backquote";
+	else if (key === " ") key = "Space";
+	else key = key.toUpperCase();
 
-  parts.push(key);
+	parts.push(key);
 
-  return parts.join('+');
+	return parts.join("+");
 }
 
 /**
  * Check if Monaco should handle this shortcut
  */
 function isMonacoHandled(e: KeyboardEvent): boolean {
-  const mod = e.ctrlKey || e.metaKey;
+	const mod = e.ctrlKey || e.metaKey;
 
-  // Monaco handles these by default
-  const monacoKeys = ['F', 'H', 'A', 'D', 'L'];
+	// Monaco handles these by default
+	const monacoKeys = ["F", "H", "A", "D", "L"];
 
-  if (!mod) return false;
+	if (!mod) return false;
 
-  // Let Monaco handle these when in editor
-  return monacoKeys.includes(e.key.toUpperCase());
+	// Let Monaco handle these when in editor
+	return monacoKeys.includes(e.key.toUpperCase());
 }
 
 /**
  * Hook to enable global keyboard shortcuts
  */
 export function useKeyboardShortcuts() {
-  useEffect(() => {
-    const shortcuts: Record<string, () => void> = {
-      // File menu
-      'Mod+N': () => menuActions.file.new(),
-      'Mod+O': () => menuActions.file.open(),
-      'Mod+S': () => menuActions.file.save(),
-      'Mod+Shift+S': () => menuActions.file.saveAs(),
+	useEffect(() => {
+		const shortcuts: Record<string, () => void> = {
+			// File menu
+			"Mod+N": () => menuActions.file.new(),
+			"Mod+O": () => menuActions.file.open(),
+			"Mod+S": () => menuActions.file.save(),
+			"Mod+Shift+S": () => menuActions.file.saveAs(),
 
-      // Edit menu - AI ASSISTANT (most important)
-      'Mod+K': () => menuActions.edit.aiAssist(),
+			// Edit menu - AI ASSISTANT (most important)
+			"Mod+K": () => menuActions.edit.aiAssist(),
 
-      // Code menu
-      // NOTE: Cmd+Enter, Cmd+Shift+Enter handled by EditorPanel's Monaco shortcuts
-      // to avoid conflicts and ensure proper cell execution with metadata
-      'Esc': () => menuActions.code.interrupt(),
-      'Mod+Shift+0': () => menuActions.code.restartSession(),
-      'Mod+/': () => menuActions.code.comment(),
+			// Code menu
+			// NOTE: Cmd+Enter, Cmd+Shift+Enter handled by EditorPanel's Monaco shortcuts
+			// to avoid conflicts and ensure proper cell execution with metadata
+			Esc: () => menuActions.code.interrupt(),
+			"Mod+Shift+0": () => menuActions.code.restartSession(),
+			"Mod+/": () => menuActions.code.comment(),
 
-  // Session menu
-  'Mod+T': () => menuActions.session.showTimeline(),
-  'Mod+Shift+N': () => menuActions.session.new(),
-  'Mod+,': () => menuActions.session.settings(),
+			// Session menu
+			"Mod+T": () => menuActions.session.showTimeline(),
+			"Mod+Shift+N": () => menuActions.session.new(),
+			"Mod+,": () => menuActions.session.settings(),
 
-  // Terminal shortcuts
-  'Mod+Backquote': () => menuActions.view.focusTerminal(),
-  'Mod+Shift+T': () => menuActions.view.newTerminalSession(),
+			// Terminal shortcuts
+			"Mod+Backquote": () => menuActions.view.focusTerminal(),
+			"Mod+Shift+T": () => menuActions.view.newTerminalSession(),
 
-  // View menu
-      'Mod+Shift+E': () => menuActions.view.togglePane('files'),
-      'Mod+1': () => menuActions.view.togglePane('editor'),
-      'Mod+2': () => menuActions.view.togglePane('assistant'),
-      'Mod++': () => menuActions.view.zoomIn(),
-      'Mod+=': () => menuActions.view.zoomIn(), // Also handle = key (no shift)
-      'Mod+-': () => menuActions.view.zoomOut(),
-      'Mod+0': () => menuActions.view.zoomReset(),
-    };
+			// View menu
+			"Mod+Shift+E": () => menuActions.view.togglePane("files"),
+			"Mod+1": () => menuActions.view.togglePane("editor"),
+			"Mod+2": () => menuActions.view.togglePane("assistant"),
+			"Mod++": () => menuActions.view.zoomIn(),
+			"Mod+=": () => menuActions.view.zoomIn(), // Also handle = key (no shift)
+			"Mod+-": () => menuActions.view.zoomOut(),
+			"Mod+0": () => menuActions.view.zoomReset(),
+		};
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Skip if user is typing in input/textarea (except AI panel)
-      const target = e.target as HTMLElement;
-      const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA';
-      const isContentEditable = target.isContentEditable;
+		const handleKeyDown = (e: KeyboardEvent) => {
+			// Skip if user is typing in input/textarea (except AI panel)
+			const target = e.target as HTMLElement;
+			const isInput = target.tagName === "INPUT" || target.tagName === "TEXTAREA";
+			const isContentEditable = target.isContentEditable;
 
-      // Allow Cmd+K even in inputs (to open AI assistant)
-      const isAIShortcut = (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k';
+			// Allow Cmd+K even in inputs (to open AI assistant)
+			const isAIShortcut = (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k";
 
-      if ((isInput || isContentEditable) && !isAIShortcut) {
-        return; // Don't intercept typing
-      }
+			if ((isInput || isContentEditable) && !isAIShortcut) {
+				return; // Don't intercept typing
+			}
 
-      // Skip if Monaco editor should handle it
-      const inEditor = target.closest('.monaco-editor');
-      if (inEditor && isMonacoHandled(e) && !isAIShortcut) {
-        return; // Let Monaco handle it
-      }
+			// Skip if Monaco editor should handle it
+			const inEditor = target.closest(".monaco-editor");
+			if (inEditor && isMonacoHandled(e) && !isAIShortcut) {
+				return; // Let Monaco handle it
+			}
 
-      // Skip browser shortcuts
-      const shortcut = eventToShortcut(e);
-      const browserShortcuts = ['Mod+R', 'Mod+W', 'Mod+Q'];
-      if (browserShortcuts.includes(shortcut)) {
-        return; // Let browser handle
-      }
+			// Skip browser shortcuts
+			const shortcut = eventToShortcut(e);
+			const browserShortcuts = ["Mod+R", "Mod+W", "Mod+Q"];
+			if (browserShortcuts.includes(shortcut)) {
+				return; // Let browser handle
+			}
 
-      const action = shortcuts[shortcut];
+			const action = shortcuts[shortcut];
 
-      if (action) {
-        e.preventDefault();
-        e.stopPropagation();
-        action();
-      }
-    };
+			if (action) {
+				e.preventDefault();
+				e.stopPropagation();
+				action();
+			}
+		};
 
-    document.addEventListener('keydown', handleKeyDown, { capture: true });
+		document.addEventListener("keydown", handleKeyDown, { capture: true });
 
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown, { capture: true });
-    };
-  }, []);
+		return () => {
+			document.removeEventListener("keydown", handleKeyDown, { capture: true });
+		};
+	}, []);
 }

--- a/client/src/hooks/useMenuSections.ts
+++ b/client/src/hooks/useMenuSections.ts
@@ -1,19 +1,19 @@
-import { useMemo } from 'react';
-import { useStore } from '@/core';
-import { buildMenuSections } from '@/core/menu/menuConfig';
+import { useMemo } from "react";
+import { useStore } from "@/core";
+import { buildMenuSections } from "@/core/menu/menuConfig";
 
 export function useMenuSections() {
-  const isEditorDirty = useStore((state) => state.editor?.isDirty ?? false);
-  const isExecutionRunning = useStore((state) => state.execution?.isRunning ?? false);
-  const viewPanes = useStore((state) => state.view.panes);
+	const isEditorDirty = useStore((state) => state.editor?.isDirty ?? false);
+	const isExecutionRunning = useStore((state) => state.execution?.isRunning ?? false);
+	const viewPanes = useStore((state) => state.view.panes);
 
-  return useMemo(
-    () =>
-      buildMenuSections({
-        isEditorDirty,
-        isExecutionRunning,
-        viewPanes,
-      }),
-    [isEditorDirty, isExecutionRunning, viewPanes]
-  );
+	return useMemo(
+		() =>
+			buildMenuSections({
+				isEditorDirty,
+				isExecutionRunning,
+				viewPanes,
+			}),
+		[isEditorDirty, isExecutionRunning, viewPanes],
+	);
 }

--- a/client/src/hooks/useProjectSession.ts
+++ b/client/src/hooks/useProjectSession.ts
@@ -1,105 +1,105 @@
-import { useEffect, useRef } from 'react';
-import type { ProjectRecord } from 'shared';
+import { useEffect, useRef } from "react";
+import type { ProjectRecord } from "shared";
 
-import { useStore } from '@/core';
-import { projectService } from '@/services/projectService';
-import { socketService } from '@/services/socket';
-import { DEFAULT_R_SCRIPT } from '@/core/state/slices/editorSlice';
+import { useStore } from "@/core";
+import { DEFAULT_R_SCRIPT } from "@/core/state/slices/editorSlice";
+import { projectService } from "@/services/projectService";
 import {
-  applySessionSnapshot,
-  getSessionSnapshot,
-  refreshTimelineData,
-} from '@/services/sessionPersistence';
+	applySessionSnapshot,
+	getSessionSnapshot,
+	refreshTimelineData,
+} from "@/services/sessionPersistence";
+import { socketService } from "@/services/socket";
 
 function resetWorkspace(options: { useSample?: boolean } = {}): void {
-  const state = useStore.getState();
-  const useSample = options.useSample ?? false;
-  state.setEditorContent(useSample ? DEFAULT_R_SCRIPT : '# New R Script\n\n');
-  state.setEditorFilepath(useSample ? 'analysis.R' : '');
-  state.setEditorIsDirty(false);
-  state.clearAIMessages();
-  state.resetExecutionState();
-  state.reset();
+	const state = useStore.getState();
+	const useSample = options.useSample ?? false;
+	state.setEditorContent(useSample ? DEFAULT_R_SCRIPT : "# New R Script\n\n");
+	state.setEditorFilepath(useSample ? "analysis.R" : "");
+	state.setEditorIsDirty(false);
+	state.clearAIMessages();
+	state.resetExecutionState();
+	state.reset();
 }
 
 export function useProjectSession(): void {
-  const setProject = useStore((state) => state.setProject);
-  const setProjects = useStore((state) => state.setProjects);
-  const setLastRestoredState = useStore((state) => state.setLastRestoredState);
-  const previousProjectId = useRef<string | null>(null);
+	const setProject = useStore((state) => state.setProject);
+	const setProjects = useStore((state) => state.setProjects);
+	const setLastRestoredState = useStore((state) => state.setLastRestoredState);
+	const previousProjectId = useRef<string | null>(null);
 
-  useEffect(() => {
-    const handleProjectOpened = (message: { project: ProjectRecord; state?: unknown }) => {
-      const nextProjectId = message.project.id;
-      const hasState = Boolean(message.state);
-      const isSameProject = previousProjectId.current === nextProjectId;
-      previousProjectId.current = nextProjectId;
+	useEffect(() => {
+		const handleProjectOpened = (message: { project: ProjectRecord; state?: unknown }) => {
+			const nextProjectId = message.project.id;
+			const hasState = Boolean(message.state);
+			const isSameProject = previousProjectId.current === nextProjectId;
+			previousProjectId.current = nextProjectId;
 
-      setProject(message.project);
-      if (hasState) {
-        applySessionSnapshot(message.state as any);
-        setLastRestoredState(message.state as Record<string, unknown>);
-        const editorState = useStore.getState().editor;
-        if (!editorState.content?.trim()) {
-          resetWorkspace({ useSample: true });
-        }
-      } else if (!isSameProject) {
-        resetWorkspace({ useSample: true });
-        void refreshTimelineData();
-        setLastRestoredState(null);
-      }
-    };
+			setProject(message.project);
+			if (hasState) {
+				applySessionSnapshot(message.state as any);
+				setLastRestoredState(message.state as Record<string, unknown>);
+				const editorState = useStore.getState().editor;
+				if (!editorState.content?.trim()) {
+					resetWorkspace({ useSample: true });
+				}
+			} else if (!isSameProject) {
+				resetWorkspace({ useSample: true });
+				void refreshTimelineData();
+				setLastRestoredState(null);
+			}
+		};
 
-    const offOpened = socketService.on('project_opened', (message) => {
-      if (message.type === 'project_opened') {
-        handleProjectOpened(message);
-      }
-    });
+		const offOpened = socketService.on("project_opened", (message) => {
+			if (message.type === "project_opened") {
+				handleProjectOpened(message);
+			}
+		});
 
-    const offList = socketService.on('project_list', (message) => {
-      if (message.type === 'project_list') {
-        setProjects(message.projects);
-      }
-    });
+		const offList = socketService.on("project_list", (message) => {
+			if (message.type === "project_list") {
+				setProjects(message.projects);
+			}
+		});
 
-    const offState = socketService.on('project_state', (message) => {
-      if (message.type === 'project_state' && message.state) {
-        applySessionSnapshot(message.state as any);
-        setLastRestoredState(message.state as Record<string, unknown>);
-      }
-    });
+		const offState = socketService.on("project_state", (message) => {
+			if (message.type === "project_state" && message.state) {
+				applySessionSnapshot(message.state as any);
+				setLastRestoredState(message.state as Record<string, unknown>);
+			}
+		});
 
-    const offSaved = socketService.on('project_state_saved', (message) => {
-      if (message.type === 'project_state_saved' && message.project_id) {
-        console.info(`Project ${message.project_id} state persisted`);
-      }
-    });
+		const offSaved = socketService.on("project_state_saved", (message) => {
+			if (message.type === "project_state_saved" && message.project_id) {
+				console.info(`Project ${message.project_id} state persisted`);
+			}
+		});
 
-    const unsubscribeConnection = socketService.onConnectionChange((status) => {
-      if (status === 'connected') {
-        projectService.requestList();
-      }
-    });
+		const unsubscribeConnection = socketService.onConnectionChange((status) => {
+			if (status === "connected") {
+				projectService.requestList();
+			}
+		});
 
-    if (socketService.isConnected()) {
-      projectService.requestList();
-    }
+		if (socketService.isConnected()) {
+			projectService.requestList();
+		}
 
-    return () => {
-      offOpened();
-      offList();
-      offState();
-      offSaved();
-      unsubscribeConnection();
-    };
-  }, [setLastRestoredState, setProject, setProjects]);
+		return () => {
+			offOpened();
+			offList();
+			offState();
+			offSaved();
+			unsubscribeConnection();
+		};
+	}, [setLastRestoredState, setProject, setProjects]);
 }
 
 export function persistCurrentProjectState(): void {
-  const { project } = useStore.getState();
-  if (!project) {
-    return;
-  }
-  const snapshot = getSessionSnapshot();
-  projectService.saveState(project.id, snapshot);
+	const { project } = useStore.getState();
+	if (!project) {
+		return;
+	}
+	const snapshot = getSessionSnapshot();
+	projectService.saveState(project.id, snapshot);
 }

--- a/client/src/hooks/useSessionControlEvents.ts
+++ b/client/src/hooks/useSessionControlEvents.ts
@@ -1,31 +1,31 @@
-import { useEffect } from 'react';
-import { socketService } from '@/services/socket';
-import { useStore } from '@/core';
-import { refreshTimelineData } from '@/services/sessionPersistence';
+import { useEffect } from "react";
+import { useStore } from "@/core";
+import { refreshTimelineData } from "@/services/sessionPersistence";
+import { socketService } from "@/services/socket";
 
 export function useSessionControlEvents(): void {
-  const setIsRunning = useStore((state) => state.setIsRunning);
-  const resetExecutionState = useStore((state) => state.resetExecutionState);
-  const resetTimeline = useStore((state) => state.reset);
+	const setIsRunning = useStore((state) => state.setIsRunning);
+	const resetExecutionState = useStore((state) => state.resetExecutionState);
+	const resetTimeline = useStore((state) => state.reset);
 
-  useEffect(() => {
-    const offInterrupt = socketService.on('execution_interrupted', (message) => {
-      if (message.type === 'execution_interrupted' && message.success) {
-        setIsRunning(false);
-      }
-    });
+	useEffect(() => {
+		const offInterrupt = socketService.on("execution_interrupted", (message) => {
+			if (message.type === "execution_interrupted" && message.success) {
+				setIsRunning(false);
+			}
+		});
 
-    const offRestart = socketService.on('session_restarted', (message) => {
-      if (message.type === 'session_restarted') {
-        resetExecutionState();
-        resetTimeline();
-        void refreshTimelineData();
-      }
-    });
+		const offRestart = socketService.on("session_restarted", (message) => {
+			if (message.type === "session_restarted") {
+				resetExecutionState();
+				resetTimeline();
+				void refreshTimelineData();
+			}
+		});
 
-    return () => {
-      offInterrupt();
-      offRestart();
-    };
-  }, [resetExecutionState, resetTimeline, setIsRunning]);
+		return () => {
+			offInterrupt();
+			offRestart();
+		};
+	}, [resetExecutionState, resetTimeline, setIsRunning]);
 }

--- a/client/src/hooks/useSettingsPersistence.ts
+++ b/client/src/hooks/useSettingsPersistence.ts
@@ -1,38 +1,38 @@
-import { useEffect, useState } from 'react';
-import { useStore } from '@/core';
+import { useEffect, useState } from "react";
+import { useStore } from "@/core";
 
-const SETTINGS_KEY = 'reprod.settings';
+const SETTINGS_KEY = "reprod.settings";
 
 export function useSettingsPersistence(): void {
-  const settings = useStore((state) => state.settings);
-  const updateSettings = useStore((state) => state.updateSettings);
-  const [hydrated, setHydrated] = useState(false);
+	const settings = useStore((state) => state.settings);
+	const updateSettings = useStore((state) => state.updateSettings);
+	const [hydrated, setHydrated] = useState(false);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
+	useEffect(() => {
+		if (typeof window === "undefined") return;
 
-    try {
-      const raw = window.localStorage.getItem(SETTINGS_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        updateSettings(parsed);
-      }
-    } catch (error) {
-      console.warn('Failed to restore settings from storage', error);
-    }
+		try {
+			const raw = window.localStorage.getItem(SETTINGS_KEY);
+			if (raw) {
+				const parsed = JSON.parse(raw);
+				updateSettings(parsed);
+			}
+		} catch (error) {
+			console.warn("Failed to restore settings from storage", error);
+		}
 
-    setHydrated(true);
-  }, [updateSettings]);
+		setHydrated(true);
+	}, [updateSettings]);
 
-  useEffect(() => {
-    if (!hydrated || typeof window === 'undefined') {
-      return;
-    }
+	useEffect(() => {
+		if (!hydrated || typeof window === "undefined") {
+			return;
+		}
 
-    try {
-      window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
-    } catch (error) {
-      console.warn('Failed to persist settings', error);
-    }
-  }, [hydrated, settings]);
+		try {
+			window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+		} catch (error) {
+			console.warn("Failed to persist settings", error);
+		}
+	}, [hydrated, settings]);
 }

--- a/client/src/hooks/useSocketConnection.ts
+++ b/client/src/hooks/useSocketConnection.ts
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
-import { socketService } from '@/services/socket';
-import { useStore } from '@/core';
+import { useEffect } from "react";
+import { useStore } from "@/core";
+import { socketService } from "@/services/socket";
 
 /**
  * Establishes and tracks the lifecycle of the shared WebSocket connection.
@@ -10,22 +10,22 @@ import { useStore } from '@/core';
  * Components can simply call `useSocketConnection()` near the top level.
  */
 export function useSocketConnection(): void {
-  const setConnected = useStore((state) => state.setConnected);
+	const setConnected = useStore((state) => state.setConnected);
 
-  useEffect(() => {
-    socketService.connect();
+	useEffect(() => {
+		socketService.connect();
 
-    if (socketService.isConnected()) {
-      setConnected(true);
-    }
+		if (socketService.isConnected()) {
+			setConnected(true);
+		}
 
-    const unsubscribe = socketService.onConnectionChange((status) => {
-      setConnected(status === 'connected');
-    });
+		const unsubscribe = socketService.onConnectionChange((status) => {
+			setConnected(status === "connected");
+		});
 
-    return () => {
-      unsubscribe();
-      socketService.disconnect();
-    };
-  }, [setConnected]);
+		return () => {
+			unsubscribe();
+			socketService.disconnect();
+		};
+	}, [setConnected]);
 }

--- a/client/src/hooks/useTerminal.ts
+++ b/client/src/hooks/useTerminal.ts
@@ -1,296 +1,297 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { invoke } from '@tauri-apps/api/core';
-import type { TerminalState } from '@/types/terminal';
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { TerminalState } from "@/types/terminal";
 
 const isTauriAvailable =
-  typeof window !== 'undefined' &&
-  Boolean(
-    (window as typeof window & {
-      __TAURI__?: unknown;
-      __TAURI_IPC__?: unknown;
-      __TAURI_INTERNALS__?: unknown;
-    }).__TAURI__ ||
-      (window as typeof window & { __TAURI_IPC__?: unknown }).__TAURI_IPC__ ||
-      (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__,
-  );
+	typeof window !== "undefined" &&
+	Boolean(
+		(
+			window as typeof window & {
+				__TAURI__?: unknown;
+				__TAURI_IPC__?: unknown;
+				__TAURI_INTERNALS__?: unknown;
+			}
+		).__TAURI__ ||
+			(window as typeof window & { __TAURI_IPC__?: unknown }).__TAURI_IPC__ ||
+			(window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__,
+	);
 
 interface UseTerminalResult {
-  state: TerminalState;
-  isAvailable: boolean;
-  error: string | null;
-  errorDetail: string | null;
-  createSession: () => Promise<void>;
-  closeSession: (sessionId: string) => Promise<void>;
-  setActiveSession: (sessionId: string) => void;
-  writeToSession: (sessionId: string, data: string) => Promise<void>;
-  resizeSession: (sessionId: string, cols: number, rows: number) => Promise<void>;
-  registerOutputHandler: (sessionId: string, handler: (chunk: string) => void) => void;
-  unregisterOutputHandler: (sessionId: string) => void;
+	state: TerminalState;
+	isAvailable: boolean;
+	error: string | null;
+	errorDetail: string | null;
+	createSession: () => Promise<void>;
+	closeSession: (sessionId: string) => Promise<void>;
+	setActiveSession: (sessionId: string) => void;
+	writeToSession: (sessionId: string, data: string) => Promise<void>;
+	resizeSession: (sessionId: string, cols: number, rows: number) => Promise<void>;
+	registerOutputHandler: (sessionId: string, handler: (chunk: string) => void) => void;
+	unregisterOutputHandler: (sessionId: string) => void;
 }
 
 export function useTerminal(): UseTerminalResult {
-  const [state, setState] = useState<TerminalState>({
-    sessions: [],
-    activeSessionId: null,
-  });
-  const [error, setError] = useState<string | null>(null);
-  const [errorDetail, setErrorDetail] = useState<string | null>(null);
-  const handlersRef = useRef(new Map<string, (chunk: string) => void>());
-  const sessionCounterRef = useRef(1);
-  const processesRef = useRef(new Map<string, SimplePty>());
+	const [state, setState] = useState<TerminalState>({
+		sessions: [],
+		activeSessionId: null,
+	});
+	const [error, setError] = useState<string | null>(null);
+	const [errorDetail, setErrorDetail] = useState<string | null>(null);
+	const handlersRef = useRef(new Map<string, (chunk: string) => void>());
+	const sessionCounterRef = useRef(1);
+	const processesRef = useRef(new Map<string, SimplePty>());
 
-  const addSession = useCallback((sessionId: string, title: string) => {
-    setState((prev) => ({
-      sessions: [
-        ...prev.sessions.map((session) => ({ ...session, isActive: false })),
-        { id: sessionId, title, isActive: true },
-      ],
-      activeSessionId: sessionId,
-    }));
-  }, []);
+	const addSession = useCallback((sessionId: string, title: string) => {
+		setState((prev) => ({
+			sessions: [
+				...prev.sessions.map((session) => ({ ...session, isActive: false })),
+				{ id: sessionId, title, isActive: true },
+			],
+			activeSessionId: sessionId,
+		}));
+	}, []);
 
-  const removeSession = useCallback((sessionId: string) => {
-    setState((prev) => {
-      const sessions = prev.sessions.filter((session) => session.id !== sessionId);
-      const nextActive =
-        prev.activeSessionId === sessionId
-          ? sessions.length > 0
-            ? sessions[sessions.length - 1].id
-            : null
-          : prev.activeSessionId;
-      const normalizedSessions = sessions.map((session) => ({
-        ...session,
-        isActive: session.id === nextActive,
-      }));
-      return {
-        sessions: normalizedSessions,
-        activeSessionId: nextActive,
-      };
-    });
+	const removeSession = useCallback((sessionId: string) => {
+		setState((prev) => {
+			const sessions = prev.sessions.filter((session) => session.id !== sessionId);
+			const nextActive =
+				prev.activeSessionId === sessionId
+					? sessions.length > 0
+						? sessions[sessions.length - 1].id
+						: null
+					: prev.activeSessionId;
+			const normalizedSessions = sessions.map((session) => ({
+				...session,
+				isActive: session.id === nextActive,
+			}));
+			return {
+				sessions: normalizedSessions,
+				activeSessionId: nextActive,
+			};
+		});
 
-    handlersRef.current.delete(sessionId);
-  }, []);
+		handlersRef.current.delete(sessionId);
+	}, []);
 
-  const setActiveSession = useCallback((sessionId: string) => {
-    setState((prev) => ({
-      sessions: prev.sessions.map((session) => ({
-        ...session,
-        isActive: session.id === sessionId,
-      })),
-      activeSessionId: sessionId,
-    }));
-  }, []);
+	const setActiveSession = useCallback((sessionId: string) => {
+		setState((prev) => ({
+			sessions: prev.sessions.map((session) => ({
+				...session,
+				isActive: session.id === sessionId,
+			})),
+			activeSessionId: sessionId,
+		}));
+	}, []);
 
-  const createSession = useCallback(async () => {
-    if (!isTauriAvailable) {
-      return;
-    }
+	const createSession = useCallback(async () => {
+		if (!isTauriAvailable) {
+			return;
+		}
 
-    try {
-      const pty = new SimplePty('bash', [], { cols: 80, rows: 24 });
-      const sessionId = `pty-${Date.now()}`;
-      const label = `Shell ${sessionCounterRef.current}`;
-      sessionCounterRef.current += 1;
-      setError(null);
-      setErrorDetail(null);
-      addSession(sessionId, label);
-      processesRef.current.set(sessionId, pty);
+		try {
+			const pty = new SimplePty("bash", [], { cols: 80, rows: 24 });
+			const sessionId = `pty-${Date.now()}`;
+			const label = `Shell ${sessionCounterRef.current}`;
+			sessionCounterRef.current += 1;
+			setError(null);
+			setErrorDetail(null);
+			addSession(sessionId, label);
+			processesRef.current.set(sessionId, pty);
 
-      pty.onData((data: string) => {
-        const handler = handlersRef.current.get(sessionId);
-        if (handler) {
-          handler(data);
-        }
-      });
+			pty.onData((data: string) => {
+				const handler = handlersRef.current.get(sessionId);
+				if (handler) {
+					handler(data);
+				}
+			});
 
-      pty.onExit((code) => {
-        console.info(`Terminal session ${sessionId} exited with code ${code}`);
-        removeSession(sessionId);
-        processesRef.current.delete(sessionId);
-      });
-    } catch (error) {
-      console.error('Unable to create terminal session:', error);
-      setError('Unable to start terminal session. Please restart the desktop app.');
-      setErrorDetail(error instanceof Error ? error.message : String(error));
-    }
-  }, [addSession, removeSession]);
+			pty.onExit((code) => {
+				console.info(`Terminal session ${sessionId} exited with code ${code}`);
+				removeSession(sessionId);
+				processesRef.current.delete(sessionId);
+			});
+		} catch (error) {
+			console.error("Unable to create terminal session:", error);
+			setError("Unable to start terminal session. Please restart the desktop app.");
+			setErrorDetail(error instanceof Error ? error.message : String(error));
+		}
+	}, [addSession, removeSession]);
 
-  const closeSession = useCallback(
-    async (sessionId: string) => {
-      const pty = processesRef.current.get(sessionId);
-      if (pty) {
-        try {
-          await pty.kill();
-        } catch (error) {
-          console.error('Unable to close terminal session:', error);
-        }
-      }
+	const closeSession = useCallback(
+		async (sessionId: string) => {
+			const pty = processesRef.current.get(sessionId);
+			if (pty) {
+				try {
+					await pty.kill();
+				} catch (error) {
+					console.error("Unable to close terminal session:", error);
+				}
+			}
 
-      removeSession(sessionId);
-      processesRef.current.delete(sessionId);
-    },
-    [removeSession]
-  );
+			removeSession(sessionId);
+			processesRef.current.delete(sessionId);
+		},
+		[removeSession],
+	);
 
-  const writeToSession = useCallback(
-    async (sessionId: string, data: string) => {
-      if (!isTauriAvailable) {
-        return;
-      }
+	const writeToSession = useCallback(async (sessionId: string, data: string) => {
+		if (!isTauriAvailable) {
+			return;
+		}
 
-      const pty = processesRef.current.get(sessionId);
-      if (!pty) {
-        setError('Terminal session not found.');
-        return;
-      }
+		const pty = processesRef.current.get(sessionId);
+		if (!pty) {
+			setError("Terminal session not found.");
+			return;
+		}
 
-      try {
-        await pty.write(data);
-      } catch (error) {
-        console.error('Unable to write to terminal session:', error);
-        setError('Failed to send input to terminal.');
-        setErrorDetail(error instanceof Error ? error.message : String(error));
-      }
-    },
-    []
-  );
+		try {
+			await pty.write(data);
+		} catch (error) {
+			console.error("Unable to write to terminal session:", error);
+			setError("Failed to send input to terminal.");
+			setErrorDetail(error instanceof Error ? error.message : String(error));
+		}
+	}, []);
 
-  const resizeSession = useCallback(
-    async (sessionId: string, cols: number, rows: number) => {
-      if (!isTauriAvailable) {
-        return;
-      }
+	const resizeSession = useCallback(async (sessionId: string, cols: number, rows: number) => {
+		if (!isTauriAvailable) {
+			return;
+		}
 
-      const pty = processesRef.current.get(sessionId);
-      if (!pty) {
-        return;
-      }
+		const pty = processesRef.current.get(sessionId);
+		if (!pty) {
+			return;
+		}
 
-      try {
-        await pty.resize(cols, rows);
-      } catch (error) {
-        console.error('Unable to resize terminal session:', error);
-      }
-    },
-    []
-  );
+		try {
+			await pty.resize(cols, rows);
+		} catch (error) {
+			console.error("Unable to resize terminal session:", error);
+		}
+	}, []);
 
-  const registerOutputHandler = useCallback((sessionId: string, handler: (chunk: string) => void) => {
-    handlersRef.current.set(sessionId, handler);
-  }, []);
+	const registerOutputHandler = useCallback(
+		(sessionId: string, handler: (chunk: string) => void) => {
+			handlersRef.current.set(sessionId, handler);
+		},
+		[],
+	);
 
-  const unregisterOutputHandler = useCallback((sessionId: string) => {
-    handlersRef.current.delete(sessionId);
-  }, []);
+	const unregisterOutputHandler = useCallback((sessionId: string) => {
+		handlersRef.current.delete(sessionId);
+	}, []);
 
-  // Do not eagerly kill PTYs on unmount to avoid StrictMode double-invocation killing live sessions.
-  useEffect(() => {}, []);
+	// Do not eagerly kill PTYs on unmount to avoid StrictMode double-invocation killing live sessions.
+	useEffect(() => {}, []);
 
-  return {
-    state,
-    isAvailable: isTauriAvailable,
-    error,
-    errorDetail,
-    createSession,
-    closeSession,
-    setActiveSession,
-    writeToSession,
-    resizeSession,
-    registerOutputHandler,
-    unregisterOutputHandler,
-  };
+	return {
+		state,
+		isAvailable: isTauriAvailable,
+		error,
+		errorDetail,
+		createSession,
+		closeSession,
+		setActiveSession,
+		writeToSession,
+		resizeSession,
+		registerOutputHandler,
+		unregisterOutputHandler,
+	};
 }
 
 type DataHandler = (chunk: string) => void;
 type ExitHandler = (code: number) => void;
 
 class SimplePty {
-  pid: number | null = null;
-  private exited = false;
-  private init: Promise<void>;
-  private onDataHandlers: DataHandler[] = [];
-  private onExitHandlers: ExitHandler[] = [];
+	pid: number | null = null;
+	private exited = false;
+	private init: Promise<void>;
+	private onDataHandlers: DataHandler[] = [];
+	private onExitHandlers: ExitHandler[] = [];
 
-  constructor(file: string, args: string[], opts: { cols?: number; rows?: number; cwd?: string }) {
-    const invokeArgs = {
-      file,
-      args,
-      termName: 'Terminal',
-      cols: opts.cols ?? null,
-      rows: opts.rows ?? null,
-      cwd: opts.cwd ?? null,
-      env: {},
-      encoding: null,
-      handleFlowControl: null,
-      flowControlPause: null,
-      flowControlResume: null,
-    };
+	constructor(file: string, args: string[], opts: { cols?: number; rows?: number; cwd?: string }) {
+		const invokeArgs = {
+			file,
+			args,
+			termName: "Terminal",
+			cols: opts.cols ?? null,
+			rows: opts.rows ?? null,
+			cwd: opts.cwd ?? null,
+			env: {},
+			encoding: null,
+			handleFlowControl: null,
+			flowControlPause: null,
+			flowControlResume: null,
+		};
 
-    this.init = invoke<number>('plugin:pty|spawn', invokeArgs).then((pid) => {
-      this.pid = pid;
-      this.readLoop();
-      this.waitLoop();
-    });
-  }
+		this.init = invoke<number>("plugin:pty|spawn", invokeArgs).then((pid) => {
+			this.pid = pid;
+			this.readLoop();
+			this.waitLoop();
+		});
+	}
 
-  onData(handler: DataHandler): () => void {
-    this.onDataHandlers.push(handler);
-    return () => {
-      this.onDataHandlers = this.onDataHandlers.filter((h) => h !== handler);
-    };
-  }
+	onData(handler: DataHandler): () => void {
+		this.onDataHandlers.push(handler);
+		return () => {
+			this.onDataHandlers = this.onDataHandlers.filter((h) => h !== handler);
+		};
+	}
 
-  onExit(handler: ExitHandler): () => void {
-    this.onExitHandlers.push(handler);
-    return () => {
-      this.onExitHandlers = this.onExitHandlers.filter((h) => h !== handler);
-    };
-  }
+	onExit(handler: ExitHandler): () => void {
+		this.onExitHandlers.push(handler);
+		return () => {
+			this.onExitHandlers = this.onExitHandlers.filter((h) => h !== handler);
+		};
+	}
 
-  async write(data: string): Promise<void> {
-    await this.init;
-    if (this.pid == null) return;
-    await invoke('plugin:pty|write', { pid: this.pid, data });
-  }
+	async write(data: string): Promise<void> {
+		await this.init;
+		if (this.pid == null) return;
+		await invoke("plugin:pty|write", { pid: this.pid, data });
+	}
 
-  async resize(cols: number, rows: number): Promise<void> {
-    await this.init;
-    if (this.pid == null) return;
-    await invoke('plugin:pty|resize', { pid: this.pid, cols, rows });
-  }
+	async resize(cols: number, rows: number): Promise<void> {
+		await this.init;
+		if (this.pid == null) return;
+		await invoke("plugin:pty|resize", { pid: this.pid, cols, rows });
+	}
 
-  async kill(): Promise<void> {
-    await this.init;
-    if (this.pid == null) return;
-    this.exited = true;
-    await invoke('plugin:pty|kill', { pid: this.pid });
-  }
+	async kill(): Promise<void> {
+		await this.init;
+		if (this.pid == null) return;
+		this.exited = true;
+		await invoke("plugin:pty|kill", { pid: this.pid });
+	}
 
-  private async readLoop(): Promise<void> {
-    await this.init;
-    if (this.pid == null) return;
-    try {
-      for (;;) {
-        const data = await invoke<string>('plugin:pty|read', { pid: this.pid });
-        this.onDataHandlers.forEach((h) => h(data));
-      }
-    } catch (e: any) {
-      if (typeof e === 'string' && e.includes('EOF')) {
-        return;
-      }
-      console.error('Reading error:', e);
-    }
-  }
+	private async readLoop(): Promise<void> {
+		await this.init;
+		if (this.pid == null) return;
+		try {
+			for (;;) {
+				const data = await invoke<string>("plugin:pty|read", { pid: this.pid });
+				this.onDataHandlers.forEach((h) => h(data));
+			}
+		} catch (e: any) {
+			if (typeof e === "string" && e.includes("EOF")) {
+				return;
+			}
+			console.error("Reading error:", e);
+		}
+	}
 
-  private async waitLoop(): Promise<void> {
-    await this.init;
-    if (this.pid == null || this.exited) return;
-    try {
-      const code = await invoke<number>('plugin:pty|exitstatus', { pid: this.pid });
-      this.exited = true;
-      this.onExitHandlers.forEach((h) => h(code));
-    } catch (e) {
-      console.error('Exit wait error:', e);
-    }
-  }
+	private async waitLoop(): Promise<void> {
+		await this.init;
+		if (this.pid == null || this.exited) return;
+		try {
+			const code = await invoke<number>("plugin:pty|exitstatus", {
+				pid: this.pid,
+			});
+			this.exited = true;
+			this.onExitHandlers.forEach((h) => h(code));
+		} catch (e) {
+			console.error("Exit wait error:", e);
+		}
+	}
 }

--- a/client/src/hooks/useTimelineData.ts
+++ b/client/src/hooks/useTimelineData.ts
@@ -1,160 +1,157 @@
-import { useEffect, useState } from 'react';
-import { useStore } from '@/core';
+import { useEffect, useState } from "react";
+import type { ExecutionEventPayload, TimelineStats } from "shared";
+import { useStore } from "@/core";
+import { appendEventToStats, matchesTimelineFilters } from "@/core/timeline/utils";
 import {
-  queryTimeline,
-  getTimelineStats,
-  subscribeToTimelineEvents,
-} from '@/services/timelineService';
-import type { ExecutionEventPayload, TimelineStats } from 'shared';
-import {
-  matchesTimelineFilters,
-  appendEventToStats,
-} from '@/core/timeline/utils';
+	getTimelineStats,
+	queryTimeline,
+	subscribeToTimelineEvents,
+} from "@/services/timelineService";
 
 export function useTimelineData() {
-  const {
-    events,
-    total,
-    hasMore,
-    loading,
-    error,
-    filters,
-    sort,
-    limit,
-    offset,
-    setEvents,
-    addEvent,
-    setFilters,
-    setSort,
-    setLoading,
-    setError,
-    loadMore,
-  } = useStore((state) => ({
-    events: state.events,
-    total: state.total,
-    hasMore: state.hasMore,
-    loading: state.loading,
-    error: state.error,
-    filters: state.filters,
-    sort: state.sort,
-    limit: state.limit,
-    offset: state.offset,
-    setEvents: state.setEvents,
-    addEvent: state.addEvent,
-    setFilters: state.setFilters,
-    setSort: state.setSort,
-    setLoading: state.setLoading,
-    setError: state.setError,
-    loadMore: state.loadMore,
-  }));
+	const {
+		events,
+		total,
+		hasMore,
+		loading,
+		error,
+		filters,
+		sort,
+		limit,
+		offset,
+		setEvents,
+		addEvent,
+		setFilters,
+		setSort,
+		setLoading,
+		setError,
+		loadMore,
+	} = useStore((state) => ({
+		events: state.events,
+		total: state.total,
+		hasMore: state.hasMore,
+		loading: state.loading,
+		error: state.error,
+		filters: state.filters,
+		sort: state.sort,
+		limit: state.limit,
+		offset: state.offset,
+		setEvents: state.setEvents,
+		addEvent: state.addEvent,
+		setFilters: state.setFilters,
+		setSort: state.setSort,
+		setLoading: state.setLoading,
+		setError: state.setError,
+		loadMore: state.loadMore,
+	}));
 
-  const isConnected = useStore((state) => state.isConnected);
-  const [stats, setStats] = useState<TimelineStats | null>(null);
-  const [statsLoading, setStatsLoading] = useState(false);
+	const isConnected = useStore((state) => state.isConnected);
+	const [stats, setStats] = useState<TimelineStats | null>(null);
+	const [statsLoading, setStatsLoading] = useState(false);
 
-  useEffect(() => {
-    if (!isConnected) {
-      setLoading(false);
-      return;
-    }
+	useEffect(() => {
+		if (!isConnected) {
+			setLoading(false);
+			return;
+		}
 
-    const fetchEvents = async () => {
-      setLoading(true);
-      setError(null);
+		const fetchEvents = async () => {
+			setLoading(true);
+			setError(null);
 
-      try {
-        const response = await queryTimeline({
-          filters,
-          sort,
-          limit,
-          offset: 0,
-        });
+			try {
+				const response = await queryTimeline({
+					filters,
+					sort,
+					limit,
+					offset: 0,
+				});
 
-        setEvents(response.events, response.total, response.hasMore);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load timeline');
-      }
-    };
+				setEvents(response.events, response.total, response.hasMore);
+			} catch (err) {
+				setError(err instanceof Error ? err.message : "Failed to load timeline");
+			}
+		};
 
-    void fetchEvents();
-  }, [filters, sort, limit, isConnected, setLoading, setError, setEvents]);
+		void fetchEvents();
+	}, [filters, sort, limit, isConnected, setLoading, setError, setEvents]);
 
-  useEffect(() => {
-    if (!isConnected || offset === 0) {
-      return;
-    }
+	useEffect(() => {
+		if (!isConnected || offset === 0) {
+			return;
+		}
 
-    const fetchMoreEvents = async () => {
-      setLoading(true);
-      setError(null);
+		const fetchMoreEvents = async () => {
+			setLoading(true);
+			setError(null);
 
-      try {
-        const response = await queryTimeline({
-          filters,
-          sort,
-          limit,
-          offset,
-        });
+			try {
+				const response = await queryTimeline({
+					filters,
+					sort,
+					limit,
+					offset,
+				});
 
-        setEvents([...events, ...response.events], response.total, response.hasMore);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load more events');
-      }
-    };
+				setEvents([...events, ...response.events], response.total, response.hasMore);
+			} catch (err) {
+				setError(err instanceof Error ? err.message : "Failed to load more events");
+			}
+		};
 
-    void fetchMoreEvents();
-  }, [offset, isConnected, filters, sort, limit, events, setEvents, setLoading, setError]);
+		void fetchMoreEvents();
+	}, [offset, isConnected, filters, sort, limit, events, setEvents, setLoading, setError]);
 
-  useEffect(() => {
-    if (!isConnected) {
-      setStats(null);
-      return;
-    }
+	useEffect(() => {
+		if (!isConnected) {
+			setStats(null);
+			return;
+		}
 
-    const fetchStats = async () => {
-      setStatsLoading(true);
-      try {
-        const statsData = await getTimelineStats();
-        setStats(statsData);
-      } catch (err) {
-        console.error('Failed to load timeline stats:', err);
-      } finally {
-        setStatsLoading(false);
-      }
-    };
+		const fetchStats = async () => {
+			setStatsLoading(true);
+			try {
+				const statsData = await getTimelineStats();
+				setStats(statsData);
+			} catch (err) {
+				console.error("Failed to load timeline stats:", err);
+			} finally {
+				setStatsLoading(false);
+			}
+		};
 
-    void fetchStats();
-  }, [isConnected]);
+		void fetchStats();
+	}, [isConnected]);
 
-  useEffect(() => {
-    if (!isConnected) {
-      return undefined;
-    }
+	useEffect(() => {
+		if (!isConnected) {
+			return undefined;
+		}
 
-    const unsubscribe = subscribeToTimelineEvents((event: ExecutionEventPayload) => {
-      if (!matchesTimelineFilters(event, filters)) {
-        return;
-      }
+		const unsubscribe = subscribeToTimelineEvents((event: ExecutionEventPayload) => {
+			if (!matchesTimelineFilters(event, filters)) {
+				return;
+			}
 
-      addEvent(event);
-      setStats((prev) => appendEventToStats(event, prev));
-    });
+			addEvent(event);
+			setStats((prev) => appendEventToStats(event, prev));
+		});
 
-    return unsubscribe;
-  }, [isConnected, filters, addEvent]);
+		return unsubscribe;
+	}, [isConnected, filters, addEvent]);
 
-  return {
-    events,
-    total,
-    hasMore,
-    loading,
-    error,
-    filters,
-    sort,
-    loadMore,
-    setFilters,
-    setSort,
-    stats,
-    statsLoading,
-  };
+	return {
+		events,
+		total,
+		hasMore,
+		loading,
+		error,
+		filters,
+		sort,
+		loadMore,
+		setFilters,
+		setSort,
+		stats,
+		statsLoading,
+	};
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import './css/index.css';
-import { initialiseTheme } from './theme';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./css/index.css";
+import { initialiseTheme } from "./theme";
 
 initialiseTheme();
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+ReactDOM.createRoot(document.getElementById("root")!).render(
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
 );

--- a/client/src/services/__tests__/timelineService.test.ts
+++ b/client/src/services/__tests__/timelineService.test.ts
@@ -1,462 +1,462 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { queryTimeline, getTimelineStats, subscribeToTimelineEvents } from '../timelineService';
-import { socketService } from '../socket';
-import type { TimelineQuery, TimelineResponse, TimelineStats, ExecutionEventPayload } from 'shared';
+import type { ExecutionEventPayload, TimelineQuery, TimelineResponse, TimelineStats } from "shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { socketService } from "../socket";
+import { getTimelineStats, queryTimeline, subscribeToTimelineEvents } from "../timelineService";
 
 // Mock the socket service
-vi.mock('../socket', () => ({
-  socketService: {
-    send: vi.fn(),
-    on: vi.fn(),
-  },
+vi.mock("../socket", () => ({
+	socketService: {
+		send: vi.fn(),
+		on: vi.fn(),
+	},
 }));
 
-describe('timelineService', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  describe('queryTimeline', () => {
-    it('should successfully query timeline with filters', async () => {
-      const mockQuery: TimelineQuery = {
-        filters: {
-          actor: 'user',
-          hasPlots: true,
-        },
-        sort: 'desc',
-        limit: 10,
-        offset: 0,
-      };
-
-      const mockResponse: TimelineResponse = {
-        events: [],
-        total: 0,
-        hasMore: false,
-        query: mockQuery,
-      };
-
-      // Mock successful send
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        // Simulate server response
-        setTimeout(() => {
-          callback({
-            type: 'timeline_response',
-            data: mockResponse,
-          });
-        }, 0);
-        return true;
-      });
-
-      const result = await queryTimeline(mockQuery);
-
-      expect(result).toEqual(mockResponse);
-      expect(socketService.send).toHaveBeenCalledWith(
-        { type: 'timeline_query', query: mockQuery },
-        expect.any(Function),
-        expect.any(Function)
-      );
-    });
-
-    it('should handle empty query', async () => {
-      const mockQuery: TimelineQuery = {};
-
-      const mockResponse: TimelineResponse = {
-        events: [],
-        total: 0,
-        hasMore: false,
-        query: mockQuery,
-      };
-
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'timeline_response',
-            data: mockResponse,
-          });
-        }, 0);
-        return true;
-      });
-
-      const result = await queryTimeline(mockQuery);
-
-      expect(result).toEqual(mockResponse);
-    });
-
-    it('should handle error response from server', async () => {
-      const mockQuery: TimelineQuery = {};
-
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'error',
-            message: 'Timeline query failed',
-          });
-        }, 0);
-        return true;
-      });
-
-      await expect(queryTimeline(mockQuery)).rejects.toThrow('Timeline query failed');
-    });
-
-    it('should reject when WebSocket is not connected', async () => {
-      const mockQuery: TimelineQuery = {};
-
-      vi.mocked(socketService.send).mockReturnValue(false);
-
-      await expect(queryTimeline(mockQuery)).rejects.toThrow(
-        'Timeline request failed: WebSocket is not connected.'
-      );
-    });
-
-    it('should handle unexpected response type', async () => {
-      const mockQuery: TimelineQuery = {};
-
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'unexpected_type',
-          } as any);
-        }, 0);
-        return true;
-      });
-
-      await expect(queryTimeline(mockQuery)).rejects.toThrow('Unexpected timeline response');
-    });
-
-    it('should query with pagination', async () => {
-      const mockQuery: TimelineQuery = {
-        limit: 20,
-        offset: 40,
-      };
-
-      const mockResponse: TimelineResponse = {
-        events: [],
-        total: 100,
-        hasMore: true,
-        query: mockQuery,
-      };
-
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'timeline_response',
-            data: mockResponse,
-          });
-        }, 0);
-        return true;
-      });
-
-      const result = await queryTimeline(mockQuery);
-
-      expect(result.total).toBe(100);
-      expect(result.hasMore).toBe(true);
-    });
-
-    it('should query with time range filter', async () => {
-      const mockQuery: TimelineQuery = {
-        filters: {
-          startTime: 1700000000000,
-          endTime: 1700003600000,
-        },
-      };
-
-      const mockResponse: TimelineResponse = {
-        events: [],
-        total: 5,
-        hasMore: false,
-        query: mockQuery,
-      };
-
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'timeline_response',
-            data: mockResponse,
-          });
-        }, 0);
-        return true;
-      });
-
-      const result = await queryTimeline(mockQuery);
-
-      expect(result.total).toBe(5);
-    });
-
-    it('should query with code search filter', async () => {
-      const mockQuery: TimelineQuery = {
-        filters: {
-          codeContains: 'ggplot',
-        },
-      };
-
-      const mockResponse: TimelineResponse = {
-        events: [],
-        total: 3,
-        hasMore: false,
-        query: mockQuery,
-      };
-
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'timeline_response',
-            data: mockResponse,
-          });
-        }, 0);
-        return true;
-      });
-
-      const result = await queryTimeline(mockQuery);
-
-      expect(result.total).toBe(3);
-    });
-  });
-
-  describe('getTimelineStats', () => {
-    it('should successfully fetch timeline statistics', async () => {
-      const mockStats: TimelineStats = {
-        totalEvents: 150,
-        totalPlots: 25,
-        totalErrors: 5,
-        userActions: 100,
-        aiActions: 50,
-        sessionStartTime: 1700000000000,
-        sessionEndTime: 1700003600000,
-        sessionDuration: 3600000,
-      };
-
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'timeline_stats_response',
-            stats: mockStats,
-          });
-        }, 0);
-        return true;
-      });
-
-      const result = await getTimelineStats();
-
-      expect(result).toEqual(mockStats);
-      expect(socketService.send).toHaveBeenCalledWith(
-        { type: 'timeline_stats_query' },
-        expect.any(Function),
-        expect.any(Function)
-      );
-    });
-
-    it('should handle error response when fetching stats', async () => {
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'error',
-            message: 'Failed to calculate stats',
-          });
-        }, 0);
-        return true;
-      });
-
-      await expect(getTimelineStats()).rejects.toThrow('Failed to calculate stats');
-    });
-
-    it('should reject when WebSocket is not connected', async () => {
-      vi.mocked(socketService.send).mockReturnValue(false);
-
-      await expect(getTimelineStats()).rejects.toThrow(
-        'Timeline stats request failed: WebSocket is not connected.'
-      );
-    });
-
-    it('should handle unexpected response type', async () => {
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'unexpected_type',
-          } as any);
-        }, 0);
-        return true;
-      });
-
-      await expect(getTimelineStats()).rejects.toThrow('Unexpected timeline stats response');
-    });
-
-    it('should handle stats with zero values', async () => {
-      const mockStats: TimelineStats = {
-        totalEvents: 0,
-        totalPlots: 0,
-        totalErrors: 0,
-        userActions: 0,
-        aiActions: 0,
-        sessionStartTime: 1700000000000,
-        sessionEndTime: 1700000000000,
-        sessionDuration: 0,
-      };
-
-      vi.mocked(socketService.send).mockImplementation((message, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'timeline_stats_response',
-            stats: mockStats,
-          });
-        }, 0);
-        return true;
-      });
-
-      const result = await getTimelineStats();
-
-      expect(result.totalEvents).toBe(0);
-      expect(result.sessionDuration).toBe(0);
-    });
-  });
-
-  describe('subscribeToTimelineEvents', () => {
-    it('should subscribe to timeline events and call handler', () => {
-      const mockHandler = vi.fn();
-      const mockUnsubscribe = vi.fn();
-
-      const mockEvent: ExecutionEventPayload = {
-        event_id: 'evt-123',
-        context: {
-          source: 'cell',
-          document_path: 'analysis.R',
-          cell_index: 1,
-          triggered_at_ms: 1700000000000,
-          actor: 'user',
-        },
-        blocks: [
-          {
-            id: 'block-1',
-            index: 0,
-            kind: 'section',
-            label: 'Setup',
-            start_line: 1,
-            end_line: 3,
-            code: 'x <- 1:10',
-          },
-        ],
-        result: {
-          success: true,
-          output: '[1] 1 2 3',
-          error: null,
-          plots: [],
-          execution_time_ms: 42,
-        },
-        environment: {
-          r_path: 'Rscript',
-          working_dir: '/tmp',
-          temp_dir: '/tmp/reprod',
-        },
-        created_at_ms: 1700000000500,
-      };
-
-      vi.mocked(socketService.on).mockImplementation((event, callback) => {
-        // Simulate incoming event
-        setTimeout(() => {
-          callback({
-            type: 'timeline_event_added',
-            event: mockEvent,
-          });
-        }, 0);
-        return mockUnsubscribe;
-      });
-
-      const unsubscribe = subscribeToTimelineEvents(mockHandler);
-
-      // Wait for event to be processed
-      setTimeout(() => {
-        expect(mockHandler).toHaveBeenCalledWith(mockEvent);
-        expect(socketService.on).toHaveBeenCalledWith('timeline_event_added', expect.any(Function));
-      }, 10);
-
-      expect(typeof unsubscribe).toBe('function');
-    });
-
-    it('should not call handler for non-timeline events', () => {
-      const mockHandler = vi.fn();
-
-      vi.mocked(socketService.on).mockImplementation((event, callback) => {
-        // Simulate non-timeline event
-        setTimeout(() => {
-          callback({
-            type: 'other_event',
-          } as any);
-        }, 0);
-        return vi.fn();
-      });
-
-      subscribeToTimelineEvents(mockHandler);
-
-      setTimeout(() => {
-        expect(mockHandler).not.toHaveBeenCalled();
-      }, 10);
-    });
-
-    it('should handle multiple events', () => {
-      const mockHandler = vi.fn();
-
-      const event1: ExecutionEventPayload = {
-        event_id: 'evt-1',
-        context: {
-          source: 'cell',
-          document_path: null,
-          cell_index: null,
-          triggered_at_ms: 1700000000000,
-          actor: 'user',
-        },
-        blocks: [],
-        result: {
-          success: true,
-          output: 'output1',
-          error: null,
-          plots: [],
-          execution_time_ms: 10,
-        },
-        environment: {
-          r_path: 'Rscript',
-          working_dir: '/tmp',
-          temp_dir: '/tmp/reprod',
-        },
-        created_at_ms: 1700000000000,
-      };
-
-      const event2: ExecutionEventPayload = {
-        ...event1,
-        event_id: 'evt-2',
-        created_at_ms: 1700000001000,
-      };
-
-      vi.mocked(socketService.on).mockImplementation((event, callback) => {
-        setTimeout(() => {
-          callback({
-            type: 'timeline_event_added',
-            event: event1,
-          });
-          callback({
-            type: 'timeline_event_added',
-            event: event2,
-          });
-        }, 0);
-        return vi.fn();
-      });
-
-      subscribeToTimelineEvents(mockHandler);
-
-      setTimeout(() => {
-        expect(mockHandler).toHaveBeenCalledTimes(2);
-        expect(mockHandler).toHaveBeenNthCalledWith(1, event1);
-        expect(mockHandler).toHaveBeenNthCalledWith(2, event2);
-      }, 10);
-    });
-
-    it('should return unsubscribe function', () => {
-      const mockHandler = vi.fn();
-      const mockUnsubscribe = vi.fn();
-
-      vi.mocked(socketService.on).mockReturnValue(mockUnsubscribe);
-
-      const unsubscribe = subscribeToTimelineEvents(mockHandler);
-
-      expect(unsubscribe).toBe(mockUnsubscribe);
-    });
-  });
+describe("timelineService", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("queryTimeline", () => {
+		it("should successfully query timeline with filters", async () => {
+			const mockQuery: TimelineQuery = {
+				filters: {
+					actor: "user",
+					hasPlots: true,
+				},
+				sort: "desc",
+				limit: 10,
+				offset: 0,
+			};
+
+			const mockResponse: TimelineResponse = {
+				events: [],
+				total: 0,
+				hasMore: false,
+				query: mockQuery,
+			};
+
+			// Mock successful send
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				// Simulate server response
+				setTimeout(() => {
+					callback({
+						type: "timeline_response",
+						data: mockResponse,
+					});
+				}, 0);
+				return true;
+			});
+
+			const result = await queryTimeline(mockQuery);
+
+			expect(result).toEqual(mockResponse);
+			expect(socketService.send).toHaveBeenCalledWith(
+				{ type: "timeline_query", query: mockQuery },
+				expect.any(Function),
+				expect.any(Function),
+			);
+		});
+
+		it("should handle empty query", async () => {
+			const mockQuery: TimelineQuery = {};
+
+			const mockResponse: TimelineResponse = {
+				events: [],
+				total: 0,
+				hasMore: false,
+				query: mockQuery,
+			};
+
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "timeline_response",
+						data: mockResponse,
+					});
+				}, 0);
+				return true;
+			});
+
+			const result = await queryTimeline(mockQuery);
+
+			expect(result).toEqual(mockResponse);
+		});
+
+		it("should handle error response from server", async () => {
+			const mockQuery: TimelineQuery = {};
+
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "error",
+						message: "Timeline query failed",
+					});
+				}, 0);
+				return true;
+			});
+
+			await expect(queryTimeline(mockQuery)).rejects.toThrow("Timeline query failed");
+		});
+
+		it("should reject when WebSocket is not connected", async () => {
+			const mockQuery: TimelineQuery = {};
+
+			vi.mocked(socketService.send).mockReturnValue(false);
+
+			await expect(queryTimeline(mockQuery)).rejects.toThrow(
+				"Timeline request failed: WebSocket is not connected.",
+			);
+		});
+
+		it("should handle unexpected response type", async () => {
+			const mockQuery: TimelineQuery = {};
+
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "unexpected_type",
+					} as any);
+				}, 0);
+				return true;
+			});
+
+			await expect(queryTimeline(mockQuery)).rejects.toThrow("Unexpected timeline response");
+		});
+
+		it("should query with pagination", async () => {
+			const mockQuery: TimelineQuery = {
+				limit: 20,
+				offset: 40,
+			};
+
+			const mockResponse: TimelineResponse = {
+				events: [],
+				total: 100,
+				hasMore: true,
+				query: mockQuery,
+			};
+
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "timeline_response",
+						data: mockResponse,
+					});
+				}, 0);
+				return true;
+			});
+
+			const result = await queryTimeline(mockQuery);
+
+			expect(result.total).toBe(100);
+			expect(result.hasMore).toBe(true);
+		});
+
+		it("should query with time range filter", async () => {
+			const mockQuery: TimelineQuery = {
+				filters: {
+					startTime: 1700000000000,
+					endTime: 1700003600000,
+				},
+			};
+
+			const mockResponse: TimelineResponse = {
+				events: [],
+				total: 5,
+				hasMore: false,
+				query: mockQuery,
+			};
+
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "timeline_response",
+						data: mockResponse,
+					});
+				}, 0);
+				return true;
+			});
+
+			const result = await queryTimeline(mockQuery);
+
+			expect(result.total).toBe(5);
+		});
+
+		it("should query with code search filter", async () => {
+			const mockQuery: TimelineQuery = {
+				filters: {
+					codeContains: "ggplot",
+				},
+			};
+
+			const mockResponse: TimelineResponse = {
+				events: [],
+				total: 3,
+				hasMore: false,
+				query: mockQuery,
+			};
+
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "timeline_response",
+						data: mockResponse,
+					});
+				}, 0);
+				return true;
+			});
+
+			const result = await queryTimeline(mockQuery);
+
+			expect(result.total).toBe(3);
+		});
+	});
+
+	describe("getTimelineStats", () => {
+		it("should successfully fetch timeline statistics", async () => {
+			const mockStats: TimelineStats = {
+				totalEvents: 150,
+				totalPlots: 25,
+				totalErrors: 5,
+				userActions: 100,
+				aiActions: 50,
+				sessionStartTime: 1700000000000,
+				sessionEndTime: 1700003600000,
+				sessionDuration: 3600000,
+			};
+
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "timeline_stats_response",
+						stats: mockStats,
+					});
+				}, 0);
+				return true;
+			});
+
+			const result = await getTimelineStats();
+
+			expect(result).toEqual(mockStats);
+			expect(socketService.send).toHaveBeenCalledWith(
+				{ type: "timeline_stats_query" },
+				expect.any(Function),
+				expect.any(Function),
+			);
+		});
+
+		it("should handle error response when fetching stats", async () => {
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "error",
+						message: "Failed to calculate stats",
+					});
+				}, 0);
+				return true;
+			});
+
+			await expect(getTimelineStats()).rejects.toThrow("Failed to calculate stats");
+		});
+
+		it("should reject when WebSocket is not connected", async () => {
+			vi.mocked(socketService.send).mockReturnValue(false);
+
+			await expect(getTimelineStats()).rejects.toThrow(
+				"Timeline stats request failed: WebSocket is not connected.",
+			);
+		});
+
+		it("should handle unexpected response type", async () => {
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "unexpected_type",
+					} as any);
+				}, 0);
+				return true;
+			});
+
+			await expect(getTimelineStats()).rejects.toThrow("Unexpected timeline stats response");
+		});
+
+		it("should handle stats with zero values", async () => {
+			const mockStats: TimelineStats = {
+				totalEvents: 0,
+				totalPlots: 0,
+				totalErrors: 0,
+				userActions: 0,
+				aiActions: 0,
+				sessionStartTime: 1700000000000,
+				sessionEndTime: 1700000000000,
+				sessionDuration: 0,
+			};
+
+			vi.mocked(socketService.send).mockImplementation((message, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "timeline_stats_response",
+						stats: mockStats,
+					});
+				}, 0);
+				return true;
+			});
+
+			const result = await getTimelineStats();
+
+			expect(result.totalEvents).toBe(0);
+			expect(result.sessionDuration).toBe(0);
+		});
+	});
+
+	describe("subscribeToTimelineEvents", () => {
+		it("should subscribe to timeline events and call handler", () => {
+			const mockHandler = vi.fn();
+			const mockUnsubscribe = vi.fn();
+
+			const mockEvent: ExecutionEventPayload = {
+				event_id: "evt-123",
+				context: {
+					source: "cell",
+					document_path: "analysis.R",
+					cell_index: 1,
+					triggered_at_ms: 1700000000000,
+					actor: "user",
+				},
+				blocks: [
+					{
+						id: "block-1",
+						index: 0,
+						kind: "section",
+						label: "Setup",
+						start_line: 1,
+						end_line: 3,
+						code: "x <- 1:10",
+					},
+				],
+				result: {
+					success: true,
+					output: "[1] 1 2 3",
+					error: null,
+					plots: [],
+					execution_time_ms: 42,
+				},
+				environment: {
+					r_path: "Rscript",
+					working_dir: "/tmp",
+					temp_dir: "/tmp/reprod",
+				},
+				created_at_ms: 1700000000500,
+			};
+
+			vi.mocked(socketService.on).mockImplementation((event, callback) => {
+				// Simulate incoming event
+				setTimeout(() => {
+					callback({
+						type: "timeline_event_added",
+						event: mockEvent,
+					});
+				}, 0);
+				return mockUnsubscribe;
+			});
+
+			const unsubscribe = subscribeToTimelineEvents(mockHandler);
+
+			// Wait for event to be processed
+			setTimeout(() => {
+				expect(mockHandler).toHaveBeenCalledWith(mockEvent);
+				expect(socketService.on).toHaveBeenCalledWith("timeline_event_added", expect.any(Function));
+			}, 10);
+
+			expect(typeof unsubscribe).toBe("function");
+		});
+
+		it("should not call handler for non-timeline events", () => {
+			const mockHandler = vi.fn();
+
+			vi.mocked(socketService.on).mockImplementation((event, callback) => {
+				// Simulate non-timeline event
+				setTimeout(() => {
+					callback({
+						type: "other_event",
+					} as any);
+				}, 0);
+				return vi.fn();
+			});
+
+			subscribeToTimelineEvents(mockHandler);
+
+			setTimeout(() => {
+				expect(mockHandler).not.toHaveBeenCalled();
+			}, 10);
+		});
+
+		it("should handle multiple events", () => {
+			const mockHandler = vi.fn();
+
+			const event1: ExecutionEventPayload = {
+				event_id: "evt-1",
+				context: {
+					source: "cell",
+					document_path: null,
+					cell_index: null,
+					triggered_at_ms: 1700000000000,
+					actor: "user",
+				},
+				blocks: [],
+				result: {
+					success: true,
+					output: "output1",
+					error: null,
+					plots: [],
+					execution_time_ms: 10,
+				},
+				environment: {
+					r_path: "Rscript",
+					working_dir: "/tmp",
+					temp_dir: "/tmp/reprod",
+				},
+				created_at_ms: 1700000000000,
+			};
+
+			const event2: ExecutionEventPayload = {
+				...event1,
+				event_id: "evt-2",
+				created_at_ms: 1700000001000,
+			};
+
+			vi.mocked(socketService.on).mockImplementation((event, callback) => {
+				setTimeout(() => {
+					callback({
+						type: "timeline_event_added",
+						event: event1,
+					});
+					callback({
+						type: "timeline_event_added",
+						event: event2,
+					});
+				}, 0);
+				return vi.fn();
+			});
+
+			subscribeToTimelineEvents(mockHandler);
+
+			setTimeout(() => {
+				expect(mockHandler).toHaveBeenCalledTimes(2);
+				expect(mockHandler).toHaveBeenNthCalledWith(1, event1);
+				expect(mockHandler).toHaveBeenNthCalledWith(2, event2);
+			}, 10);
+		});
+
+		it("should return unsubscribe function", () => {
+			const mockHandler = vi.fn();
+			const mockUnsubscribe = vi.fn();
+
+			vi.mocked(socketService.on).mockReturnValue(mockUnsubscribe);
+
+			const unsubscribe = subscribeToTimelineEvents(mockHandler);
+
+			expect(unsubscribe).toBe(mockUnsubscribe);
+		});
+	});
 });

--- a/client/src/services/errorHandler.ts
+++ b/client/src/services/errorHandler.ts
@@ -6,17 +6,17 @@
  */
 
 type NotifyOptions = {
-  description?: string;
-  error?: unknown;
-  actionLabel?: string;
-  onAction?: () => void;
-  duration?: number;
-  persist?: boolean;
+	description?: string;
+	error?: unknown;
+	actionLabel?: string;
+	onAction?: () => void;
+	duration?: number;
+	persist?: boolean;
 };
 
 const DEFAULT_DURATION = 6000;
-const CONTAINER_ID = 'app-error-notifications';
-const STYLE_ID = 'app-error-notification-styles';
+const CONTAINER_ID = "app-error-notifications";
+const STYLE_ID = "app-error-notification-styles";
 
 const styles = `
   #${CONTAINER_ID} {
@@ -106,130 +106,130 @@ const styles = `
 `;
 
 export class ErrorHandler {
-  private static styleInjected = false;
+	private static styleInjected = false;
 
-  static notify(message: string, options: NotifyOptions = {}): void {
-    if (typeof document === 'undefined') {
-      ErrorHandler.logToConsole(message, options.error);
-      return;
-    }
+	static notify(message: string, options: NotifyOptions = {}): void {
+		if (typeof document === "undefined") {
+			ErrorHandler.logToConsole(message, options.error);
+			return;
+		}
 
-    ErrorHandler.injectStyles();
-    const container = ErrorHandler.ensureContainer();
-    const notification = document.createElement('div');
-    notification.className = 'error-notification';
-    notification.setAttribute('role', 'alert');
-    notification.setAttribute('aria-live', 'assertive');
-    notification.style.position = 'relative';
+		ErrorHandler.injectStyles();
+		const container = ErrorHandler.ensureContainer();
+		const notification = document.createElement("div");
+		notification.className = "error-notification";
+		notification.setAttribute("role", "alert");
+		notification.setAttribute("aria-live", "assertive");
+		notification.style.position = "relative";
 
-    const title = document.createElement('p');
-    title.className = 'error-notification__title';
-    title.textContent = message;
-    notification.appendChild(title);
+		const title = document.createElement("p");
+		title.className = "error-notification__title";
+		title.textContent = message;
+		notification.appendChild(title);
 
-    const description = options.description ?? ErrorHandler.describe(options.error);
-    if (description) {
-      const descriptionEl = document.createElement('p');
-      descriptionEl.className = 'error-notification__description';
-      descriptionEl.textContent = description;
-      notification.appendChild(descriptionEl);
-    }
+		const description = options.description ?? ErrorHandler.describe(options.error);
+		if (description) {
+			const descriptionEl = document.createElement("p");
+			descriptionEl.className = "error-notification__description";
+			descriptionEl.textContent = description;
+			notification.appendChild(descriptionEl);
+		}
 
-    if (options.actionLabel && options.onAction) {
-      const actions = document.createElement('div');
-      actions.className = 'error-notification__actions';
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'error-notification__button';
-      button.textContent = options.actionLabel;
-      button.addEventListener('click', () => {
-        options.onAction?.();
-        ErrorHandler.dismiss(notification);
-      });
-      actions.appendChild(button);
-      notification.appendChild(actions);
-    }
+		if (options.actionLabel && options.onAction) {
+			const actions = document.createElement("div");
+			actions.className = "error-notification__actions";
+			const button = document.createElement("button");
+			button.type = "button";
+			button.className = "error-notification__button";
+			button.textContent = options.actionLabel;
+			button.addEventListener("click", () => {
+				options.onAction?.();
+				ErrorHandler.dismiss(notification);
+			});
+			actions.appendChild(button);
+			notification.appendChild(actions);
+		}
 
-    const close = document.createElement('button');
-    close.type = 'button';
-    close.className = 'error-notification__close';
-    close.setAttribute('aria-label', 'Dismiss notification');
-    close.textContent = '\u00d7';
-    close.addEventListener('click', () => ErrorHandler.dismiss(notification));
-    notification.appendChild(close);
+		const close = document.createElement("button");
+		close.type = "button";
+		close.className = "error-notification__close";
+		close.setAttribute("aria-label", "Dismiss notification");
+		close.textContent = "\u00d7";
+		close.addEventListener("click", () => ErrorHandler.dismiss(notification));
+		notification.appendChild(close);
 
-    container.appendChild(notification);
+		container.appendChild(notification);
 
-    if (!options.persist) {
-      const duration = options.duration ?? DEFAULT_DURATION;
-      window.setTimeout(() => ErrorHandler.dismiss(notification), duration);
-    }
+		if (!options.persist) {
+			const duration = options.duration ?? DEFAULT_DURATION;
+			window.setTimeout(() => ErrorHandler.dismiss(notification), duration);
+		}
 
-    ErrorHandler.logToConsole(message, options.error);
-  }
+		ErrorHandler.logToConsole(message, options.error);
+	}
 
-  private static ensureContainer(): HTMLDivElement {
-    const existing = document.getElementById(CONTAINER_ID) as HTMLDivElement | null;
-    if (existing) {
-      return existing;
-    }
-    const container = document.createElement('div');
-    container.id = CONTAINER_ID;
-    container.setAttribute('aria-live', 'assertive');
-    container.setAttribute('aria-atomic', 'true');
-    document.body.appendChild(container);
-    return container;
-  }
+	private static ensureContainer(): HTMLDivElement {
+		const existing = document.getElementById(CONTAINER_ID) as HTMLDivElement | null;
+		if (existing) {
+			return existing;
+		}
+		const container = document.createElement("div");
+		container.id = CONTAINER_ID;
+		container.setAttribute("aria-live", "assertive");
+		container.setAttribute("aria-atomic", "true");
+		document.body.appendChild(container);
+		return container;
+	}
 
-  private static injectStyles(): void {
-    if (ErrorHandler.styleInjected || typeof document === 'undefined') {
-      return;
-    }
-    if (document.getElementById(STYLE_ID)) {
-      ErrorHandler.styleInjected = true;
-      return;
-    }
-    const styleEl = document.createElement('style');
-    styleEl.id = STYLE_ID;
-    styleEl.textContent = styles;
-    document.head.appendChild(styleEl);
-    ErrorHandler.styleInjected = true;
-  }
+	private static injectStyles(): void {
+		if (ErrorHandler.styleInjected || typeof document === "undefined") {
+			return;
+		}
+		if (document.getElementById(STYLE_ID)) {
+			ErrorHandler.styleInjected = true;
+			return;
+		}
+		const styleEl = document.createElement("style");
+		styleEl.id = STYLE_ID;
+		styleEl.textContent = styles;
+		document.head.appendChild(styleEl);
+		ErrorHandler.styleInjected = true;
+	}
 
-  private static describe(error: unknown): string | undefined {
-    if (!error) {
-      return undefined;
-    }
+	private static describe(error: unknown): string | undefined {
+		if (!error) {
+			return undefined;
+		}
 
-    if (typeof error === 'string') {
-      return error;
-    }
+		if (typeof error === "string") {
+			return error;
+		}
 
-    if (error instanceof Error) {
-      return error.message;
-    }
+		if (error instanceof Error) {
+			return error.message;
+		}
 
-    try {
-      return JSON.stringify(error);
-    } catch {
-      return undefined;
-    }
-  }
+		try {
+			return JSON.stringify(error);
+		} catch {
+			return undefined;
+		}
+	}
 
-  private static dismiss(element: HTMLElement): void {
-    element.classList.add('error-notification--leaving');
-    window.setTimeout(() => {
-      element.remove();
-    }, 180);
-  }
+	private static dismiss(element: HTMLElement): void {
+		element.classList.add("error-notification--leaving");
+		window.setTimeout(() => {
+			element.remove();
+		}, 180);
+	}
 
-  private static logToConsole(message: string, error?: unknown): void {
-    if (error) {
-      console.error(message, error);
-    } else {
-      console.error(message);
-    }
-  }
+	private static logToConsole(message: string, error?: unknown): void {
+		if (error) {
+			console.error(message, error);
+		} else {
+			console.error(message);
+		}
+	}
 }
 
 export default ErrorHandler;

--- a/client/src/services/executionService.ts
+++ b/client/src/services/executionService.ts
@@ -1,22 +1,22 @@
-import type { ExecutionRequestPayload, ExecutionResultPayload } from '@shared/types';
-import type { ServerMessage } from 'shared';
-import { socketService } from './socket';
+import type { ExecutionRequestPayload, ExecutionResultPayload } from "@shared/types";
+import type { ServerMessage } from "shared";
+import { socketService } from "./socket";
 
-type ExecutionSuccessMessage = Extract<ServerMessage, { type: 'execution_result' }>;
+type ExecutionSuccessMessage = Extract<ServerMessage, { type: "execution_result" }>;
 
 const executionMatcher = (message: ServerMessage): boolean =>
-  message.type === 'execution_result' || message.type === 'error';
+	message.type === "execution_result" || message.type === "error";
 
 export class ExecutionServiceError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'ExecutionServiceError';
-  }
+	constructor(message: string) {
+		super(message);
+		this.name = "ExecutionServiceError";
+	}
 }
 
 export interface ExecuteResponse {
-  raw: ExecutionSuccessMessage;
-  result: ExecutionResultPayload;
+	raw: ExecutionSuccessMessage;
+	result: ExecutionResultPayload;
 }
 
 /**
@@ -25,27 +25,27 @@ export interface ExecuteResponse {
  * wire callbacks manually.
  */
 export async function executeRequest(request: ExecutionRequestPayload): Promise<ExecuteResponse> {
-  return new Promise<ExecuteResponse>((resolve, reject) => {
-    const didSend = socketService.send(
-      { type: 'execute', request },
-      (message) => {
-        if (message.type === 'execution_result') {
-          resolve({ raw: message, result: message.result });
-          return;
-        }
+	return new Promise<ExecuteResponse>((resolve, reject) => {
+		const didSend = socketService.send(
+			{ type: "execute", request },
+			(message) => {
+				if (message.type === "execution_result") {
+					resolve({ raw: message, result: message.result });
+					return;
+				}
 
-        if (message.type === 'error') {
-          reject(new ExecutionServiceError(message.message));
-          return;
-        }
+				if (message.type === "error") {
+					reject(new ExecutionServiceError(message.message));
+					return;
+				}
 
-        reject(new ExecutionServiceError(`Unexpected execution response: ${message.type}`));
-      },
-      executionMatcher
-    );
+				reject(new ExecutionServiceError(`Unexpected execution response: ${message.type}`));
+			},
+			executionMatcher,
+		);
 
-    if (!didSend) {
-      reject(new ExecutionServiceError('WebSocket is not connected'));
-    }
-  });
+		if (!didSend) {
+			reject(new ExecutionServiceError("WebSocket is not connected"));
+		}
+	});
 }

--- a/client/src/services/exportService.ts
+++ b/client/src/services/exportService.ts
@@ -1,67 +1,67 @@
-import { socketService } from '@/services/socket';
 import type {
-  ExportRMarkdownRequestPayload,
-  ExportRMarkdownResponsePayload,
-  ServerMessage,
-} from 'shared';
+	ExportRMarkdownRequestPayload,
+	ExportRMarkdownResponsePayload,
+	ServerMessage,
+} from "shared";
+import { socketService } from "@/services/socket";
 
 const exportMatcher = (message: ServerMessage) =>
-  message.type === 'export_rmarkdown_response' || message.type === 'error';
+	message.type === "export_rmarkdown_response" || message.type === "error";
 
 export class ExportServiceError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'ExportServiceError';
-  }
+	constructor(message: string) {
+		super(message);
+		this.name = "ExportServiceError";
+	}
 }
 
 export async function exportRMarkdown(
-  payload: ExportRMarkdownRequestPayload,
-  timeoutMs = 30000
+	payload: ExportRMarkdownRequestPayload,
+	timeoutMs = 30000,
 ): Promise<ExportRMarkdownResponsePayload> {
-  return new Promise<ExportRMarkdownResponsePayload>((resolve, reject) => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+	return new Promise<ExportRMarkdownResponsePayload>((resolve, reject) => {
+		let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
-    const cleanup = () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
+		const cleanup = () => {
+			if (timeoutId) {
+				clearTimeout(timeoutId);
+			}
+		};
 
-    timeoutId = setTimeout(() => {
-      timeoutId = null;
-      reject(new ExportServiceError('Export timeout - please check server logs'));
-    }, timeoutMs);
+		timeoutId = setTimeout(() => {
+			timeoutId = null;
+			reject(new ExportServiceError("Export timeout - please check server logs"));
+		}, timeoutMs);
 
-    const didSend = socketService.send(
-      { type: 'export_rmarkdown', request: payload },
-      (message) => {
-        cleanup();
+		const didSend = socketService.send(
+			{ type: "export_rmarkdown", request: payload },
+			(message) => {
+				cleanup();
 
-        if (message.type === 'export_rmarkdown_response') {
-          const { response } = message;
-          if (response.success) {
-            resolve(response);
-            return;
-          }
+				if (message.type === "export_rmarkdown_response") {
+					const { response } = message;
+					if (response.success) {
+						resolve(response);
+						return;
+					}
 
-          reject(new ExportServiceError(response.error || 'Export failed'));
-          return;
-        }
+					reject(new ExportServiceError(response.error || "Export failed"));
+					return;
+				}
 
-        if (message.type === 'error') {
-          reject(new ExportServiceError(message.message || 'Export failed'));
-          return;
-        }
+				if (message.type === "error") {
+					reject(new ExportServiceError(message.message || "Export failed"));
+					return;
+				}
 
-        reject(new ExportServiceError('Export failed'));
-      },
-      exportMatcher
-    );
+				reject(new ExportServiceError("Export failed"));
+			},
+			exportMatcher,
+		);
 
-    if (!didSend) {
-      cleanup();
-      reject(new ExportServiceError('WebSocket not connected'));
-    }
-  });
+		if (!didSend) {
+			cleanup();
+			reject(new ExportServiceError("WebSocket not connected"));
+		}
+	});
 }

--- a/client/src/services/fileService.ts
+++ b/client/src/services/fileService.ts
@@ -1,16 +1,16 @@
-import type { CodeBlock } from '@shared/types';
+import type { CodeBlock } from "@shared/types";
 
 export async function applyCodeChangeFile(codeBlock: CodeBlock): Promise<void> {
-  const response = await fetch('/api/ai/code-change', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ codeBlock }),
-  });
+	const response = await fetch("/api/ai/code-change", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({ codeBlock }),
+	});
 
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(text || `Failed to apply code change (${response.status})`);
-  }
+	if (!response.ok) {
+		const text = await response.text();
+		throw new Error(text || `Failed to apply code change (${response.status})`);
+	}
 }

--- a/client/src/services/fileSystem.ts
+++ b/client/src/services/fileSystem.ts
@@ -1,137 +1,133 @@
-import type {
-  FileEntryPayload,
-  FileSystemAction,
-  FileSystemEventPayload,
-} from '@shared/types';
-import type { ExtractServerMessage } from 'shared';
-import { ROOT_PATH, normalizePathInput, normalizeRelativePath } from '@/core/pathUtils';
-import { socketService } from './socket';
+import type { FileEntryPayload, FileSystemAction, FileSystemEventPayload } from "@shared/types";
+import type { ExtractServerMessage } from "shared";
+import { normalizePathInput, normalizeRelativePath, ROOT_PATH } from "@/core/pathUtils";
+import { socketService } from "./socket";
 
 export type FileEntry = FileEntryPayload & {
-  children?: FileEntry[];
+	children?: FileEntry[];
 };
 
 export type FileSystemEvent = FileSystemEventPayload;
 
-type FileSystemResultMessage = ExtractServerMessage<'fs_result'>;
+type FileSystemResultMessage = ExtractServerMessage<"fs_result">;
 
 const mapEntry = (entry: FileEntryPayload): FileEntry => {
-  const normalizedPath = normalizeRelativePath(entry.path, { keepRootEmpty: true });
-  return {
-    ...entry,
-    path: normalizedPath,
-    children: entry.children ? entry.children.map(mapEntry) : undefined,
-  };
+	const normalizedPath = normalizeRelativePath(entry.path, {
+		keepRootEmpty: true,
+	});
+	return {
+		...entry,
+		path: normalizedPath,
+		children: entry.children ? entry.children.map(mapEntry) : undefined,
+	};
 };
 
 const toFileEntries = (data: FileEntryPayload[] | string | null | undefined): FileEntry[] => {
-  if (!Array.isArray(data)) {
-    return [];
-  }
-  return data.map(mapEntry);
+	if (!Array.isArray(data)) {
+		return [];
+	}
+	return data.map(mapEntry);
 };
 
 const sendFsAction = async <TData>(
-  action: FileSystemAction,
-  path: string,
-  options?: {
-    content?: string;
-    to?: string;
-    transform?: (message: FileSystemResultMessage) => TData;
-  }
+	action: FileSystemAction,
+	path: string,
+	options?: {
+		content?: string;
+		to?: string;
+		transform?: (message: FileSystemResultMessage) => TData;
+	},
 ): Promise<TData> => {
-  const normalizedPath = normalizePathInput(path);
-  const normalizedTo = options?.to ? normalizePathInput(options.to) : undefined;
-  const response = await socketService.request(
-    {
-      type: 'fs_action',
-      action,
-      path: normalizedPath,
-      content: options?.content,
-      to: normalizedTo,
-    },
-    'fs_result',
-    (message) => {
-      if (message.action !== action) {
-        return false;
-      }
+	const normalizedPath = normalizePathInput(path);
+	const normalizedTo = options?.to ? normalizePathInput(options.to) : undefined;
+	const response = await socketService.request(
+		{
+			type: "fs_action",
+			action,
+			path: normalizedPath,
+			content: options?.content,
+			to: normalizedTo,
+		},
+		"fs_result",
+		(message) => {
+			if (message.action !== action) {
+				return false;
+			}
 
-      const messagePath = message.path
-        ? normalizePathInput(message.path)
-        : undefined;
-      if (messagePath !== normalizedPath) {
-        return false;
-      }
+			const messagePath = message.path ? normalizePathInput(message.path) : undefined;
+			if (messagePath !== normalizedPath) {
+				return false;
+			}
 
-      if (normalizedTo) {
-        const messageTo = message.to ? normalizePathInput(message.to) : undefined;
-        return messageTo === normalizedTo;
-      }
+			if (normalizedTo) {
+				const messageTo = message.to ? normalizePathInput(message.to) : undefined;
+				return messageTo === normalizedTo;
+			}
 
-      return true;
-    }
-  );
+			return true;
+		},
+	);
 
-  if (!response.success) {
-    throw new Error(response.error ?? `File system action "${action}" failed`);
-  }
+	if (!response.success) {
+		throw new Error(response.error ?? `File system action "${action}" failed`);
+	}
 
-  if (options?.transform) {
-    return options.transform(response);
-  }
+	if (options?.transform) {
+		return options.transform(response);
+	}
 
-  return response.data as TData;
+	return response.data as TData;
 };
 
 export const fileSystem = {
-  listDir: async (path: string): Promise<FileEntry[]> => {
-    return sendFsAction<FileEntry[]>('list', path, {
-      transform: (message) => toFileEntries(message.data),
-    });
-  },
+	listDir: async (path: string): Promise<FileEntry[]> => {
+		return sendFsAction<FileEntry[]>("list", path, {
+			transform: (message) => toFileEntries(message.data),
+		});
+	},
 
-  readFile: async (path: string): Promise<string> => {
-    return sendFsAction<string>('read', path, {
-      transform: (message) => (typeof message.data === 'string' ? message.data : ''),
-    });
-  },
+	readFile: async (path: string): Promise<string> => {
+		return sendFsAction<string>("read", path, {
+			transform: (message) => (typeof message.data === "string" ? message.data : ""),
+		});
+	},
 
-  writeFile: async (path: string, content: string): Promise<void> => {
-    await sendFsAction('write', path, {
-      content,
-      transform: () => undefined,
-    });
-  },
+	writeFile: async (path: string, content: string): Promise<void> => {
+		await sendFsAction("write", path, {
+			content,
+			transform: () => undefined,
+		});
+	},
 
-  deletePath: async (path: string): Promise<void> => {
-    await sendFsAction('delete', path, {
-      transform: () => undefined,
-    });
-  },
+	deletePath: async (path: string): Promise<void> => {
+		await sendFsAction("delete", path, {
+			transform: () => undefined,
+		});
+	},
 
-  renamePath: async (path: string, to: string): Promise<void> => {
-    await sendFsAction('rename', path, {
-      to,
-      transform: () => undefined,
-    });
-  },
+	renamePath: async (path: string, to: string): Promise<void> => {
+		await sendFsAction("rename", path, {
+			to,
+			transform: () => undefined,
+		});
+	},
 
-  createDir: async (path: string): Promise<void> => {
-    await sendFsAction('create_dir', path, {
-      transform: () => undefined,
-    });
-  },
+	createDir: async (path: string): Promise<void> => {
+		await sendFsAction("create_dir", path, {
+			transform: () => undefined,
+		});
+	},
 
-  copyPath: async (path: string, to: string): Promise<void> => {
-    await sendFsAction('copy', path, {
-      to,
-      transform: () => undefined,
-    });
-  },
+	copyPath: async (path: string, to: string): Promise<void> => {
+		await sendFsAction("copy", path, {
+			to,
+			transform: () => undefined,
+		});
+	},
 
-  getWorkspaceRoot: async (): Promise<string> => {
-    return sendFsAction<string>('root', ROOT_PATH, {
-      transform: (message) => (typeof message.data === 'string' ? message.data : ''),
-    });
-  },
+	getWorkspaceRoot: async (): Promise<string> => {
+		return sendFsAction<string>("root", ROOT_PATH, {
+			transform: (message) => (typeof message.data === "string" ? message.data : ""),
+		});
+	},
 };

--- a/client/src/services/menuActions.ts
+++ b/client/src/services/menuActions.ts
@@ -11,31 +11,31 @@
  * with cell metadata, use EditorPanel's buttons or shortcuts.
  */
 
-import { useStore } from '@/core/state/store';
-import { DEFAULT_R_SCRIPT } from '@/core/state/slices/editorSlice';
-import type { ViewPane } from '@/core/state/slices/viewSlice';
-import { interruptExecution, restartSession as restartSessionRequest } from './sessionControl';
-import { exportSessionSnapshot, importSessionSnapshot } from './sessionPersistence';
-import { DOCS_URL, GITHUB_ISSUE_URL } from '@/constants/urls';
+import { DOCS_URL, GITHUB_ISSUE_URL } from "@/constants/urls";
+import { DEFAULT_R_SCRIPT } from "@/core/state/slices/editorSlice";
+import type { ViewPane } from "@/core/state/slices/viewSlice";
+import { useStore } from "@/core/state/store";
+import { interruptExecution, restartSession as restartSessionRequest } from "./sessionControl";
+import { exportSessionSnapshot, importSessionSnapshot } from "./sessionPersistence";
 
 const callGlobalHandler = (name: string) => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  const handler = (window as typeof window & Record<string, unknown>)[name];
-  if (typeof handler === 'function') {
-    (handler as () => void)();
-  } else {
-    console.error(`${name} handler not available`);
-  }
+	if (typeof window === "undefined") {
+		return;
+	}
+	const handler = (window as typeof window & Record<string, unknown>)[name];
+	if (typeof handler === "function") {
+		(handler as () => void)();
+	} else {
+		console.error(`${name} handler not available`);
+	}
 };
 
 const dispatchTerminalEvent = (name: string) => {
-  if (typeof window === 'undefined') {
-    return;
-  }
+	if (typeof window === "undefined") {
+		return;
+	}
 
-  window.dispatchEvent(new Event(name));
+	window.dispatchEvent(new Event(name));
 };
 
 /**
@@ -44,413 +44,413 @@ const dispatchTerminalEvent = (name: string) => {
  * Organized by menu section (File, Edit, Code, Session, View, Help)
  */
 export const menuActions = {
-  // ===== FILE MENU =====
-  file: {
-    /**
-     * Create new R script
-     * Clears editor with confirmation if there are unsaved changes
-     */
-    new: () => {
-      const store = useStore.getState();
-      const isDirty = store.editor?.isDirty;
+	// ===== FILE MENU =====
+	file: {
+		/**
+		 * Create new R script
+		 * Clears editor with confirmation if there are unsaved changes
+		 */
+		new: () => {
+			const store = useStore.getState();
+			const isDirty = store.editor?.isDirty;
 
-      if (isDirty) {
-        if (!confirm('Discard unsaved changes?')) {
-          return;
-        }
-      }
+			if (isDirty) {
+				if (!confirm("Discard unsaved changes?")) {
+					return;
+				}
+			}
 
-      // Reset editor state
-      store.setEditorContent(DEFAULT_R_SCRIPT);
-      store.setEditorFilepath('analysis.R');
-      store.setEditorIsDirty(false);
-    },
-    projects: () => {
-      callGlobalHandler('openProjectsDialog');
-    },
+			// Reset editor state
+			store.setEditorContent(DEFAULT_R_SCRIPT);
+			store.setEditorFilepath("analysis.R");
+			store.setEditorIsDirty(false);
+		},
+		projects: () => {
+			callGlobalHandler("openProjectsDialog");
+		},
 
-    /**
-     * Open file dialog
-     * Browser file picker for .R and .Rmd files
-     */
-    open: () => {
-      const input = document.createElement('input');
-      input.type = 'file';
-      input.accept = '.R,.Rmd';
-      input.onchange = async (e) => {
-        const file = (e.target as HTMLInputElement).files?.[0];
-        if (!file) return;
+		/**
+		 * Open file dialog
+		 * Browser file picker for .R and .Rmd files
+		 */
+		open: () => {
+			const input = document.createElement("input");
+			input.type = "file";
+			input.accept = ".R,.Rmd";
+			input.onchange = async (e) => {
+				const file = (e.target as HTMLInputElement).files?.[0];
+				if (!file) return;
 
-        try {
-          const content = await file.text();
-          const store = useStore.getState();
-          store.setEditorContent(content);
-          store.setEditorFilepath(file.name);
-          store.setEditorIsDirty(false);
-        } catch (error) {
-          console.error(`Failed to open file: ${error}`);
-        }
-      };
-      input.click();
-    },
+				try {
+					const content = await file.text();
+					const store = useStore.getState();
+					store.setEditorContent(content);
+					store.setEditorFilepath(file.name);
+					store.setEditorIsDirty(false);
+				} catch (error) {
+					console.error(`Failed to open file: ${error}`);
+				}
+			};
+			input.click();
+		},
 
-    /**
-     * Save current file
-     * Emits save-file socket event
-     */
-    save: () => {
-      const store = useStore.getState();
-      const { filepath, content } = store.editor || {};
+		/**
+		 * Save current file
+		 * Emits save-file socket event
+		 */
+		save: () => {
+			const store = useStore.getState();
+			const { filepath, content } = store.editor || {};
 
-      if (!filepath) {
-        return menuActions.file.saveAs();
-      }
+			if (!filepath) {
+				return menuActions.file.saveAs();
+			}
 
-      if (!content) {
-        console.error('No content to save');
-        return;
-      }
+			if (!content) {
+				console.error("No content to save");
+				return;
+			}
 
-      // Save file (simplified - no socket event for now)
-      const blob = new Blob([content], { type: 'text/plain' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filepath;
-      a.click();
-      URL.revokeObjectURL(url);
+			// Save file (simplified - no socket event for now)
+			const blob = new Blob([content], { type: "text/plain" });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = filepath;
+			a.click();
+			URL.revokeObjectURL(url);
 
-      store.setEditorIsDirty(false);
-    },
+			store.setEditorIsDirty(false);
+		},
 
-    /**
-     * Save as new file
-     * Browser download
-     */
-    saveAs: () => {
-      const store = useStore.getState();
-      const { content } = store.editor || {};
+		/**
+		 * Save as new file
+		 * Browser download
+		 */
+		saveAs: () => {
+			const store = useStore.getState();
+			const { content } = store.editor || {};
 
-      if (!content) {
-        console.error('No content to save');
-        return;
-      }
+			if (!content) {
+				console.error("No content to save");
+				return;
+			}
 
-      const blob = new Blob([content], { type: 'text/plain' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'untitled.R';
-      a.click();
-      URL.revokeObjectURL(url);
-    },
+			const blob = new Blob([content], { type: "text/plain" });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = "untitled.R";
+			a.click();
+			URL.revokeObjectURL(url);
+		},
 
-    /**
-     * Export reproducible session
-     * Opens export dialog for RMarkdown/Bundle export
-     */
-    exportSession: () => {
-      // Call global export dialog handler
-      if (typeof (window as any).openExportDialog === 'function') {
-        (window as any).openExportDialog();
-      } else {
-        console.error('Export dialog not initialized');
-      }
-    },
-  },
+		/**
+		 * Export reproducible session
+		 * Opens export dialog for RMarkdown/Bundle export
+		 */
+		exportSession: () => {
+			// Call global export dialog handler
+			if (typeof (window as any).openExportDialog === "function") {
+				(window as any).openExportDialog();
+			} else {
+				console.error("Export dialog not initialized");
+			}
+		},
+	},
 
-  // ===== EDIT MENU =====
-  edit: {
-    // These delegate to Monaco editor
-    undo: () => {
-      const editor = useStore.getState().monacoEditor;
-      if (editor?.trigger) {
-        editor.trigger('menu', 'undo', null);
-      }
-    },
+	// ===== EDIT MENU =====
+	edit: {
+		// These delegate to Monaco editor
+		undo: () => {
+			const editor = useStore.getState().monacoEditor;
+			if (editor?.trigger) {
+				editor.trigger("menu", "undo", null);
+			}
+		},
 
-    redo: () => {
-      const editor = useStore.getState().monacoEditor;
-      if (editor?.trigger) {
-        editor.trigger('menu', 'redo', null);
-      }
-    },
+		redo: () => {
+			const editor = useStore.getState().monacoEditor;
+			if (editor?.trigger) {
+				editor.trigger("menu", "redo", null);
+			}
+		},
 
-    cut: () => {
-      const editor = useStore.getState().monacoEditor;
-      if (editor?.trigger) {
-        editor.trigger('menu', 'editor.action.clipboardCutAction', null);
-      }
-    },
+		cut: () => {
+			const editor = useStore.getState().monacoEditor;
+			if (editor?.trigger) {
+				editor.trigger("menu", "editor.action.clipboardCutAction", null);
+			}
+		},
 
-    copy: () => {
-      const editor = useStore.getState().monacoEditor;
-      if (editor?.trigger) {
-        editor.trigger('menu', 'editor.action.clipboardCopyAction', null);
-      }
-    },
+		copy: () => {
+			const editor = useStore.getState().monacoEditor;
+			if (editor?.trigger) {
+				editor.trigger("menu", "editor.action.clipboardCopyAction", null);
+			}
+		},
 
-    paste: () => {
-      const editor = useStore.getState().monacoEditor;
-      if (editor?.trigger) {
-        editor.trigger('menu', 'editor.action.clipboardPasteAction', null);
-      }
-    },
+		paste: () => {
+			const editor = useStore.getState().monacoEditor;
+			if (editor?.trigger) {
+				editor.trigger("menu", "editor.action.clipboardPasteAction", null);
+			}
+		},
 
-    find: () => {
-      const editor = useStore.getState().monacoEditor;
-      if (editor?.trigger) {
-        editor.trigger('menu', 'actions.find', null);
-      }
-    },
+		find: () => {
+			const editor = useStore.getState().monacoEditor;
+			if (editor?.trigger) {
+				editor.trigger("menu", "actions.find", null);
+			}
+		},
 
-    replace: () => {
-      const editor = useStore.getState().monacoEditor;
-      if (editor?.trigger) {
-        editor.trigger('menu', 'editor.action.startFindReplaceAction', null);
-      }
-    },
+		replace: () => {
+			const editor = useStore.getState().monacoEditor;
+			if (editor?.trigger) {
+				editor.trigger("menu", "editor.action.startFindReplaceAction", null);
+			}
+		},
 
-    /**
-     * Focus AI Assistant panel
-     * Most important menu action - Cmd+K
-     */
-    aiAssist: () => {
-      // Focus AI panel input
-      setTimeout(() => {
-        const aiInput = document.querySelector('.ai-input') as HTMLTextAreaElement;
-        if (aiInput) {
-          aiInput.focus();
-        }
-      }, 100);
-    },
-  },
+		/**
+		 * Focus AI Assistant panel
+		 * Most important menu action - Cmd+K
+		 */
+		aiAssist: () => {
+			// Focus AI panel input
+			setTimeout(() => {
+				const aiInput = document.querySelector(".ai-input") as HTMLTextAreaElement;
+				if (aiInput) {
+					aiInput.focus();
+				}
+			}, 100);
+		},
+	},
 
-  // ===== CODE MENU =====
-  code: {
-    /**
-     * Run selected code or current line
-     * Delegates to EditorPanel's handleRunCurrentCell for full functionality
-     */
-    runSelection: () => {
-      const runCurrentCell = useStore.getState().runCurrentCell;
-      if (runCurrentCell) {
-        runCurrentCell();
-      } else {
-        console.error('Code execution not available: EditorPanel not mounted');
-      }
-    },
+	// ===== CODE MENU =====
+	code: {
+		/**
+		 * Run selected code or current line
+		 * Delegates to EditorPanel's handleRunCurrentCell for full functionality
+		 */
+		runSelection: () => {
+			const runCurrentCell = useStore.getState().runCurrentCell;
+			if (runCurrentCell) {
+				runCurrentCell();
+			} else {
+				console.error("Code execution not available: EditorPanel not mounted");
+			}
+		},
 
-    /**
-     * Run all code in editor
-     * Delegates to EditorPanel's handleRunAll for full functionality
-     */
-    runAll: () => {
-      const runAll = useStore.getState().runAll;
-      if (runAll) {
-        runAll();
-      } else {
-        console.error('Code execution not available: EditorPanel not mounted');
-      }
-    },
+		/**
+		 * Run all code in editor
+		 * Delegates to EditorPanel's handleRunAll for full functionality
+		 */
+		runAll: () => {
+			const runAll = useStore.getState().runAll;
+			if (runAll) {
+				runAll();
+			} else {
+				console.error("Code execution not available: EditorPanel not mounted");
+			}
+		},
 
-    /**
-     * Source file in clean environment
-     * Same as runAll (executes whole document)
-     */
-    sourceFile: () => {
-      const runAll = useStore.getState().runAll;
-      if (runAll) {
-        runAll();
-      } else {
-        console.error('Code execution not available: EditorPanel not mounted');
-      }
-    },
+		/**
+		 * Source file in clean environment
+		 * Same as runAll (executes whole document)
+		 */
+		sourceFile: () => {
+			const runAll = useStore.getState().runAll;
+			if (runAll) {
+				runAll();
+			} else {
+				console.error("Code execution not available: EditorPanel not mounted");
+			}
+		},
 
-    /**
-     * Interrupt running R execution
-     */
-    interrupt: () => {
-      const store = useStore.getState();
-      if (!store.execution.isRunning) {
-        return;
-      }
+		/**
+		 * Interrupt running R execution
+		 */
+		interrupt: () => {
+			const store = useStore.getState();
+			if (!store.execution.isRunning) {
+				return;
+			}
 
-      void interruptExecution().catch((error) => {
-        console.error('Failed to interrupt execution', error);
-      });
-    },
+			void interruptExecution().catch((error) => {
+				console.error("Failed to interrupt execution", error);
+			});
+		},
 
-    /**
-     * Restart R session
-     * Clears workspace and restarts R process
-     */
-    restartSession: () => {
-      if (!confirm('Restart R session? All workspace variables will be lost.')) {
-        return;
-      }
+		/**
+		 * Restart R session
+		 * Clears workspace and restarts R process
+		 */
+		restartSession: () => {
+			if (!confirm("Restart R session? All workspace variables will be lost.")) {
+				return;
+			}
 
-      void restartSessionRequest().catch((error) => {
-        console.error('Failed to restart session', error);
-        window.alert('Unable to restart session. Check logs for details.');
-      });
-    },
+			void restartSessionRequest().catch((error) => {
+				console.error("Failed to restart session", error);
+				window.alert("Unable to restart session. Check logs for details.");
+			});
+		},
 
-    /**
-     * Comment/uncomment selected lines
-     */
-    comment: () => {
-      const editor = useStore.getState().monacoEditor;
-      if (editor?.trigger) {
-        editor.trigger('menu', 'editor.action.commentLine', null);
-      }
-    },
-  },
+		/**
+		 * Comment/uncomment selected lines
+		 */
+		comment: () => {
+			const editor = useStore.getState().monacoEditor;
+			if (editor?.trigger) {
+				editor.trigger("menu", "editor.action.commentLine", null);
+			}
+		},
+	},
 
-  // ===== SESSION MENU =====
-  session: {
-    /**
-     * Show timeline dialog
-     */
-    showTimeline: () => {
-      // Call global timeline dialog handler
-      if (typeof (window as any).openTimelineDialog === 'function') {
-        (window as any).openTimelineDialog();
-      } else {
-        console.error('Timeline dialog not initialized');
-      }
-    },
+	// ===== SESSION MENU =====
+	session: {
+		/**
+		 * Show timeline dialog
+		 */
+		showTimeline: () => {
+			// Call global timeline dialog handler
+			if (typeof (window as any).openTimelineDialog === "function") {
+				(window as any).openTimelineDialog();
+			} else {
+				console.error("Timeline dialog not initialized");
+			}
+		},
 
-    /**
-     * Export reproducible package
-     */
-    exportReproducible: () => {
-      // Same as file:exportSession
-      menuActions.file.exportSession();
-    },
+		/**
+		 * Export reproducible package
+		 */
+		exportReproducible: () => {
+			// Same as file:exportSession
+			menuActions.file.exportSession();
+		},
 
-    /**
-     * Start new session
-     */
-    new: () => {
-      if (!confirm('Start new session? Unsaved work will be lost.')) {
-        return;
-      }
+		/**
+		 * Start new session
+		 */
+		new: () => {
+			if (!confirm("Start new session? Unsaved work will be lost.")) {
+				return;
+			}
 
-      window.location.reload();
-    },
+			window.location.reload();
+		},
 
-    /**
-     * Save session
-     */
-    save: () => {
-      exportSessionSnapshot();
-    },
+		/**
+		 * Save session
+		 */
+		save: () => {
+			exportSessionSnapshot();
+		},
 
-    /**
-     * Load session
-     */
-    load: () => {
-      importSessionSnapshot();
-    },
+		/**
+		 * Load session
+		 */
+		load: () => {
+			importSessionSnapshot();
+		},
 
-    /**
-     * Show session info
-     */
-    info: () => {
-      callGlobalHandler('openSessionInfoDialog');
-    },
+		/**
+		 * Show session info
+		 */
+		info: () => {
+			callGlobalHandler("openSessionInfoDialog");
+		},
 
-    /**
-     * Open settings
-     * TODO: Implement settings modal
-     */
-    settings: () => {
-      callGlobalHandler('openSettingsDialog');
-    },
-  },
+		/**
+		 * Open settings
+		 * TODO: Implement settings modal
+		 */
+		settings: () => {
+			callGlobalHandler("openSettingsDialog");
+		},
+	},
 
-  // ===== VIEW MENU =====
-  view: {
-    /**
-     * Toggle pane visibility
-     */
-    togglePane: (paneId: string) => {
-      const pane = paneId as ViewPane;
-      const { togglePaneVisibility } = useStore.getState();
-      togglePaneVisibility(pane);
-    },
+	// ===== VIEW MENU =====
+	view: {
+		/**
+		 * Toggle pane visibility
+		 */
+		togglePane: (paneId: string) => {
+			const pane = paneId as ViewPane;
+			const { togglePaneVisibility } = useStore.getState();
+			togglePaneVisibility(pane);
+		},
 
-    /**
-     * Zoom in
-     */
-    zoomIn: () => {
-      const { adjustZoom } = useStore.getState();
-      adjustZoom(0.1);
-    },
+		/**
+		 * Zoom in
+		 */
+		zoomIn: () => {
+			const { adjustZoom } = useStore.getState();
+			adjustZoom(0.1);
+		},
 
-    /**
-     * Zoom out
-     */
-    zoomOut: () => {
-      const { adjustZoom } = useStore.getState();
-      adjustZoom(-0.1);
-    },
+		/**
+		 * Zoom out
+		 */
+		zoomOut: () => {
+			const { adjustZoom } = useStore.getState();
+			adjustZoom(-0.1);
+		},
 
-    /**
-     * Reset zoom to 100%
-     */
-    zoomReset: () => {
-      const { resetZoom } = useStore.getState();
-      resetZoom();
-    },
+		/**
+		 * Reset zoom to 100%
+		 */
+		zoomReset: () => {
+			const { resetZoom } = useStore.getState();
+			resetZoom();
+		},
 
-    /**
-     * Focus the terminal tab in the bottom pane
-     */
-    focusTerminal: () => {
-      dispatchTerminalEvent('terminal:focus');
-    },
+		/**
+		 * Focus the terminal tab in the bottom pane
+		 */
+		focusTerminal: () => {
+			dispatchTerminalEvent("terminal:focus");
+		},
 
-    /**
-     * Create a new terminal session and show the terminal tab
-     */
-    newTerminalSession: () => {
-      dispatchTerminalEvent('terminal:focus');
-      dispatchTerminalEvent('terminal:new');
-    },
-  },
+		/**
+		 * Create a new terminal session and show the terminal tab
+		 */
+		newTerminalSession: () => {
+			dispatchTerminalEvent("terminal:focus");
+			dispatchTerminalEvent("terminal:new");
+		},
+	},
 
-  // ===== HELP MENU =====
-  help: {
-    /**
-     * Open documentation in new tab
-     */
-    docs: () => {
-      window.open(DOCS_URL, '_blank');
-    },
+	// ===== HELP MENU =====
+	help: {
+		/**
+		 * Open documentation in new tab
+		 */
+		docs: () => {
+			window.open(DOCS_URL, "_blank");
+		},
 
-    /**
-     * Show keyboard shortcuts modal
-     * TODO: Implement shortcuts modal
-     */
-    shortcuts: () => {
-      callGlobalHandler('openShortcutsDialog');
-    },
+		/**
+		 * Show keyboard shortcuts modal
+		 * TODO: Implement shortcuts modal
+		 */
+		shortcuts: () => {
+			callGlobalHandler("openShortcutsDialog");
+		},
 
-    /**
-     * Open GitHub issues page
-     */
-    reportIssue: () => {
-      window.open(GITHUB_ISSUE_URL, '_blank');
-    },
+		/**
+		 * Open GitHub issues page
+		 */
+		reportIssue: () => {
+			window.open(GITHUB_ISSUE_URL, "_blank");
+		},
 
-    /**
-     * Show about modal
-     * TODO: Implement about modal
-     */
-    about: () => {
-      callGlobalHandler('openAboutDialog');
-    },
-  },
+		/**
+		 * Show about modal
+		 * TODO: Implement about modal
+		 */
+		about: () => {
+			callGlobalHandler("openAboutDialog");
+		},
+	},
 };

--- a/client/src/services/projectService.ts
+++ b/client/src/services/projectService.ts
@@ -1,49 +1,49 @@
-import type { SessionSnapshot } from '@/services/sessionPersistence';
-import { getSessionSnapshot } from '@/services/sessionPersistence';
-import { socketService } from '@/services/socket';
+import type { SessionSnapshot } from "@/services/sessionPersistence";
+import { getSessionSnapshot } from "@/services/sessionPersistence";
+import { socketService } from "@/services/socket";
 
 interface CreateProjectPayload {
-  name: string;
-  path: string;
+	name: string;
+	path: string;
 }
 
 interface CloneProjectPayload {
-  remote: string;
-  path: string;
-  name?: string;
+	remote: string;
+	path: string;
+	name?: string;
 }
 
 export const projectService = {
-  requestList(): void {
-    socketService.send({ type: 'project_list' });
-  },
+	requestList(): void {
+		socketService.send({ type: "project_list" });
+	},
 
-  open(projectId: string): void {
-    socketService.send({ type: 'project_open', projectId });
-  },
+	open(projectId: string): void {
+		socketService.send({ type: "project_open", projectId });
+	},
 
-  create(payload: CreateProjectPayload): void {
-    socketService.send({ type: 'project_create', ...payload });
-  },
+	create(payload: CreateProjectPayload): void {
+		socketService.send({ type: "project_create", ...payload });
+	},
 
-  addExisting(path: string): void {
-    socketService.send({ type: 'project_add_existing', path });
-  },
+	addExisting(path: string): void {
+		socketService.send({ type: "project_add_existing", path });
+	},
 
-  clone(payload: CloneProjectPayload): void {
-    socketService.send({ type: 'project_clone', ...payload });
-  },
+	clone(payload: CloneProjectPayload): void {
+		socketService.send({ type: "project_clone", ...payload });
+	},
 
-  loadState(projectId: string): void {
-    socketService.send({ type: 'project_state_load', projectId });
-  },
+	loadState(projectId: string): void {
+		socketService.send({ type: "project_state_load", projectId });
+	},
 
-  saveState(projectId: string, snapshot?: SessionSnapshot): void {
-    const state = snapshot ?? getSessionSnapshot();
-    socketService.send({
-      type: 'project_state_save',
-      projectId,
-      state: state as unknown as Record<string, unknown>,
-    });
-  },
+	saveState(projectId: string, snapshot?: SessionSnapshot): void {
+		const state = snapshot ?? getSessionSnapshot();
+		socketService.send({
+			type: "project_state_save",
+			projectId,
+			state: state as unknown as Record<string, unknown>,
+		});
+	},
 };

--- a/client/src/services/sessionControl.ts
+++ b/client/src/services/sessionControl.ts
@@ -1,54 +1,54 @@
-import { socketService } from './socket';
-import type { ServerMessage } from 'shared';
+import type { ServerMessage } from "shared";
+import { socketService } from "./socket";
 
 const interruptMatcher = (message: ServerMessage): boolean =>
-  message.type === 'execution_interrupted' || message.type === 'error';
+	message.type === "execution_interrupted" || message.type === "error";
 
 const restartMatcher = (message: ServerMessage): boolean =>
-  message.type === 'session_restarted' || message.type === 'error';
+	message.type === "session_restarted" || message.type === "error";
 
 export async function interruptExecution(): Promise<boolean> {
-  return new Promise((resolve, reject) => {
-    const didSend = socketService.send(
-      { type: 'interrupt_execution' },
-      (message) => {
-        if (message.type === 'execution_interrupted') {
-          resolve(message.success);
-          return;
-        }
+	return new Promise((resolve, reject) => {
+		const didSend = socketService.send(
+			{ type: "interrupt_execution" },
+			(message) => {
+				if (message.type === "execution_interrupted") {
+					resolve(message.success);
+					return;
+				}
 
-        if (message.type === 'error') {
-          reject(new Error(message.message));
-        }
-      },
-      interruptMatcher,
-    );
+				if (message.type === "error") {
+					reject(new Error(message.message));
+				}
+			},
+			interruptMatcher,
+		);
 
-    if (!didSend) {
-      reject(new Error('WebSocket is not connected.'));
-    }
-  });
+		if (!didSend) {
+			reject(new Error("WebSocket is not connected."));
+		}
+	});
 }
 
 export async function restartSession(): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const didSend = socketService.send(
-      { type: 'restart_session' },
-      (message) => {
-        if (message.type === 'session_restarted') {
-          resolve();
-          return;
-        }
+	return new Promise((resolve, reject) => {
+		const didSend = socketService.send(
+			{ type: "restart_session" },
+			(message) => {
+				if (message.type === "session_restarted") {
+					resolve();
+					return;
+				}
 
-        if (message.type === 'error') {
-          reject(new Error(message.message));
-        }
-      },
-      restartMatcher,
-    );
+				if (message.type === "error") {
+					reject(new Error(message.message));
+				}
+			},
+			restartMatcher,
+		);
 
-    if (!didSend) {
-      reject(new Error('WebSocket is not connected.'));
-    }
-  });
+		if (!didSend) {
+			reject(new Error("WebSocket is not connected."));
+		}
+	});
 }

--- a/client/src/services/sessionPersistence.ts
+++ b/client/src/services/sessionPersistence.ts
@@ -1,118 +1,116 @@
-import type { ExecutionLogEntry, AppSettings, AIMessage } from '@shared/types';
-import { extractCodeBlocks } from '@/core/ai/codeBlockUtils';
-import { useStore } from '@/core';
-import { queryTimeline } from '@/services/timelineService';
+import type { AIMessage, AppSettings, ExecutionLogEntry } from "@shared/types";
+import { useStore } from "@/core";
+import { extractCodeBlocks } from "@/core/ai/codeBlockUtils";
+import { queryTimeline } from "@/services/timelineService";
 
 const SNAPSHOT_VERSION = 1;
 const STORAGE_FILENAME = () =>
-  `reprod-session-${new Date().toISOString().replace(/[:]/g, '-')}.json`;
+	`reprod-session-${new Date().toISOString().replace(/[:]/g, "-")}.json`;
 
 export interface SessionSnapshot {
-  version: number;
-  savedAt: number;
-  editor: {
-    content: string;
-    filepath: string;
-  };
-  executionHistory: ExecutionLogEntry[];
-  settings: AppSettings;
-  aiMessages: AIMessage[];
+	version: number;
+	savedAt: number;
+	editor: {
+		content: string;
+		filepath: string;
+	};
+	executionHistory: ExecutionLogEntry[];
+	settings: AppSettings;
+	aiMessages: AIMessage[];
 }
 
 const normalizeAIMessages = (messages: AIMessage[]): AIMessage[] =>
-  messages.map((message) => {
-    if (message.codeBlocks && message.codeBlocks.length > 0) {
-      return message;
-    }
+	messages.map((message) => {
+		if (message.codeBlocks && message.codeBlocks.length > 0) {
+			return message;
+		}
 
-    const fallbackText = message.content || message.code || '';
-    const codeBlocks = fallbackText ? extractCodeBlocks(fallbackText) : [];
+		const fallbackText = message.content || message.code || "";
+		const codeBlocks = fallbackText ? extractCodeBlocks(fallbackText) : [];
 
-    return codeBlocks.length
-      ? { ...message, codeBlocks }
-      : message;
-  });
+		return codeBlocks.length ? { ...message, codeBlocks } : message;
+	});
 
 export function getSessionSnapshot(): SessionSnapshot {
-  const state = useStore.getState();
-  return {
-    version: SNAPSHOT_VERSION,
-    savedAt: Date.now(),
-    editor: {
-      content: state.editor.content,
-      filepath: state.editor.filepath,
-    },
-    executionHistory: state.execution.history,
-    settings: state.settings,
-    aiMessages: normalizeAIMessages(state.ai.messages),
-  };
+	const state = useStore.getState();
+	return {
+		version: SNAPSHOT_VERSION,
+		savedAt: Date.now(),
+		editor: {
+			content: state.editor.content,
+			filepath: state.editor.filepath,
+		},
+		executionHistory: state.execution.history,
+		settings: state.settings,
+		aiMessages: normalizeAIMessages(state.ai.messages),
+	};
 }
 
 export function exportSessionSnapshot(): void {
-  const snapshot = getSessionSnapshot();
+	const snapshot = getSessionSnapshot();
 
-  const blob = new Blob([JSON.stringify(snapshot, null, 2)], {
-    type: 'application/json',
-  });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = STORAGE_FILENAME();
-  link.click();
-  URL.revokeObjectURL(url);
+	const blob = new Blob([JSON.stringify(snapshot, null, 2)], {
+		type: "application/json",
+	});
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement("a");
+	link.href = url;
+	link.download = STORAGE_FILENAME();
+	link.click();
+	URL.revokeObjectURL(url);
 }
 
 export function importSessionSnapshot(): void {
-  const input = document.createElement('input');
-  input.type = 'file';
-  input.accept = 'application/json';
-  input.onchange = async (event) => {
-    const file = (event.target as HTMLInputElement).files?.[0];
-    if (!file) return;
+	const input = document.createElement("input");
+	input.type = "file";
+	input.accept = "application/json";
+	input.onchange = async (event) => {
+		const file = (event.target as HTMLInputElement).files?.[0];
+		if (!file) return;
 
-    try {
-      const text = await file.text();
-      const data = JSON.parse(text) as SessionSnapshot;
-      applySessionSnapshot(data);
-    } catch (error) {
-      console.error('Failed to load session snapshot', error);
-      window.alert('Unable to load session snapshot. Ensure the file is valid JSON.');
-    }
-  };
+		try {
+			const text = await file.text();
+			const data = JSON.parse(text) as SessionSnapshot;
+			applySessionSnapshot(data);
+		} catch (error) {
+			console.error("Failed to load session snapshot", error);
+			window.alert("Unable to load session snapshot. Ensure the file is valid JSON.");
+		}
+	};
 
-  input.click();
+	input.click();
 }
 
 export function applySessionSnapshot(snapshot: SessionSnapshot): void {
-  if (snapshot.version !== SNAPSHOT_VERSION) {
-    window.alert('Session snapshot version is not compatible with this build.');
-    return;
-  }
+	if (snapshot.version !== SNAPSHOT_VERSION) {
+		window.alert("Session snapshot version is not compatible with this build.");
+		return;
+	}
 
-  const state = useStore.getState();
-  state.setEditorContent(snapshot.editor.content);
-  state.setEditorFilepath(snapshot.editor.filepath);
-  state.setEditorIsDirty(false);
-  state.loadExecutionHistory(snapshot.executionHistory ?? []);
-  state.updateSettings(snapshot.settings);
-  state.setAIMessages(normalizeAIMessages(snapshot.aiMessages ?? []));
-  void refreshTimelineData();
+	const state = useStore.getState();
+	state.setEditorContent(snapshot.editor.content);
+	state.setEditorFilepath(snapshot.editor.filepath);
+	state.setEditorIsDirty(false);
+	state.loadExecutionHistory(snapshot.executionHistory ?? []);
+	state.updateSettings(snapshot.settings);
+	state.setAIMessages(normalizeAIMessages(snapshot.aiMessages ?? []));
+	void refreshTimelineData();
 }
 
 export async function refreshTimelineData(): Promise<void> {
-  const state = useStore.getState();
-  const { filters, sort, limit, setEvents, setLoading, setError } = state;
+	const state = useStore.getState();
+	const { filters, sort, limit, setEvents, setLoading, setError } = state;
 
-  setLoading(true);
-  try {
-    const response = await queryTimeline({
-      filters,
-      sort,
-      limit,
-      offset: 0,
-    });
-    setEvents(response.events, response.total, response.hasMore);
-  } catch (error) {
-    setError(error instanceof Error ? error.message : 'Failed to refresh timeline');
-  }
+	setLoading(true);
+	try {
+		const response = await queryTimeline({
+			filters,
+			sort,
+			limit,
+			offset: 0,
+		});
+		setEvents(response.events, response.total, response.hasMore);
+	} catch (error) {
+		setError(error instanceof Error ? error.message : "Failed to refresh timeline");
+	}
 }

--- a/client/src/services/socket.ts
+++ b/client/src/services/socket.ts
@@ -1,264 +1,267 @@
-import type { ClientMessage, ExtractServerMessage, ServerMessage, ServerMessageType } from 'shared';
+import type { ClientMessage, ExtractServerMessage, ServerMessage, ServerMessageType } from "shared";
 
 export type WSRequest = ClientMessage;
 export type WSResponse = ServerMessage;
 
 type MessageHandler = (response: ServerMessage) => void;
 type OneShotHandler = {
-  handler: MessageHandler;
-  matcher?: (message: ServerMessage) => boolean;
+	handler: MessageHandler;
+	matcher?: (message: ServerMessage) => boolean;
 };
 
-type ConnectionStatus = 'connected' | 'disconnected' | 'error';
+type ConnectionStatus = "connected" | "disconnected" | "error";
 
 class SocketService {
-  private ws: WebSocket | null = null;
-  // Event handlers keyed by response.type (e.g., 'ai_response').
-  private messageHandlers: Map<string, Set<MessageHandler>> = new Map();
-  // One-shot handlers for request/response style calls with optional matchers.
-  private oneShotHandlers: OneShotHandler[] = [];
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private autoReconnectEnabled = true;
-  private intentionalDisconnect = false;
-  private url: string = '';
-  private connectionListeners: Set<(status: ConnectionStatus) => void> = new Set();
+	private ws: WebSocket | null = null;
+	// Event handlers keyed by response.type (e.g., 'ai_response').
+	private messageHandlers: Map<string, Set<MessageHandler>> = new Map();
+	// One-shot handlers for request/response style calls with optional matchers.
+	private oneShotHandlers: OneShotHandler[] = [];
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private autoReconnectEnabled = true;
+	private intentionalDisconnect = false;
+	private url: string = "";
+	private connectionListeners: Set<(status: ConnectionStatus) => void> = new Set();
 
-  connect(url: string = 'ws://localhost:3001/ws'): void {
-    // Prevent duplicate connections
-    if (this.ws) {
-      if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
-        return;
-      }
-    }
+	connect(url: string = "ws://localhost:3001/ws"): void {
+		// Prevent duplicate connections
+		if (this.ws) {
+			if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
+				return;
+			}
+		}
 
-    this.intentionalDisconnect = false;
-    this.url = url;
-    this.ws = new WebSocket(url);
+		this.intentionalDisconnect = false;
+		this.url = url;
+		this.ws = new WebSocket(url);
 
-    this.ws.onopen = () => {
-      this.clearReconnectTimer();
-      this.notifyConnection('connected');
-    };
+		this.ws.onopen = () => {
+			this.clearReconnectTimer();
+			this.notifyConnection("connected");
+		};
 
-    this.ws.onmessage = (event) => {
-      try {
-        const response: WSResponse = JSON.parse(event.data);
-        // Deliver to type-specific handler
-        this.dispatch(response.type, response);
-        // Wildcard handler (optional)
-        this.dispatch('*', response);
-        // Deliver to one-shot handler matching this message
-        this.consumeOneShot(response);
-      } catch (e) {
-        console.error('Failed to parse WebSocket message:', e);
-      }
-    };
+		this.ws.onmessage = (event) => {
+			try {
+				const response: WSResponse = JSON.parse(event.data);
+				// Deliver to type-specific handler
+				this.dispatch(response.type, response);
+				// Wildcard handler (optional)
+				this.dispatch("*", response);
+				// Deliver to one-shot handler matching this message
+				this.consumeOneShot(response);
+			} catch (e) {
+				console.error("Failed to parse WebSocket message:", e);
+			}
+		};
 
-    this.ws.onerror = (error) => {
-      console.error('WebSocket error:', error);
-      this.notifyConnection('error');
-    };
+		this.ws.onerror = (error) => {
+			console.error("WebSocket error:", error);
+			this.notifyConnection("error");
+		};
 
-    this.ws.onclose = () => {
-      if (this.intentionalDisconnect) {
-        this.intentionalDisconnect = false;
-        return;
-      }
+		this.ws.onclose = () => {
+			if (this.intentionalDisconnect) {
+				this.intentionalDisconnect = false;
+				return;
+			}
 
-      this.notifyConnection('disconnected');
-      this.scheduleReconnect();
-    };
-  }
+			this.notifyConnection("disconnected");
+			this.scheduleReconnect();
+		};
+	}
 
-  send(
-    request: WSRequest,
-    handler?: MessageHandler,
-    matcher?: (message: ServerMessage) => boolean
-  ): boolean {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-      console.error('WebSocket is not connected');
-      return false;
-    }
+	send(
+		request: WSRequest,
+		handler?: MessageHandler,
+		matcher?: (message: ServerMessage) => boolean,
+	): boolean {
+		if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+			console.error("WebSocket is not connected");
+			return false;
+		}
 
-    if (handler) {
-      this.oneShotHandlers.push({ handler, matcher });
-    }
+		if (handler) {
+			this.oneShotHandlers.push({ handler, matcher });
+		}
 
-    this.ws.send(JSON.stringify(request));
-    return true;
-  }
+		this.ws.send(JSON.stringify(request));
+		return true;
+	}
 
-  on(event: ServerMessageType | '*', handler: MessageHandler): () => void {
-    const existing = this.messageHandlers.get(event) ?? new Set<MessageHandler>();
-    existing.add(handler);
-    this.messageHandlers.set(event, existing);
-    return () => this.off(event, handler);
-  }
+	on(event: ServerMessageType | "*", handler: MessageHandler): () => void {
+		const existing = this.messageHandlers.get(event) ?? new Set<MessageHandler>();
+		existing.add(handler);
+		this.messageHandlers.set(event, existing);
+		return () => this.off(event, handler);
+	}
 
-  off(event: ServerMessageType | '*', handler?: MessageHandler): void {
-    if (!handler) {
-      this.messageHandlers.delete(event);
-      return;
-    }
+	off(event: ServerMessageType | "*", handler?: MessageHandler): void {
+		if (!handler) {
+			this.messageHandlers.delete(event);
+			return;
+		}
 
-    const existing = this.messageHandlers.get(event);
-    if (!existing) return;
+		const existing = this.messageHandlers.get(event);
+		if (!existing) return;
 
-    existing.delete(handler);
-    if (existing.size === 0) {
-      this.messageHandlers.delete(event);
-    }
-  }
+		existing.delete(handler);
+		if (existing.size === 0) {
+			this.messageHandlers.delete(event);
+		}
+	}
 
-  disconnect(): void {
-    this.intentionalDisconnect = true;
-    this.clearReconnectTimer();
-    if (this.ws) {
-      if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
-        this.ws.close(1000, 'Client disconnecting');
-      }
-      this.ws = null;
-    }
-    this.messageHandlers.clear();
-    this.oneShotHandlers = [];
-    this.notifyConnection('disconnected');
-  }
+	disconnect(): void {
+		this.intentionalDisconnect = true;
+		this.clearReconnectTimer();
+		if (this.ws) {
+			if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
+				this.ws.close(1000, "Client disconnecting");
+			}
+			this.ws = null;
+		}
+		this.messageHandlers.clear();
+		this.oneShotHandlers = [];
+		this.notifyConnection("disconnected");
+	}
 
-  isConnected(): boolean {
-    return this.ws?.readyState === WebSocket.OPEN;
-  }
+	isConnected(): boolean {
+		return this.ws?.readyState === WebSocket.OPEN;
+	}
 
-  disableAutoReconnect(): void {
-    this.autoReconnectEnabled = false;
-    this.clearReconnectTimer();
-  }
+	disableAutoReconnect(): void {
+		this.autoReconnectEnabled = false;
+		this.clearReconnectTimer();
+	}
 
-  enableAutoReconnect(): void {
-    this.autoReconnectEnabled = true;
-  }
+	enableAutoReconnect(): void {
+		this.autoReconnectEnabled = true;
+	}
 
-  onConnectionChange(listener: (status: ConnectionStatus) => void): () => void {
-    this.connectionListeners.add(listener);
-    return () => {
-      this.connectionListeners.delete(listener);
-    };
-  }
+	onConnectionChange(listener: (status: ConnectionStatus) => void): () => void {
+		this.connectionListeners.add(listener);
+		return () => {
+			this.connectionListeners.delete(listener);
+		};
+	}
 
-  request<TType extends ServerMessageType>(
-    payload: WSRequest,
-    responseType: TType,
-    matcher?: (message: ExtractServerMessage<TType>) => boolean,
-    timeoutMs = 10000
-  ): Promise<ExtractServerMessage<TType>> {
-    return new Promise((resolve, reject) => {
-      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
-        reject(new Error('WebSocket is not connected'));
-        return;
-      }
+	request<TType extends ServerMessageType>(
+		payload: WSRequest,
+		responseType: TType,
+		matcher?: (message: ExtractServerMessage<TType>) => boolean,
+		timeoutMs = 10000,
+	): Promise<ExtractServerMessage<TType>> {
+		return new Promise((resolve, reject) => {
+			if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+				reject(new Error("WebSocket is not connected"));
+				return;
+			}
 
-      let timeoutId: ReturnType<typeof setTimeout> | null = null;
-      let unsubscribe: (() => void) | null = null;
+			let timeoutId: ReturnType<typeof setTimeout> | null = null;
+			let unsubscribe: (() => void) | null = null;
 
-      const cleanup = (): void => {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-          timeoutId = null;
-        }
-        if (unsubscribe) {
-          unsubscribe();
-          unsubscribe = null;
-        }
-      };
+			const cleanup = (): void => {
+				if (timeoutId) {
+					clearTimeout(timeoutId);
+					timeoutId = null;
+				}
+				if (unsubscribe) {
+					unsubscribe();
+					unsubscribe = null;
+				}
+			};
 
-      const handler = (message: ServerMessage): void => {
-        if (message.type !== responseType) {
-          return;
-        }
-        const typed = message as ExtractServerMessage<TType>;
-        if (matcher && !matcher(typed)) {
-          return;
-        }
-        cleanup();
-        resolve(typed);
-      };
+			const handler = (message: ServerMessage): void => {
+				if (message.type !== responseType) {
+					return;
+				}
+				const typed = message as ExtractServerMessage<TType>;
+				if (matcher && !matcher(typed)) {
+					return;
+				}
+				cleanup();
+				resolve(typed);
+			};
 
-      unsubscribe = this.on(responseType, handler);
-      const didSend = this.send(payload);
-      if (!didSend) {
-        cleanup();
-        reject(new Error('Failed to send WebSocket request'));
-        return;
-      }
+			unsubscribe = this.on(responseType, handler);
+			const didSend = this.send(payload);
+			if (!didSend) {
+				cleanup();
+				reject(new Error("Failed to send WebSocket request"));
+				return;
+			}
 
-      timeoutId = setTimeout(() => {
-        cleanup();
-        reject(new Error(`Timed out waiting for ${responseType}`));
-      }, timeoutMs);
-    });
-  }
+			timeoutId = setTimeout(() => {
+				cleanup();
+				reject(new Error(`Timed out waiting for ${responseType}`));
+			}, timeoutMs);
+		});
+	}
 
-  private dispatch(type: string, message: ServerMessage): void {
-    const handlers = this.messageHandlers.get(type);
-    handlers?.forEach((handler) => {
-      try {
-        handler(message);
-      } catch (error) {
-        console.error('WebSocket handler threw an error', error);
-      }
-    });
-  }
+	private dispatch(type: string, message: ServerMessage): void {
+		const handlers = this.messageHandlers.get(type);
+		handlers?.forEach((handler) => {
+			try {
+				handler(message);
+			} catch (error) {
+				console.error("WebSocket handler threw an error", error);
+			}
+		});
+	}
 
-  private consumeOneShot(message: ServerMessage): void {
-    if (this.oneShotHandlers.length === 0) return;
+	private consumeOneShot(message: ServerMessage): void {
+		if (this.oneShotHandlers.length === 0) return;
 
-    const index = this.oneShotHandlers.findIndex(({ matcher }) =>
-      matcher ? matcher(message) : true
-    );
+		const index = this.oneShotHandlers.findIndex(({ matcher }) =>
+			matcher ? matcher(message) : true,
+		);
 
-    if (index === -1) {
-      return;
-    }
+		if (index === -1) {
+			return;
+		}
 
-    const [{ handler }] = this.oneShotHandlers.splice(index, 1);
-    try {
-      handler(message);
-    } catch (error) {
-      console.error('WebSocket one-shot handler threw an error', error);
-    }
-  }
+		const [{ handler }] = this.oneShotHandlers.splice(index, 1);
+		try {
+			handler(message);
+		} catch (error) {
+			console.error("WebSocket one-shot handler threw an error", error);
+		}
+	}
 
-  private notifyConnection(status: ConnectionStatus): void {
-    this.connectionListeners.forEach((listener) => {
-      try {
-        listener(status);
-      } catch (error) {
-        console.error('WebSocket connection listener threw an error', error);
-      }
-    });
-  }
+	private notifyConnection(status: ConnectionStatus): void {
+		this.connectionListeners.forEach((listener) => {
+			try {
+				listener(status);
+			} catch (error) {
+				console.error("WebSocket connection listener threw an error", error);
+			}
+		});
+	}
 
-  private clearReconnectTimer(): void {
-    if (this.reconnectTimer) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
-  }
+	private clearReconnectTimer(): void {
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
+	}
 
-  private scheduleReconnect(): void {
-    if (!this.autoReconnectEnabled) {
-      return;
-    }
+	private scheduleReconnect(): void {
+		if (!this.autoReconnectEnabled) {
+			return;
+		}
 
-    this.clearReconnectTimer();
-    this.reconnectTimer = setTimeout(() => {
-      this.reconnectTimer = null;
-      this.connect(this.url);
-    }, 2000);
+		this.clearReconnectTimer();
+		this.reconnectTimer = setTimeout(() => {
+			this.reconnectTimer = null;
+			this.connect(this.url);
+		}, 2000);
 
-    if (this.reconnectTimer && typeof (this.reconnectTimer as unknown as { unref?: () => void }).unref === 'function') {
-      (this.reconnectTimer as unknown as { unref: () => void }).unref();
-    }
-  }
+		if (
+			this.reconnectTimer &&
+			typeof (this.reconnectTimer as unknown as { unref?: () => void }).unref === "function"
+		) {
+			(this.reconnectTimer as unknown as { unref: () => void }).unref();
+		}
+	}
 }
 
 export const socketService = new SocketService();

--- a/client/src/services/timelineService.ts
+++ b/client/src/services/timelineService.ts
@@ -1,73 +1,73 @@
-import {
-  type ExecutionEventPayload,
-  type TimelineQuery,
-  type TimelineResponse,
-  type TimelineStats,
-  type ServerMessage,
-} from 'shared';
-import { socketService } from './socket';
+import type {
+	ExecutionEventPayload,
+	ServerMessage,
+	TimelineQuery,
+	TimelineResponse,
+	TimelineStats,
+} from "shared";
+import { socketService } from "./socket";
 
 const timelineMatcher = (message: ServerMessage): boolean =>
-  message.type === 'timeline_response' || message.type === 'error';
+	message.type === "timeline_response" || message.type === "error";
 
 export async function queryTimeline(query: TimelineQuery): Promise<TimelineResponse> {
-  return new Promise((resolve, reject) => {
-    const didSend = socketService.send(
-      { type: 'timeline_query', query },
-      (message) => {
-        if (message.type === 'timeline_response') {
-          resolve(message.data);
-          return;
-        }
+	return new Promise((resolve, reject) => {
+		const didSend = socketService.send(
+			{ type: "timeline_query", query },
+			(message) => {
+				if (message.type === "timeline_response") {
+					resolve(message.data);
+					return;
+				}
 
-        if (message.type === 'error') {
-          reject(new Error(message.message));
-          return;
-        }
+				if (message.type === "error") {
+					reject(new Error(message.message));
+					return;
+				}
 
-        reject(new Error(`Unexpected timeline response: ${message.type}`));
-      },
-      timelineMatcher
-    );
+				reject(new Error(`Unexpected timeline response: ${message.type}`));
+			},
+			timelineMatcher,
+		);
 
-    if (!didSend) {
-      reject(new Error('Timeline request failed: WebSocket is not connected.'));
-    }
-  });
+		if (!didSend) {
+			reject(new Error("Timeline request failed: WebSocket is not connected."));
+		}
+	});
 }
 
 export async function getTimelineStats(): Promise<TimelineStats> {
-  return new Promise((resolve, reject) => {
-    const didSend = socketService.send(
-      { type: 'timeline_stats_query' },
-      (message) => {
-        if (message.type === 'timeline_stats_response') {
-          resolve(message.stats);
-          return;
-        }
+	return new Promise((resolve, reject) => {
+		const didSend = socketService.send(
+			{ type: "timeline_stats_query" },
+			(message) => {
+				if (message.type === "timeline_stats_response") {
+					resolve(message.stats);
+					return;
+				}
 
-        if (message.type === 'error') {
-          reject(new Error(message.message));
-          return;
-        }
+				if (message.type === "error") {
+					reject(new Error(message.message));
+					return;
+				}
 
-        reject(new Error(`Unexpected timeline stats response: ${message.type}`));
-      },
-      (message) => message.type === 'timeline_stats_response' || message.type === 'error'
-    );
+				reject(new Error(`Unexpected timeline stats response: ${message.type}`));
+			},
+			(message) => message.type === "timeline_stats_response" || message.type === "error",
+		);
 
-    if (!didSend) {
-      reject(new Error('Timeline stats request failed: WebSocket is not connected.'));
-    }
-  });
+		if (!didSend) {
+			reject(new Error("Timeline stats request failed: WebSocket is not connected."));
+		}
+	});
 }
 
 export function subscribeToTimelineEvents(
-  handler: (event: ExecutionEventPayload) => void,
+	handler: (event: ExecutionEventPayload) => void,
 ): () => void {
-  return socketService.on('timeline_event_added', (message) => {
-    if (message.type === 'timeline_event_added') {
-      handler(message.event);
-    }
-  });
+	return socketService.on("timeline_event_added", (message) => {
+		if (message.type === "timeline_event_added") {
+			handler(message.event);
+		}
+	});
 }

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -1,40 +1,40 @@
-import { expect, afterEach, vi } from 'vitest';
-import { cleanup } from '@testing-library/react';
-import * as matchers from '@testing-library/jest-dom/matchers';
-import { socketService } from '@/services/socket';
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { cleanup } from "@testing-library/react";
+import { afterEach, expect, vi } from "vitest";
+import { socketService } from "@/services/socket";
 
 // Extend Vitest matchers with jest-dom matchers
 expect.extend(matchers);
 
 // Mock WebSocket globally to prevent actual connections in tests
 globalThis.WebSocket = vi.fn().mockImplementation(() => ({
-  addEventListener: vi.fn(),
-  removeEventListener: vi.fn(),
-  close: vi.fn(),
-  send: vi.fn(),
-  readyState: 3, // CLOSED
+	addEventListener: vi.fn(),
+	removeEventListener: vi.fn(),
+	close: vi.fn(),
+	send: vi.fn(),
+	readyState: 3, // CLOSED
 })) as unknown as typeof WebSocket;
 
 // Polyfill timer.unref() for jsdom environment
 const originalSetTimeout = globalThis.setTimeout;
-globalThis.setTimeout = function (handler: TimerHandler, timeout?: number, ...args: unknown[]) {
-  const id = originalSetTimeout(handler, timeout, ...args);
-  // Add unref() method if it doesn't exist
-  if (typeof id === 'object' || typeof id === 'number') {
-    const timer = id as ReturnType<typeof setTimeout> & { unref?: () => void };
-    if (!timer.unref) {
-      timer.unref = () => timer;
-    }
-  }
-  return id;
-} as typeof setTimeout;
+globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+	const id = originalSetTimeout(handler, timeout, ...args);
+	// Add unref() method if it doesn't exist
+	if (typeof id === "object" || typeof id === "number") {
+		const timer = id as ReturnType<typeof setTimeout> & { unref?: () => void };
+		if (!timer.unref) {
+			timer.unref = () => timer;
+		}
+	}
+	return id;
+}) as typeof setTimeout;
 
 // Disable auto reconnect during tests to avoid background timers
 socketService.disableAutoReconnect();
 
 // Cleanup after each test case
 afterEach(() => {
-  cleanup();
-  // Disconnect socket to clear any timers/handlers
-  socketService.disconnect();
+	cleanup();
+	// Disconnect socket to clear any timers/handlers
+	socketService.disconnect();
 });

--- a/client/src/theme/index.ts
+++ b/client/src/theme/index.ts
@@ -1,44 +1,43 @@
-const THEME_ATTRIBUTE = 'data-theme';
-const STORAGE_KEY = 'reprod.theme';
+const THEME_ATTRIBUTE = "data-theme";
+const STORAGE_KEY = "reprod.theme";
 
-export type ThemeName = 'default' | 'phylo';
+export type ThemeName = "default" | "phylo";
 
-const DEFAULT_THEME: ThemeName = 'phylo';
+const DEFAULT_THEME: ThemeName = "phylo";
 
-const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
+const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
 
-const getRootElement = (): HTMLElement | null =>
-  isBrowser ? document.documentElement : null;
+const getRootElement = (): HTMLElement | null => (isBrowser ? document.documentElement : null);
 
 export function applyTheme(theme: ThemeName): ThemeName {
-  const root = getRootElement();
-  if (!root) return theme;
+	const root = getRootElement();
+	if (!root) return theme;
 
-  root.setAttribute(THEME_ATTRIBUTE, theme);
+	root.setAttribute(THEME_ATTRIBUTE, theme);
 
-  try {
-    window.localStorage.setItem(STORAGE_KEY, theme);
-  } catch {
-    /* ignore storage failures (private mode, etc.) */
-  }
+	try {
+		window.localStorage.setItem(STORAGE_KEY, theme);
+	} catch {
+		/* ignore storage failures (private mode, etc.) */
+	}
 
-  return theme;
+	return theme;
 }
 
 export function getStoredTheme(): ThemeName | null {
-  if (!isBrowser) return null;
+	if (!isBrowser) return null;
 
-  try {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    return stored === 'default' || stored === 'phylo' ? stored : null;
-  } catch {
-    return null;
-  }
+	try {
+		const stored = window.localStorage.getItem(STORAGE_KEY);
+		return stored === "default" || stored === "phylo" ? stored : null;
+	} catch {
+		return null;
+	}
 }
 
 export function initialiseTheme(): ThemeName {
-  const stored = getStoredTheme();
-  const theme = stored ?? DEFAULT_THEME;
-  applyTheme(theme);
-  return theme;
+	const stored = getStoredTheme();
+	const theme = stored ?? DEFAULT_THEME;
+	applyTheme(theme);
+	return theme;
 }

--- a/client/src/types/exportDialog.ts
+++ b/client/src/types/exportDialog.ts
@@ -1,49 +1,54 @@
-import type { ExportRMarkdownRequestPayload } from 'shared';
+import type { ExportRMarkdownRequestPayload } from "shared";
 
 export type ExportDialogOptions = Pick<
-  ExportRMarkdownRequestPayload,
-  'includeTimestamps' | 'showActor' | 'embedPlots' | 'includeOutputs' | 'includeErrors' | 'includeSummary'
+	ExportRMarkdownRequestPayload,
+	| "includeTimestamps"
+	| "showActor"
+	| "embedPlots"
+	| "includeOutputs"
+	| "includeErrors"
+	| "includeSummary"
 >;
 
 export type ExportOptionKey = keyof ExportDialogOptions;
 
-export type ExportFormat = 'bundle' | 'rmarkdown' | 'both';
+export type ExportFormat = "bundle" | "rmarkdown" | "both";
 
 export interface ExportDialogState {
-  format: ExportFormat;
-  mode: ExportRMarkdownRequestPayload['mode'];
-  options: ExportDialogOptions;
-  documentPath: string;
-  outputPath: string;
-  exporting: boolean;
-  error: string;
+	format: ExportFormat;
+	mode: ExportRMarkdownRequestPayload["mode"];
+	options: ExportDialogOptions;
+	documentPath: string;
+	outputPath: string;
+	exporting: boolean;
+	error: string;
 }
 
 export type ExportDialogAction =
-  | { type: 'set-format'; payload: ExportFormat }
-  | { type: 'set-mode'; payload: ExportRMarkdownRequestPayload['mode'] }
-  | { type: 'set-option'; key: ExportOptionKey; value: boolean }
-  | { type: 'set-document-path'; payload: string }
-  | { type: 'set-output-path'; payload: string }
-  | { type: 'set-exporting'; payload: boolean }
-  | { type: 'set-error'; payload: string }
-  | { type: 'reset' };
+	| { type: "set-format"; payload: ExportFormat }
+	| { type: "set-mode"; payload: ExportRMarkdownRequestPayload["mode"] }
+	| { type: "set-option"; key: ExportOptionKey; value: boolean }
+	| { type: "set-document-path"; payload: string }
+	| { type: "set-output-path"; payload: string }
+	| { type: "set-exporting"; payload: boolean }
+	| { type: "set-error"; payload: string }
+	| { type: "reset" };
 
 export const exportDialogDefaultOptions: ExportDialogOptions = {
-  includeTimestamps: true,
-  showActor: true,
-  embedPlots: true,
-  includeOutputs: true,
-  includeErrors: false,
-  includeSummary: true,
+	includeTimestamps: true,
+	showActor: true,
+	embedPlots: true,
+	includeOutputs: true,
+	includeErrors: false,
+	includeSummary: true,
 };
 
 export const exportDialogInitialState: ExportDialogState = {
-  format: 'rmarkdown',
-  mode: 'timeline',
-  options: exportDialogDefaultOptions,
-  documentPath: '',
-  outputPath: 'analysis_report.Rmd',
-  exporting: false,
-  error: '',
+	format: "rmarkdown",
+	mode: "timeline",
+	options: exportDialogDefaultOptions,
+	documentPath: "",
+	outputPath: "analysis_report.Rmd",
+	exporting: false,
+	error: "",
 };

--- a/client/src/types/menu.ts
+++ b/client/src/types/menu.ts
@@ -8,14 +8,14 @@
  */
 
 /** Finite set of top-level sections in the UI menu */
-export type MenuSectionId = 'file' | 'edit' | 'code' | 'session' | 'view' | 'help';
+export type MenuSectionId = "file" | "edit" | "code" | "session" | "view" | "help";
 
 /** Optional metadata for hinting about menu usage */
 export interface MenuHint {
-  /** Additional context shown in tooltips or secondary UI */
-  description?: string;
-  /** Highlight visually (used for AI Assistant) */
-  prominent?: boolean;
+	/** Additional context shown in tooltips or secondary UI */
+	description?: string;
+	/** Highlight visually (used for AI Assistant) */
+	prominent?: boolean;
 }
 
 /** Functions used across menu items */
@@ -25,49 +25,49 @@ export type MenuCheckedPredicate = () => boolean;
 
 /** Base menu item – executes an action when clicked */
 export interface MenuCommandItem extends MenuHint {
-  id: string;
-  label: string;
-  shortcut?: string;
-  action: MenuActionHandler;
-  enabled?: MenuAvailabilityPredicate;
+	id: string;
+	label: string;
+	shortcut?: string;
+	action: MenuActionHandler;
+	enabled?: MenuAvailabilityPredicate;
 }
 
 /** Toggle style menu item with a persistent checked state */
 export interface MenuToggleItem extends MenuCommandItem {
-  checked: MenuCheckedPredicate;
+	checked: MenuCheckedPredicate;
 }
 
 export type MenuItem = MenuCommandItem | MenuToggleItem;
 
 /** Menu separator (horizontal divider between groups) */
 export interface MenuSeparator {
-  type: 'separator';
+	type: "separator";
 }
 
 export type MenuEntry = MenuItem | MenuSeparator;
 
 /** Menu section (File, Edit, Code, Session, View, Help) */
 export interface MenuSection {
-  id: MenuSectionId;
-  label: string;
-  items: MenuEntry[];
+	id: MenuSectionId;
+	label: string;
+	items: MenuEntry[];
 }
 
 /** Render props shared by menu section renderers */
 export interface MenuSectionComponentProps {
-  section: MenuSection;
-  isOpen: boolean;
-  anyMenuOpen: boolean;
-  onOpenExplicit: (label: string) => void;
-  onClose: () => void;
+	section: MenuSection;
+	isOpen: boolean;
+	anyMenuOpen: boolean;
+	onOpenExplicit: (label: string) => void;
+	onClose: () => void;
 }
 
 /** Props for small status indicator used in the menubar */
 export interface ConnectionIndicatorProps {
-  isConnected: boolean;
+	isConnected: boolean;
 }
 
 /** Convenience structure for declaring full menu trees */
 export interface MenuConfiguration {
-  sections: MenuSection[];
+	sections: MenuSection[];
 }

--- a/client/src/types/panels.ts
+++ b/client/src/types/panels.ts
@@ -7,24 +7,24 @@
  */
 
 /** Tabs rendered in the Console panel */
-export type ConsoleTabId = 'console' | 'history';
+export type ConsoleTabId = "console" | "history";
 
 /** Tabs rendered in the consolidated bottom pane (excluding the console) */
-export type BottomPanePlotTab = 'plots' | 'help';
+export type BottomPanePlotTab = "plots" | "help";
 
 /** Tabs rendered in the consolidated bottom pane */
-export type BottomPaneTab = 'console' | 'history' | 'terminal' | BottomPanePlotTab;
+export type BottomPaneTab = "console" | "history" | "terminal" | BottomPanePlotTab;
 
 /** Payload sent when other components want to focus a plot */
 export interface PlotFocusEventDetail {
-  plotIndex: number;
+	plotIndex: number;
 }
 
 /** State snapshot for navigating generated plots */
 export interface PlotNavigationState {
-  activeTab: BottomPanePlotTab;
-  selectedPlotIndex: number;
-  totalPlots: number;
+	activeTab: BottomPanePlotTab;
+	selectedPlotIndex: number;
+	totalPlots: number;
 }
 
 /** Strongly typed custom event fired from the console */

--- a/client/src/types/terminal.ts
+++ b/client/src/types/terminal.ts
@@ -1,46 +1,46 @@
 export interface TerminalSession {
-  id: string;
-  title: string;
-  isActive: boolean;
+	id: string;
+	title: string;
+	isActive: boolean;
 }
 
 export interface TerminalState {
-  sessions: TerminalSession[];
-  activeSessionId: string | null;
+	sessions: TerminalSession[];
+	activeSessionId: string | null;
 }
 
 export interface TerminalOutputEvent {
-  session_id: string;
-  data: string;
+	session_id: string;
+	data: string;
 }
 
 export interface TerminalExitEvent {
-  session_id: string;
-  exit_code: number | null;
+	session_id: string;
+	exit_code: number | null;
 }
 
 export interface TerminalErrorEvent {
-  session_id: string;
-  message: string;
+	session_id: string;
+	message: string;
 }
 
 export interface TerminalKeepAliveEvent {
-  session_id: string;
+	session_id: string;
 }
 
 export interface TerminalEvent<T> {
-  payload: T;
+	payload: T;
 }
 
 export interface TauriTerminalAPI {
-  invoke: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
-  event: {
-    listen: <T>(event: string, handler: (event: TerminalEvent<T>) => void) => Promise<() => void>;
-  };
+	invoke: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+	event: {
+		listen: <T>(event: string, handler: (event: TerminalEvent<T>) => void) => Promise<() => void>;
+	};
 }
 
 declare global {
-  interface Window {
-    __TAURI__?: TauriTerminalAPI;
-  }
+	interface Window {
+		__TAURI__?: TauriTerminalAPI;
+	}
 }

--- a/client/src/types/timeline.ts
+++ b/client/src/types/timeline.ts
@@ -1,36 +1,36 @@
 import type {
-  TimelineQuery,
-  TimelineStats as TimelineStatsType,
-  ExecutionEventPayload,
-} from 'shared';
+	ExecutionEventPayload,
+	TimelineQuery,
+	TimelineStats as TimelineStatsType,
+} from "shared";
 
-export type TimelineSortOrder = 'asc' | 'desc';
+export type TimelineSortOrder = "asc" | "desc";
 
 export interface TimelineFiltersProps {
-  filters?: TimelineQuery['filters'];
-  onChange: (filters: TimelineQuery['filters']) => void;
+	filters?: TimelineQuery["filters"];
+	onChange: (filters: TimelineQuery["filters"]) => void;
 }
 
 export interface TimelineSortProps {
-  sort: TimelineSortOrder;
-  onChange: (sort: TimelineSortOrder) => void;
+	sort: TimelineSortOrder;
+	onChange: (sort: TimelineSortOrder) => void;
 }
 
 export interface TimelineStatsProps {
-  stats: TimelineStatsType | null;
-  loading: boolean;
+	stats: TimelineStatsType | null;
+	loading: boolean;
 }
 
 export interface TimelineEventProps {
-  event: ExecutionEventPayload;
-  onNavigate?: (event: ExecutionEventPayload) => void;
+	event: ExecutionEventPayload;
+	onNavigate?: (event: ExecutionEventPayload) => void;
 }
 
 export interface TimelineListProps {
-  events: ExecutionEventPayload[];
-  total: number;
-  hasMore: boolean;
-  loading: boolean;
-  onLoadMore: () => void;
-  onNavigate?: (event: ExecutionEventPayload) => void;
+	events: ExecutionEventPayload[];
+	total: number;
+	hasMore: boolean;
+	loading: boolean;
+	onLoadMore: () => void;
+	onNavigate?: (event: ExecutionEventPayload) => void;
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,37 +1,37 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
+	"compilerOptions": {
+		"target": "ES2020",
+		"useDefineForClassFields": true,
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"module": "ESNext",
+		"skipLibCheck": true,
 
-    "moduleResolution": "bundler",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"],
-      "@/components/*": ["src/components/*"],
-      "@/core/*": ["src/core/*"],
-      "@/hooks/*": ["src/hooks/*"],
-      "@/utils/*": ["src/utils/*"],
-      "@/css/*": ["src/css/*"],
-      "@shared": ["../shared/src/index.ts"],
-      "@shared/*": ["../shared/src/*"],
-      "shared": ["../shared/src/index.ts"],
-      "shared/*": ["../shared/src/*"]
-    },
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
+		"moduleResolution": "bundler",
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["src/*"],
+			"@/components/*": ["src/components/*"],
+			"@/core/*": ["src/core/*"],
+			"@/hooks/*": ["src/hooks/*"],
+			"@/utils/*": ["src/utils/*"],
+			"@/css/*": ["src/css/*"],
+			"@shared": ["../shared/src/index.ts"],
+			"@shared/*": ["../shared/src/*"],
+			"shared": ["../shared/src/index.ts"],
+			"shared/*": ["../shared/src/*"]
+		},
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react-jsx",
 
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
-  },
-  "include": ["src"],
-  "exclude": ["src/**/__tests__", "src/**/*.test.ts", "src/**/*.test.tsx"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"include": ["src"],
+	"exclude": ["src/**/__tests__", "src/**/*.test.ts", "src/**/*.test.tsx"],
+	"references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -1,10 +1,10 @@
 {
-  "compilerOptions": {
-    "composite": true,
-    "skipLibCheck": true,
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
-  },
-  "include": ["vite.config.ts"]
+	"compilerOptions": {
+		"composite": true,
+		"skipLibCheck": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"allowSyntheticDefaultImports": true
+	},
+	"include": ["vite.config.ts"]
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,25 +1,25 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { fileURLToPath } from "url";
+import { defineConfig } from "vite";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@/components': path.resolve(__dirname, './src/components'),
-      '@/core': path.resolve(__dirname, './src/core'),
-      '@/hooks': path.resolve(__dirname, './src/hooks'),
-      '@/utils': path.resolve(__dirname, './src/utils'),
-      '@/css': path.resolve(__dirname, './src/css'),
-      'shared': path.resolve(__dirname, '../shared/src/index.ts')
-    }
-  },
-  server: {
-    port: 5173
-    // No proxy needed - using native WebSocket at ws://localhost:3001/ws
-  }
+	plugins: [react()],
+	resolve: {
+		alias: {
+			"@": path.resolve(__dirname, "./src"),
+			"@/components": path.resolve(__dirname, "./src/components"),
+			"@/core": path.resolve(__dirname, "./src/core"),
+			"@/hooks": path.resolve(__dirname, "./src/hooks"),
+			"@/utils": path.resolve(__dirname, "./src/utils"),
+			"@/css": path.resolve(__dirname, "./src/css"),
+			shared: path.resolve(__dirname, "../shared/src/index.ts"),
+		},
+	},
+	server: {
+		port: 5173,
+		// No proxy needed - using native WebSocket at ws://localhost:3001/ws
+	},
 });

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,32 +1,32 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { fileURLToPath } from "url";
+import { defineConfig } from "vitest/config";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  plugins: [react()],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: './src/test/setup.ts',
-    pool: 'threads',
-    poolOptions: {
-      threads: {
-        singleThread: true,
-      },
-    },
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@/components': path.resolve(__dirname, './src/components'),
-      '@/core': path.resolve(__dirname, './src/core'),
-      '@/hooks': path.resolve(__dirname, './src/hooks'),
-      '@/utils': path.resolve(__dirname, './src/utils'),
-      '@/css': path.resolve(__dirname, './src/css'),
-      'shared': path.resolve(__dirname, '../shared/src/index.ts')
-    }
-  },
+	plugins: [react()],
+	test: {
+		globals: true,
+		environment: "jsdom",
+		setupFiles: "./src/test/setup.ts",
+		pool: "threads",
+		poolOptions: {
+			threads: {
+				singleThread: true,
+			},
+		},
+	},
+	resolve: {
+		alias: {
+			"@": path.resolve(__dirname, "./src"),
+			"@/components": path.resolve(__dirname, "./src/components"),
+			"@/core": path.resolve(__dirname, "./src/core"),
+			"@/hooks": path.resolve(__dirname, "./src/hooks"),
+			"@/utils": path.resolve(__dirname, "./src/utils"),
+			"@/css": path.resolve(__dirname, "./src/css"),
+			shared: path.resolve(__dirname, "../shared/src/index.ts"),
+		},
+	},
 });

--- a/desktop/capabilities/default.json
+++ b/desktop/capabilities/default.json
@@ -1,9 +1,6 @@
 {
-  "identifier": "default",
-  "description": "Default capabilities for development",
-  "windows": ["main"],
-  "permissions": [
-    "core:default",
-    "pty:default"
-  ]
+	"identifier": "default",
+	"description": "Default capabilities for development",
+	"windows": ["main"],
+	"permissions": ["core:default", "pty:default"]
 }

--- a/desktop/e2e/package.json
+++ b/desktop/e2e/package.json
@@ -1,28 +1,28 @@
 {
-  "name": "@reprod/e2e",
-  "private": true,
-  "scripts": {
-    "test": "playwright test",
-    "test:playwright": "playwright test",
-    "test:playwright:ui": "playwright test --ui",
-    "test:playwright:headed": "playwright test --headed",
-    "test:playwright:debug": "playwright test --debug",
-    "test:webdriver": "wdio run wdio.conf.ts",
-    "test:webdriver:debug": "wdio run wdio.conf.ts --debug",
-    "test:all": "pnpm test:playwright && pnpm test:webdriver"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.56.1",
-    "@types/mocha": "^10.0.0",
-    "@types/node": "^20.0.0",
-    "@wdio/cli": "^8.0.0",
-    "@wdio/globals": "^8.0.0",
-    "@wdio/local-runner": "^8.0.0",
-    "@wdio/mocha-framework": "^8.0.0",
-    "@wdio/spec-reporter": "^8.0.0",
-    "@wdio/types": "^8.0.0",
-    "ts-node": "^10.9.0",
-    "typescript": "^5.0.0",
-    "webdriverio": "^8.0.0"
-  }
+	"name": "@reprod/e2e",
+	"private": true,
+	"scripts": {
+		"test": "playwright test",
+		"test:playwright": "playwright test",
+		"test:playwright:ui": "playwright test --ui",
+		"test:playwright:headed": "playwright test --headed",
+		"test:playwright:debug": "playwright test --debug",
+		"test:webdriver": "wdio run wdio.conf.ts",
+		"test:webdriver:debug": "wdio run wdio.conf.ts --debug",
+		"test:all": "pnpm test:playwright && pnpm test:webdriver"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.56.1",
+		"@types/mocha": "^10.0.0",
+		"@types/node": "^20.0.0",
+		"@wdio/cli": "^8.0.0",
+		"@wdio/globals": "^8.0.0",
+		"@wdio/local-runner": "^8.0.0",
+		"@wdio/mocha-framework": "^8.0.0",
+		"@wdio/spec-reporter": "^8.0.0",
+		"@wdio/types": "^8.0.0",
+		"ts-node": "^10.9.0",
+		"typescript": "^5.0.0",
+		"webdriverio": "^8.0.0"
+	}
 }

--- a/desktop/e2e/playwright.config.ts
+++ b/desktop/e2e/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 /**
  * Playwright E2E Test Configuration
@@ -7,69 +7,69 @@ import { defineConfig, devices } from '@playwright/test';
  * Works on all platforms (macOS, Linux, Windows).
  */
 export default defineConfig({
-  // Test directory
-  testDir: './tests',
+	// Test directory
+	testDir: "./tests",
 
-  // Maximum time one test can run (5 minutes)
-  timeout: 300000,
+	// Maximum time one test can run (5 minutes)
+	timeout: 300000,
 
-  // Run tests in files in parallel
-  fullyParallel: false,
+	// Run tests in files in parallel
+	fullyParallel: false,
 
-  // Fail the build on CI if you accidentally left test.only in the source code
-  forbidOnly: !!process.env.CI,
+	// Fail the build on CI if you accidentally left test.only in the source code
+	forbidOnly: !!process.env.CI,
 
-  // Retry on CI only
-  retries: process.env.CI ? 1 : 0,
+	// Retry on CI only
+	retries: process.env.CI ? 1 : 0,
 
-  // Opt out of parallel tests on CI
-  workers: process.env.CI ? 1 : undefined,
+	// Opt out of parallel tests on CI
+	workers: process.env.CI ? 1 : undefined,
 
-  // Reporter to use
-  reporter: process.env.CI ? 'github' : 'list',
+	// Reporter to use
+	reporter: process.env.CI ? "github" : "list",
 
-  // Shared settings for all the projects below
-  use: {
-    // Base URL to use in actions like `await page.goto('/')`
-    baseURL: 'http://localhost:5173',
+	// Shared settings for all the projects below
+	use: {
+		// Base URL to use in actions like `await page.goto('/')`
+		baseURL: "http://localhost:5173",
 
-    // Collect trace when retrying the failed test
-    trace: 'on-first-retry',
+		// Collect trace when retrying the failed test
+		trace: "on-first-retry",
 
-    // Screenshot on failure
-    screenshot: 'only-on-failure',
+		// Screenshot on failure
+		screenshot: "only-on-failure",
 
-    // Video on failure
-    video: 'retain-on-failure',
-  },
+		// Video on failure
+		video: "retain-on-failure",
+	},
 
-  // Configure projects for major browsers
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-    },
+	// Configure projects for major browsers
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
 
-    // Uncomment to test on Firefox
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
+		// Uncomment to test on Firefox
+		// {
+		//   name: 'firefox',
+		//   use: { ...devices['Desktop Firefox'] },
+		// },
 
-    // Uncomment to test on WebKit (Safari)
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
-  ],
+		// Uncomment to test on WebKit (Safari)
+		// {
+		//   name: 'webkit',
+		//   use: { ...devices['Desktop Safari'] },
+		// },
+	],
 
-  // Run your local dev server before starting the tests
-  webServer: {
-    command: 'cd ../.. && pnpm dev',
-    url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000,
-    stdout: 'ignore',
-    stderr: 'ignore',
-  },
+	// Run your local dev server before starting the tests
+	webServer: {
+		command: "cd ../.. && pnpm dev",
+		url: "http://localhost:5173",
+		reuseExistingServer: !process.env.CI,
+		timeout: 120000,
+		stdout: "ignore",
+		stderr: "ignore",
+	},
 });

--- a/desktop/e2e/shared/helpers.ts
+++ b/desktop/e2e/shared/helpers.ts
@@ -2,118 +2,113 @@
  * Common test helper functions
  */
 
-import type { Page } from '@playwright/test';
+import type { Page } from "@playwright/test";
 
 /**
  * Wait for element with timeout
  */
 export async function waitForElement(
-  page: Page,
-  selector: string,
-  options: { timeout?: number } = {}
+	page: Page,
+	selector: string,
+	options: { timeout?: number } = {},
 ) {
-  const timeout = options.timeout || 30000;
-  await page.locator(selector).waitFor({ timeout });
+	const timeout = options.timeout || 30000;
+	await page.locator(selector).waitFor({ timeout });
 }
 
 /**
  * Execute R code in the editor
  */
 export async function executeRCode(page: Page, code: string) {
-  // Wait for Monaco Editor to be ready
-  await page.waitForSelector('.monaco-editor', { timeout: 30000 });
+	// Wait for Monaco Editor to be ready
+	await page.waitForSelector(".monaco-editor", { timeout: 30000 });
 
-  // Set editor content using Monaco Editor API (more reliable than keyboard input)
-  await page.evaluate((newCode) => {
-    const monaco = (window as any).monaco;
-    if (monaco && monaco.editor) {
-      const editors = monaco.editor.getEditors();
-      if (editors && editors.length > 0) {
-        const editor = editors[0];
-        editor.setValue(newCode);
-        editor.focus();
-      }
-    }
-  }, code);
+	// Set editor content using Monaco Editor API (more reliable than keyboard input)
+	await page.evaluate((newCode) => {
+		const monaco = (window as any).monaco;
+		if (monaco && monaco.editor) {
+			const editors = monaco.editor.getEditors();
+			if (editors && editors.length > 0) {
+				const editor = editors[0];
+				editor.setValue(newCode);
+				editor.focus();
+			}
+		}
+	}, code);
 
-  // Wait a bit for the change to take effect
-  await page.waitForTimeout(500);
+	// Wait a bit for the change to take effect
+	await page.waitForTimeout(500);
 
-  // Click run button
-  const runButton = page.locator('button[title="Run All (Cmd/Ctrl+Shift+Enter)"]');
-  await runButton.waitFor({ timeout: 15000 });
-  await runButton.click();
+	// Click run button
+	const runButton = page.locator('button[title="Run All (Cmd/Ctrl+Shift+Enter)"]');
+	await runButton.waitFor({ timeout: 15000 });
+	await runButton.click();
 }
 
 /**
  * Wait for console output containing specific text
  */
 export async function waitForConsoleOutput(
-  page: Page,
-  expectedText: string,
-  options: { timeout?: number } = {}
+	page: Page,
+	expectedText: string,
+	options: { timeout?: number } = {},
 ) {
-  const timeout = options.timeout || 30000;
+	const timeout = options.timeout || 30000;
 
-  await page.waitForFunction(
-    ({ selector, text }) => {
-      const outputs = document.querySelectorAll(selector);
-      return Array.from(outputs).some((output) =>
-        output.textContent?.includes(text)
-      );
-    },
-    { selector: '.console-stdout', text: expectedText },
-    { timeout }
-  );
+	await page.waitForFunction(
+		({ selector, text }) => {
+			const outputs = document.querySelectorAll(selector);
+			return Array.from(outputs).some((output) => output.textContent?.includes(text));
+		},
+		{ selector: ".console-stdout", text: expectedText },
+		{ timeout },
+	);
 }
 
 /**
  * Open Timeline dialog
  */
 export async function openTimelineDialog(page: Page) {
-  await page.evaluate(() => {
-    (window as any).openTimelineDialog?.();
-  });
+	await page.evaluate(() => {
+		(window as any).openTimelineDialog?.();
+	});
 
-  const dialog = page.locator('.timeline-dialog');
-  await dialog.waitFor({ timeout: 10000 });
+	const dialog = page.locator(".timeline-dialog");
+	await dialog.waitFor({ timeout: 10000 });
 }
 
 /**
  * Open Export dialog
  */
 export async function openExportDialog(page: Page) {
-  await page.evaluate(() => {
-    (window as any).openExportDialog?.();
-  });
+	await page.evaluate(() => {
+		(window as any).openExportDialog?.();
+	});
 
-  const dialog = page.locator('.export-dialog');
-  await dialog.waitFor({ timeout: 10000 });
+	const dialog = page.locator(".export-dialog");
+	await dialog.waitFor({ timeout: 10000 });
 }
 
 /**
  * Close dialog with Escape key
  */
 export async function closeDialog(page: Page) {
-  await page.keyboard.press('Escape');
-  await page.waitForTimeout(500); // Give time for animation
+	await page.keyboard.press("Escape");
+	await page.waitForTimeout(500); // Give time for animation
 }
 
 /**
  * Get all console outputs
  */
 export async function getConsoleOutputs(page: Page): Promise<string[]> {
-  const outputs = await page.locator('.console-stdout').all();
-  return Promise.all(outputs.map((output) => output.textContent() || ''));
+	const outputs = await page.locator(".console-stdout").all();
+	return Promise.all(outputs.map((output) => output.textContent() || ""));
 }
 
 /**
  * Check if console has output containing text
  */
-export async function consoleHasOutput(
-  page: Page,
-  expectedText: string
-): Promise<boolean> {
-  const outputs = await getConsoleOutputs(page);
-  return outputs.some((text) => text.includes(expectedText));
+export async function consoleHasOutput(page: Page, expectedText: string): Promise<boolean> {
+	const outputs = await getConsoleOutputs(page);
+	return outputs.some((text) => text.includes(expectedText));
 }

--- a/desktop/e2e/shared/selectors.ts
+++ b/desktop/e2e/shared/selectors.ts
@@ -3,29 +3,29 @@
  */
 
 export const selectors = {
-  // Editor
-  editor: '.monaco-editor textarea',
+	// Editor
+	editor: ".monaco-editor textarea",
 
-  // Buttons
-  runButton: 'button[title="Run All (Cmd/Ctrl+Shift+Enter)"]',
+	// Buttons
+	runButton: 'button[title="Run All (Cmd/Ctrl+Shift+Enter)"]',
 
-  // Console
-  consoleOutput: '.console-stdout',
-  consoleError: '.console-stderr',
+	// Console
+	consoleOutput: ".console-stdout",
+	consoleError: ".console-stderr",
 
-  // Dialogs
-  timelineDialog: '.timeline-dialog',
-  exportDialog: '.export-dialog',
+	// Dialogs
+	timelineDialog: ".timeline-dialog",
+	exportDialog: ".export-dialog",
 
-  // Timeline
-  timelineEvent: '.timeline-event',
-  timelineStats: '.timeline-stat',
-  timelineFilterDropdown: '.timeline-filter',
+	// Timeline
+	timelineEvent: ".timeline-event",
+	timelineStats: ".timeline-stat",
+	timelineFilterDropdown: ".timeline-filter",
 
-  // Export
-  exportFormatBundleRadio: 'input[value="bundle"]',
-  exportFormatRMarkdownRadio: 'input[value="rmarkdown"]',
-  exportFormatBothRadio: 'input[value="both"]',
-  exportModeStandaloneRadio: 'input[value="standalone"]',
-  exportModeLinkedRadio: 'input[value="linked"]',
+	// Export
+	exportFormatBundleRadio: 'input[value="bundle"]',
+	exportFormatRMarkdownRadio: 'input[value="rmarkdown"]',
+	exportFormatBothRadio: 'input[value="both"]',
+	exportModeStandaloneRadio: 'input[value="standalone"]',
+	exportModeLinkedRadio: 'input[value="linked"]',
 } as const;

--- a/desktop/e2e/tests/error-handling.spec.ts
+++ b/desktop/e2e/tests/error-handling.spec.ts
@@ -1,132 +1,132 @@
-import { test, expect } from '@playwright/test';
-import { selectors } from '../shared/selectors';
-import { executeRCode, waitForConsoleOutput, consoleHasOutput } from '../shared/helpers';
+import { expect, test } from "@playwright/test";
+import { consoleHasOutput, executeRCode, waitForConsoleOutput } from "../shared/helpers";
+import { selectors } from "../shared/selectors";
 
-test.describe('Error handling scenarios', () => {
-  test('displays R syntax errors in console', async ({ page }) => {
-    await page.goto('/');
+test.describe("Error handling scenarios", () => {
+	test("displays R syntax errors in console", async ({ page }) => {
+		await page.goto("/");
 
-    // Execute code with syntax error (incomplete expression)
-    await executeRCode(page, 'x <- 1 +');
+		// Execute code with syntax error (incomplete expression)
+		await executeRCode(page, "x <- 1 +");
 
-    // Wait for error to appear (might be in stderr)
-    await page.waitForTimeout(3000);
+		// Wait for error to appear (might be in stderr)
+		await page.waitForTimeout(3000);
 
-    // Check for error in console (stderr or stdout)
-    const stderrOutputs = page.locator(selectors.consoleError);
-    const stdoutOutputs = page.locator(selectors.consoleOutput);
+		// Check for error in console (stderr or stdout)
+		const stderrOutputs = page.locator(selectors.consoleError);
+		const stdoutOutputs = page.locator(selectors.consoleOutput);
 
-    const stderrCount = await stderrOutputs.count();
-    const stdoutCount = await stdoutOutputs.count();
+		const stderrCount = await stderrOutputs.count();
+		const stdoutCount = await stdoutOutputs.count();
 
-    // Error should appear somewhere
-    expect(stderrCount + stdoutCount).toBeGreaterThan(0);
-  });
+		// Error should appear somewhere
+		expect(stderrCount + stdoutCount).toBeGreaterThan(0);
+	});
 
-  test('displays R runtime errors', async ({ page }) => {
-    await page.goto('/');
+	test("displays R runtime errors", async ({ page }) => {
+		await page.goto("/");
 
-    // Execute code with type error
-    await executeRCode(page, 'x <- "text"\ny <- x / 2');
+		// Execute code with type error
+		await executeRCode(page, 'x <- "text"\ny <- x / 2');
 
-    // Wait for error
-    await page.waitForTimeout(3000);
+		// Wait for error
+		await page.waitForTimeout(3000);
 
-    // Verify error is displayed
-    const stderrOutputs = page.locator(selectors.consoleError);
-    const stderrCount = await stderrOutputs.count();
+		// Verify error is displayed
+		const stderrOutputs = page.locator(selectors.consoleError);
+		const stderrCount = await stderrOutputs.count();
 
-    // Should have error output
-    expect(stderrCount).toBeGreaterThanOrEqual(0);
-  });
+		// Should have error output
+		expect(stderrCount).toBeGreaterThanOrEqual(0);
+	});
 
-  test('recovers from errors and allows subsequent executions', async ({ page }) => {
-    await page.goto('/');
+	test("recovers from errors and allows subsequent executions", async ({ page }) => {
+		await page.goto("/");
 
-    // Execute error code
-    await executeRCode(page, 'x <- 1 +');
-    await page.waitForTimeout(2000);
+		// Execute error code
+		await executeRCode(page, "x <- 1 +");
+		await page.waitForTimeout(2000);
 
-    // Execute valid code
-    await executeRCode(page, 'valid_result <- 5 + 5\nvalid_result');
+		// Execute valid code
+		await executeRCode(page, "valid_result <- 5 + 5\nvalid_result");
 
-    // Wait for successful output
-    await waitForConsoleOutput(page, '[1] 10', { timeout: 30000 });
+		// Wait for successful output
+		await waitForConsoleOutput(page, "[1] 10", { timeout: 30000 });
 
-    // Verify app recovered
-    const hasOutput = await consoleHasOutput(page, '[1] 10');
-    expect(hasOutput).toBeTruthy();
-  });
+		// Verify app recovered
+		const hasOutput = await consoleHasOutput(page, "[1] 10");
+		expect(hasOutput).toBeTruthy();
+	});
 
-  test('handles undefined variable errors', async ({ page }) => {
-    await page.goto('/');
+	test("handles undefined variable errors", async ({ page }) => {
+		await page.goto("/");
 
-    // Reference undefined variable
-    await executeRCode(page, 'print(undefined_variable)');
+		// Reference undefined variable
+		await executeRCode(page, "print(undefined_variable)");
 
-    // Wait for error
-    await page.waitForTimeout(3000);
+		// Wait for error
+		await page.waitForTimeout(3000);
 
-    // Error should be displayed
-    const stderrOutputs = page.locator(selectors.consoleError);
-    const stderrCount = await stderrOutputs.count();
+		// Error should be displayed
+		const stderrOutputs = page.locator(selectors.consoleError);
+		const stderrCount = await stderrOutputs.count();
 
-    expect(stderrCount).toBeGreaterThanOrEqual(0);
-  });
+		expect(stderrCount).toBeGreaterThanOrEqual(0);
+	});
 
-  test('handles function errors gracefully', async ({ page }) => {
-    await page.goto('/');
+	test("handles function errors gracefully", async ({ page }) => {
+		await page.goto("/");
 
-    // Call non-existent function
-    await executeRCode(page, 'result <- nonExistentFunction(123)');
+		// Call non-existent function
+		await executeRCode(page, "result <- nonExistentFunction(123)");
 
-    // Wait for error
-    await page.waitForTimeout(3000);
+		// Wait for error
+		await page.waitForTimeout(3000);
 
-    // Verify error handling
-    const stderrOutputs = page.locator(selectors.consoleError);
-    const stderrCount = await stderrOutputs.count();
+		// Verify error handling
+		const stderrOutputs = page.locator(selectors.consoleError);
+		const stderrCount = await stderrOutputs.count();
 
-    expect(stderrCount).toBeGreaterThanOrEqual(0);
-  });
+		expect(stderrCount).toBeGreaterThanOrEqual(0);
+	});
 
-  test('displays parse errors', async ({ page }) => {
-    await page.goto('/');
+	test("displays parse errors", async ({ page }) => {
+		await page.goto("/");
 
-    // Execute code with parse error (mismatched parentheses)
-    await executeRCode(page, 'result <- (1 + 2');
+		// Execute code with parse error (mismatched parentheses)
+		await executeRCode(page, "result <- (1 + 2");
 
-    // Wait for error
-    await page.waitForTimeout(3000);
+		// Wait for error
+		await page.waitForTimeout(3000);
 
-    // Verify error is shown
-    const stderrOutputs = page.locator(selectors.consoleError);
-    const stderrCount = await stderrOutputs.count();
+		// Verify error is shown
+		const stderrOutputs = page.locator(selectors.consoleError);
+		const stderrCount = await stderrOutputs.count();
 
-    expect(stderrCount).toBeGreaterThanOrEqual(0);
-  });
+		expect(stderrCount).toBeGreaterThanOrEqual(0);
+	});
 
-  test('maintains app responsiveness after multiple errors', async ({ page }) => {
-    await page.goto('/');
+	test("maintains app responsiveness after multiple errors", async ({ page }) => {
+		await page.goto("/");
 
-    // Execute multiple errors
-    await executeRCode(page, 'x <- 1 +');
-    await page.waitForTimeout(1000);
+		// Execute multiple errors
+		await executeRCode(page, "x <- 1 +");
+		await page.waitForTimeout(1000);
 
-    await executeRCode(page, 'y <- "text" / 2');
-    await page.waitForTimeout(1000);
+		await executeRCode(page, 'y <- "text" / 2');
+		await page.waitForTimeout(1000);
 
-    await executeRCode(page, 'z <- undefinedVar');
-    await page.waitForTimeout(1000);
+		await executeRCode(page, "z <- undefinedVar");
+		await page.waitForTimeout(1000);
 
-    // Execute valid code to verify app still works
-    await executeRCode(page, 'final_result <- 100\nfinal_result');
+		// Execute valid code to verify app still works
+		await executeRCode(page, "final_result <- 100\nfinal_result");
 
-    // Wait for successful output
-    await waitForConsoleOutput(page, '[1] 100', { timeout: 30000 });
+		// Wait for successful output
+		await waitForConsoleOutput(page, "[1] 100", { timeout: 30000 });
 
-    // Verify app is still functional
-    const hasOutput = await consoleHasOutput(page, '[1] 100');
-    expect(hasOutput).toBeTruthy();
-  });
+		// Verify app is still functional
+		const hasOutput = await consoleHasOutput(page, "[1] 100");
+		expect(hasOutput).toBeTruthy();
+	});
 });

--- a/desktop/e2e/tests/export.spec.ts
+++ b/desktop/e2e/tests/export.spec.ts
@@ -1,146 +1,146 @@
-import { test, expect } from '@playwright/test';
-import { selectors } from '../shared/selectors';
-import { executeRCode, openExportDialog, closeDialog } from '../shared/helpers';
+import { expect, test } from "@playwright/test";
+import { closeDialog, executeRCode, openExportDialog } from "../shared/helpers";
+import { selectors } from "../shared/selectors";
 
-test.describe('Export functionality', () => {
-  test('opens export dialog and displays export options', async ({ page }) => {
-    await page.goto('/');
+test.describe("Export functionality", () => {
+	test("opens export dialog and displays export options", async ({ page }) => {
+		await page.goto("/");
 
-    // Execute some code first
-    await executeRCode(page, 'data <- c(1, 2, 3, 4, 5)\nmean(data)');
-    await page.waitForTimeout(2000);
+		// Execute some code first
+		await executeRCode(page, "data <- c(1, 2, 3, 4, 5)\nmean(data)");
+		await page.waitForTimeout(2000);
 
-    // Open export dialog
-    await openExportDialog(page);
+		// Open export dialog
+		await openExportDialog(page);
 
-    // Verify dialog is visible
-    const dialog = page.locator(selectors.exportDialog);
-    await expect(dialog).toBeVisible();
+		// Verify dialog is visible
+		const dialog = page.locator(selectors.exportDialog);
+		await expect(dialog).toBeVisible();
 
-    // Verify export format options exist
-    const bundleRadio = page.locator(selectors.exportFormatBundleRadio);
-    const rmarkdownRadio = page.locator(selectors.exportFormatRMarkdownRadio);
+		// Verify export format options exist
+		const bundleRadio = page.locator(selectors.exportFormatBundleRadio);
+		const rmarkdownRadio = page.locator(selectors.exportFormatRMarkdownRadio);
 
-    const hasBundleOption = await bundleRadio.count();
-    const hasRMarkdownOption = await rmarkdownRadio.count();
+		const hasBundleOption = await bundleRadio.count();
+		const hasRMarkdownOption = await rmarkdownRadio.count();
 
-    expect(hasBundleOption + hasRMarkdownOption).toBeGreaterThan(0);
+		expect(hasBundleOption + hasRMarkdownOption).toBeGreaterThan(0);
 
-    await closeDialog(page);
-  });
+		await closeDialog(page);
+	});
 
-  test('allows selecting different export formats', async ({ page }) => {
-    await page.goto('/');
+	test("allows selecting different export formats", async ({ page }) => {
+		await page.goto("/");
 
-    await executeRCode(page, 'x <- 10');
-    await page.waitForTimeout(2000);
+		await executeRCode(page, "x <- 10");
+		await page.waitForTimeout(2000);
 
-    await openExportDialog(page);
+		await openExportDialog(page);
 
-    // Try selecting bundle format
-    const bundleRadio = page.locator(selectors.exportFormatBundleRadio);
-    if (await bundleRadio.count() > 0) {
-      await bundleRadio.click();
-      await expect(bundleRadio).toBeChecked();
-    }
+		// Try selecting bundle format
+		const bundleRadio = page.locator(selectors.exportFormatBundleRadio);
+		if ((await bundleRadio.count()) > 0) {
+			await bundleRadio.click();
+			await expect(bundleRadio).toBeChecked();
+		}
 
-    // Try selecting RMarkdown format
-    const rmarkdownRadio = page.locator(selectors.exportFormatRMarkdownRadio);
-    if (await rmarkdownRadio.count() > 0) {
-      await rmarkdownRadio.click();
-      await expect(rmarkdownRadio).toBeChecked();
-    }
+		// Try selecting RMarkdown format
+		const rmarkdownRadio = page.locator(selectors.exportFormatRMarkdownRadio);
+		if ((await rmarkdownRadio.count()) > 0) {
+			await rmarkdownRadio.click();
+			await expect(rmarkdownRadio).toBeChecked();
+		}
 
-    await closeDialog(page);
-  });
+		await closeDialog(page);
+	});
 
-  test('allows selecting export mode (standalone vs linked)', async ({ page }) => {
-    await page.goto('/');
+	test("allows selecting export mode (standalone vs linked)", async ({ page }) => {
+		await page.goto("/");
 
-    await executeRCode(page, 'y <- 20');
-    await page.waitForTimeout(2000);
+		await executeRCode(page, "y <- 20");
+		await page.waitForTimeout(2000);
 
-    await openExportDialog(page);
+		await openExportDialog(page);
 
-    // Try selecting standalone mode
-    const standaloneRadio = page.locator(selectors.exportModeStandaloneRadio);
-    if (await standaloneRadio.count() > 0) {
-      await standaloneRadio.click();
-      await expect(standaloneRadio).toBeChecked();
-    }
+		// Try selecting standalone mode
+		const standaloneRadio = page.locator(selectors.exportModeStandaloneRadio);
+		if ((await standaloneRadio.count()) > 0) {
+			await standaloneRadio.click();
+			await expect(standaloneRadio).toBeChecked();
+		}
 
-    // Try selecting linked mode
-    const linkedRadio = page.locator(selectors.exportModeLinkedRadio);
-    if (await linkedRadio.count() > 0) {
-      await linkedRadio.click();
-      await expect(linkedRadio).toBeChecked();
-    }
+		// Try selecting linked mode
+		const linkedRadio = page.locator(selectors.exportModeLinkedRadio);
+		if ((await linkedRadio.count()) > 0) {
+			await linkedRadio.click();
+			await expect(linkedRadio).toBeChecked();
+		}
 
-    await closeDialog(page);
-  });
+		await closeDialog(page);
+	});
 
-  test('displays export options configuration', async ({ page }) => {
-    await page.goto('/');
+	test("displays export options configuration", async ({ page }) => {
+		await page.goto("/");
 
-    await executeRCode(page, 'z <- 30');
-    await page.waitForTimeout(2000);
+		await executeRCode(page, "z <- 30");
+		await page.waitForTimeout(2000);
 
-    await openExportDialog(page);
+		await openExportDialog(page);
 
-    const dialog = page.locator(selectors.exportDialog);
-    await expect(dialog).toBeVisible();
+		const dialog = page.locator(selectors.exportDialog);
+		await expect(dialog).toBeVisible();
 
-    // Verify dialog has form elements
-    const inputs = dialog.locator('input');
-    const inputCount = await inputs.count();
-    expect(inputCount).toBeGreaterThan(0);
+		// Verify dialog has form elements
+		const inputs = dialog.locator("input");
+		const inputCount = await inputs.count();
+		expect(inputCount).toBeGreaterThan(0);
 
-    await closeDialog(page);
-  });
+		await closeDialog(page);
+	});
 
-  test('validates export form inputs', async ({ page }) => {
-    await page.goto('/');
+	test("validates export form inputs", async ({ page }) => {
+		await page.goto("/");
 
-    await executeRCode(page, 'value <- 100');
-    await page.waitForTimeout(2000);
+		await executeRCode(page, "value <- 100");
+		await page.waitForTimeout(2000);
 
-    await openExportDialog(page);
+		await openExportDialog(page);
 
-    // Verify form validation exists
-    const dialog = page.locator(selectors.exportDialog);
+		// Verify form validation exists
+		const dialog = page.locator(selectors.exportDialog);
 
-    // Look for required fields or validation messages
-    const requiredInputs = dialog.locator('input[required]');
-    const requiredCount = await requiredInputs.count();
+		// Look for required fields or validation messages
+		const requiredInputs = dialog.locator("input[required]");
+		const requiredCount = await requiredInputs.count();
 
-    // Either there are required fields or the form allows submission
-    expect(requiredCount).toBeGreaterThanOrEqual(0);
+		// Either there are required fields or the form allows submission
+		expect(requiredCount).toBeGreaterThanOrEqual(0);
 
-    await closeDialog(page);
-  });
+		await closeDialog(page);
+	});
 
-  test('handles export errors gracefully', async ({ page }) => {
-    await page.goto('/');
+	test("handles export errors gracefully", async ({ page }) => {
+		await page.goto("/");
 
-    await executeRCode(page, 'test <- 42');
-    await page.waitForTimeout(2000);
+		await executeRCode(page, "test <- 42");
+		await page.waitForTimeout(2000);
 
-    await openExportDialog(page);
+		await openExportDialog(page);
 
-    // Try to submit without filling required fields (if any)
-    const submitButton = page.locator('button[type="submit"]');
-    if (await submitButton.count() > 0) {
-      // Click submit
-      await submitButton.click();
+		// Try to submit without filling required fields (if any)
+		const submitButton = page.locator('button[type="submit"]');
+		if ((await submitButton.count()) > 0) {
+			// Click submit
+			await submitButton.click();
 
-      // Either validation message appears or dialog stays open
-      const dialog = page.locator(selectors.exportDialog);
-      const isStillVisible = await dialog.isVisible().catch(() => false);
+			// Either validation message appears or dialog stays open
+			const dialog = page.locator(selectors.exportDialog);
+			const isStillVisible = await dialog.isVisible().catch(() => false);
 
-      // This is acceptable - form should handle validation
-      expect(true).toBeTruthy();
-    }
+			// This is acceptable - form should handle validation
+			expect(true).toBeTruthy();
+		}
 
-    await closeDialog(page);
-  });
+		await closeDialog(page);
+	});
 });

--- a/desktop/e2e/tests/full-workflow.spec.ts
+++ b/desktop/e2e/tests/full-workflow.spec.ts
@@ -1,29 +1,29 @@
-import { test, expect } from '@playwright/test';
-import { selectors } from '../shared/selectors';
+import { expect, test } from "@playwright/test";
 import {
-  executeRCode,
-  waitForConsoleOutput,
-  consoleHasOutput,
-  openTimelineDialog,
-  openExportDialog,
-  closeDialog,
-} from '../shared/helpers';
+	closeDialog,
+	consoleHasOutput,
+	executeRCode,
+	openExportDialog,
+	openTimelineDialog,
+	waitForConsoleOutput,
+} from "../shared/helpers";
+import { selectors } from "../shared/selectors";
 
-test.describe('Full user workflow', () => {
-  test('completes a full data analysis workflow', async ({ page }) => {
-    // ========================================
-    // STEP 1: App Launch and Initial State
-    // ========================================
-    await page.goto('/');
+test.describe("Full user workflow", () => {
+	test("completes a full data analysis workflow", async ({ page }) => {
+		// ========================================
+		// STEP 1: App Launch and Initial State
+		// ========================================
+		await page.goto("/");
 
-    const editor = page.locator(selectors.editor);
-    await editor.waitFor({ timeout: 30000 });
-    await expect(editor).toBeVisible();
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
+		await expect(editor).toBeVisible();
 
-    // ========================================
-    // STEP 2: Write and Execute R Code
-    // ========================================
-    const analysisCode = `# Data Analysis Workflow
+		// ========================================
+		// STEP 2: Write and Execute R Code
+		// ========================================
+		const analysisCode = `# Data Analysis Workflow
 # Create sample data
 data <- c(23, 45, 67, 12, 89, 34, 56, 78)
 
@@ -37,142 +37,140 @@ cat("Mean:", mean_value, "\\n")
 cat("Median:", median_value, "\\n")
 cat("SD:", sd_value, "\\n")`;
 
-    await executeRCode(page, analysisCode);
+		await executeRCode(page, analysisCode);
 
-    // ========================================
-    // STEP 3: Verify Console Output
-    // ========================================
-    await waitForConsoleOutput(page, 'Mean:', { timeout: 30000 });
+		// ========================================
+		// STEP 3: Verify Console Output
+		// ========================================
+		await waitForConsoleOutput(page, "Mean:", { timeout: 30000 });
 
-    const hasOutput = await consoleHasOutput(page, 'Mean:');
-    expect(hasOutput).toBeTruthy();
+		const hasOutput = await consoleHasOutput(page, "Mean:");
+		expect(hasOutput).toBeTruthy();
 
-    // ========================================
-    // STEP 4: Check Timeline for Execution History
-    // ========================================
-    await openTimelineDialog(page);
+		// ========================================
+		// STEP 4: Check Timeline for Execution History
+		// ========================================
+		await openTimelineDialog(page);
 
-    const timelineEvents = page.locator(selectors.timelineEvent);
-    const eventCount = await timelineEvents.count();
-    expect(eventCount).toBeGreaterThan(0);
+		const timelineEvents = page.locator(selectors.timelineEvent);
+		const eventCount = await timelineEvents.count();
+		expect(eventCount).toBeGreaterThan(0);
 
-    await closeDialog(page);
+		await closeDialog(page);
 
-    // ========================================
-    // STEP 5: Open Export Dialog
-    // ========================================
-    await openExportDialog(page);
+		// ========================================
+		// STEP 5: Open Export Dialog
+		// ========================================
+		await openExportDialog(page);
 
-    const exportDialog = page.locator(selectors.exportDialog);
-    await expect(exportDialog).toBeVisible();
+		const exportDialog = page.locator(selectors.exportDialog);
+		await expect(exportDialog).toBeVisible();
 
-    // Verify export options are available
-    const bundleRadio = page.locator(selectors.exportFormatBundleRadio);
-    const rmarkdownRadio = page.locator(selectors.exportFormatRMarkdownRadio);
+		// Verify export options are available
+		const bundleRadio = page.locator(selectors.exportFormatBundleRadio);
+		const rmarkdownRadio = page.locator(selectors.exportFormatRMarkdownRadio);
 
-    const hasExportOptions =
-      (await bundleRadio.count()) + (await rmarkdownRadio.count());
-    expect(hasExportOptions).toBeGreaterThan(0);
+		const hasExportOptions = (await bundleRadio.count()) + (await rmarkdownRadio.count());
+		expect(hasExportOptions).toBeGreaterThan(0);
 
-    await closeDialog(page);
+		await closeDialog(page);
 
-    // ========================================
-    // STEP 6: Execute Additional Code
-    // ========================================
-    const additionalCode = `# Additional analysis
+		// ========================================
+		// STEP 6: Execute Additional Code
+		// ========================================
+		const additionalCode = `# Additional analysis
 # Create a plot (won't display in console but will execute)
 result <- sum(data)
 cat("Total sum:", result, "\\n")`;
 
-    await executeRCode(page, additionalCode);
+		await executeRCode(page, additionalCode);
 
-    // Wait for new execution
-    await waitForConsoleOutput(page, 'Total sum:', { timeout: 30000 });
+		// Wait for new execution
+		await waitForConsoleOutput(page, "Total sum:", { timeout: 30000 });
 
-    // ========================================
-    // STEP 7: Verify Timeline Updated
-    // ========================================
-    await openTimelineDialog(page);
+		// ========================================
+		// STEP 7: Verify Timeline Updated
+		// ========================================
+		await openTimelineDialog(page);
 
-    const updatedEvents = page.locator(selectors.timelineEvent);
-    const updatedCount = await updatedEvents.count();
-    expect(updatedCount).toBeGreaterThanOrEqual(eventCount);
+		const updatedEvents = page.locator(selectors.timelineEvent);
+		const updatedCount = await updatedEvents.count();
+		expect(updatedCount).toBeGreaterThanOrEqual(eventCount);
 
-    await closeDialog(page);
+		await closeDialog(page);
 
-    // ========================================
-    // STEP 8: Final Verification
-    // ========================================
-    // Verify app is still responsive
-    const hasBothOutputs =
-      (await consoleHasOutput(page, 'Mean:')) &&
-      (await consoleHasOutput(page, 'Total sum:'));
+		// ========================================
+		// STEP 8: Final Verification
+		// ========================================
+		// Verify app is still responsive
+		const hasBothOutputs =
+			(await consoleHasOutput(page, "Mean:")) && (await consoleHasOutput(page, "Total sum:"));
 
-    expect(hasBothOutputs).toBeTruthy();
+		expect(hasBothOutputs).toBeTruthy();
 
-    // Verify editor is still functional
-    await editor.click();
-    await page.keyboard.press('Control+A');
-    await page.keyboard.type('# Workflow complete');
+		// Verify editor is still functional
+		await editor.click();
+		await page.keyboard.press("Control+A");
+		await page.keyboard.type("# Workflow complete");
 
-    await expect(editor).toBeVisible();
-  });
+		await expect(editor).toBeVisible();
+	});
 
-  test('handles workflow with errors and recovery', async ({ page }) => {
-    await page.goto('/');
+	test("handles workflow with errors and recovery", async ({ page }) => {
+		await page.goto("/");
 
-    const editor = page.locator(selectors.editor);
-    await editor.waitFor({ timeout: 30000 });
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
 
-    // Execute code with error
-    await executeRCode(page, 'x <- 1\ny <- x / 0  # Division by zero warning');
-    await page.waitForTimeout(3000);
+		// Execute code with error
+		await executeRCode(page, "x <- 1\ny <- x / 0  # Division by zero warning");
+		await page.waitForTimeout(3000);
 
-    // Continue with valid code
-    await executeRCode(page, 'z <- 10\nprint(z * 2)');
+		// Continue with valid code
+		await executeRCode(page, "z <- 10\nprint(z * 2)");
 
-    // Verify recovery
-    await waitForConsoleOutput(page, '[1] 20', { timeout: 30000 });
+		// Verify recovery
+		await waitForConsoleOutput(page, "[1] 20", { timeout: 30000 });
 
-    const hasOutput = await consoleHasOutput(page, '[1] 20');
-    expect(hasOutput).toBeTruthy();
+		const hasOutput = await consoleHasOutput(page, "[1] 20");
+		expect(hasOutput).toBeTruthy();
 
-    // Check timeline still works
-    await openTimelineDialog(page);
+		// Check timeline still works
+		await openTimelineDialog(page);
 
-    const events = page.locator(selectors.timelineEvent);
-    const eventCount = await events.count();
-    expect(eventCount).toBeGreaterThan(0);
+		const events = page.locator(selectors.timelineEvent);
+		const eventCount = await events.count();
+		expect(eventCount).toBeGreaterThan(0);
 
-    await closeDialog(page);
-  });
+		await closeDialog(page);
+	});
 
-  test('completes workflow with multiple code blocks', async ({ page }) => {
-    await page.goto('/');
+	test("completes workflow with multiple code blocks", async ({ page }) => {
+		await page.goto("/");
 
-    const editor = page.locator(selectors.editor);
-    await editor.waitFor({ timeout: 30000 });
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
 
-    // Execute first block
-    await executeRCode(page, '# Block 1\na <- 5');
-    await page.waitForTimeout(2000);
+		// Execute first block
+		await executeRCode(page, "# Block 1\na <- 5");
+		await page.waitForTimeout(2000);
 
-    // Execute second block
-    await executeRCode(page, '# Block 2\nb <- a * 2\nprint(b)');
+		// Execute second block
+		await executeRCode(page, "# Block 2\nb <- a * 2\nprint(b)");
 
-    // Wait for final output
-    await waitForConsoleOutput(page, '[1] 10', { timeout: 30000 });
+		// Wait for final output
+		await waitForConsoleOutput(page, "[1] 10", { timeout: 30000 });
 
-    const hasOutput = await consoleHasOutput(page, '[1] 10');
-    expect(hasOutput).toBeTruthy();
+		const hasOutput = await consoleHasOutput(page, "[1] 10");
+		expect(hasOutput).toBeTruthy();
 
-    // Verify timeline has both executions
-    await openTimelineDialog(page);
+		// Verify timeline has both executions
+		await openTimelineDialog(page);
 
-    const events = page.locator(selectors.timelineEvent);
-    const eventCount = await events.count();
-    expect(eventCount).toBeGreaterThanOrEqual(2);
+		const events = page.locator(selectors.timelineEvent);
+		const eventCount = await events.count();
+		expect(eventCount).toBeGreaterThanOrEqual(2);
 
-    await closeDialog(page);
-  });
+		await closeDialog(page);
+	});
 });

--- a/desktop/e2e/tests/r-execution.spec.ts
+++ b/desktop/e2e/tests/r-execution.spec.ts
@@ -1,62 +1,62 @@
-import { test, expect } from '@playwright/test';
-import { selectors } from '../shared/selectors';
-import { executeRCode, waitForConsoleOutput, consoleHasOutput } from '../shared/helpers';
+import { expect, test } from "@playwright/test";
+import { consoleHasOutput, executeRCode, waitForConsoleOutput } from "../shared/helpers";
+import { selectors } from "../shared/selectors";
 
-test.describe('R execution flow', () => {
-  test('runs a simple expression and shows the result', async ({ page }) => {
-    // Navigate to the app
-    await page.goto('/');
+test.describe("R execution flow", () => {
+	test("runs a simple expression and shows the result", async ({ page }) => {
+		// Navigate to the app
+		await page.goto("/");
 
-    // Wait for editor to be ready
-    const editor = page.locator(selectors.editor);
-    await editor.waitFor({ timeout: 30000 });
+		// Wait for editor to be ready
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
 
-    // Execute simple R code
-    await executeRCode(page, '1 + 1');
+		// Execute simple R code
+		await executeRCode(page, "1 + 1");
 
-    // Wait for output to appear
-    await waitForConsoleOutput(page, '[1] 2', { timeout: 30000 });
+		// Wait for output to appear
+		await waitForConsoleOutput(page, "[1] 2", { timeout: 30000 });
 
-    // Verify output is displayed
-    const hasOutput = await consoleHasOutput(page, '[1] 2');
-    expect(hasOutput).toBeTruthy();
-  });
+		// Verify output is displayed
+		const hasOutput = await consoleHasOutput(page, "[1] 2");
+		expect(hasOutput).toBeTruthy();
+	});
 
-  test('handles multiple expressions', async ({ page }) => {
-    await page.goto('/');
+	test("handles multiple expressions", async ({ page }) => {
+		await page.goto("/");
 
-    const editor = page.locator(selectors.editor);
-    await editor.waitFor({ timeout: 30000 });
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
 
-    // Execute multiple lines
-    const code = `x <- 5
+		// Execute multiple lines
+		const code = `x <- 5
 y <- 10
 x + y`;
 
-    await executeRCode(page, code);
+		await executeRCode(page, code);
 
-    // Wait for result
-    await waitForConsoleOutput(page, '[1] 15', { timeout: 30000 });
+		// Wait for result
+		await waitForConsoleOutput(page, "[1] 15", { timeout: 30000 });
 
-    // Verify output
-    const hasOutput = await consoleHasOutput(page, '[1] 15');
-    expect(hasOutput).toBeTruthy();
-  });
+		// Verify output
+		const hasOutput = await consoleHasOutput(page, "[1] 15");
+		expect(hasOutput).toBeTruthy();
+	});
 
-  test('displays formatted output correctly', async ({ page }) => {
-    await page.goto('/');
+	test("displays formatted output correctly", async ({ page }) => {
+		await page.goto("/");
 
-    const editor = page.locator(selectors.editor);
-    await editor.waitFor({ timeout: 30000 });
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
 
-    // Execute code that produces formatted output
-    await executeRCode(page, 'print("Hello, Re-prod!")');
+		// Execute code that produces formatted output
+		await executeRCode(page, 'print("Hello, Re-prod!")');
 
-    // Wait for output
-    await waitForConsoleOutput(page, 'Hello, Re-prod!', { timeout: 30000 });
+		// Wait for output
+		await waitForConsoleOutput(page, "Hello, Re-prod!", { timeout: 30000 });
 
-    // Verify output
-    const hasOutput = await consoleHasOutput(page, 'Hello, Re-prod!');
-    expect(hasOutput).toBeTruthy();
-  });
+		// Verify output
+		const hasOutput = await consoleHasOutput(page, "Hello, Re-prod!");
+		expect(hasOutput).toBeTruthy();
+	});
 });

--- a/desktop/e2e/tests/timeline.spec.ts
+++ b/desktop/e2e/tests/timeline.spec.ts
@@ -1,122 +1,122 @@
-import { test, expect } from '@playwright/test';
-import { selectors } from '../shared/selectors';
-import { executeRCode, openTimelineDialog, closeDialog } from '../shared/helpers';
+import { expect, test } from "@playwright/test";
+import { closeDialog, executeRCode, openTimelineDialog } from "../shared/helpers";
+import { selectors } from "../shared/selectors";
 
-test.describe('Timeline feature', () => {
-  test('opens timeline dialog and displays execution history', async ({ page }) => {
-    await page.goto('/');
+test.describe("Timeline feature", () => {
+	test("opens timeline dialog and displays execution history", async ({ page }) => {
+		await page.goto("/");
 
-    // Execute some R code to create timeline events
-    await executeRCode(page, 'x <- 1 + 1\nx');
+		// Execute some R code to create timeline events
+		await executeRCode(page, "x <- 1 + 1\nx");
 
-    // Wait for execution to complete
-    await page.waitForTimeout(2000);
+		// Wait for execution to complete
+		await page.waitForTimeout(2000);
 
-    // Open timeline dialog
-    await openTimelineDialog(page);
+		// Open timeline dialog
+		await openTimelineDialog(page);
 
-    // Verify dialog is visible
-    const dialog = page.locator(selectors.timelineDialog);
-    await expect(dialog).toBeVisible();
+		// Verify dialog is visible
+		const dialog = page.locator(selectors.timelineDialog);
+		await expect(dialog).toBeVisible();
 
-    // Verify timeline has events
-    const events = page.locator(selectors.timelineEvent);
-    const eventCount = await events.count();
-    expect(eventCount).toBeGreaterThan(0);
+		// Verify timeline has events
+		const events = page.locator(selectors.timelineEvent);
+		const eventCount = await events.count();
+		expect(eventCount).toBeGreaterThan(0);
 
-    // Verify timeline stats are displayed
-    const stats = page.locator(selectors.timelineStats);
-    const statsCount = await stats.count();
-    expect(statsCount).toBeGreaterThan(0);
+		// Verify timeline stats are displayed
+		const stats = page.locator(selectors.timelineStats);
+		const statsCount = await stats.count();
+		expect(statsCount).toBeGreaterThan(0);
 
-    // Close dialog
-    await closeDialog(page);
-    await expect(dialog).not.toBeVisible();
-  });
+		// Close dialog
+		await closeDialog(page);
+		await expect(dialog).not.toBeVisible();
+	});
 
-  test('filters timeline events by type', async ({ page }) => {
-    await page.goto('/');
+	test("filters timeline events by type", async ({ page }) => {
+		await page.goto("/");
 
-    // Execute code to create events
-    await executeRCode(page, 'result <- 5 * 3\nresult');
-    await page.waitForTimeout(2000);
+		// Execute code to create events
+		await executeRCode(page, "result <- 5 * 3\nresult");
+		await page.waitForTimeout(2000);
 
-    // Open timeline
-    await openTimelineDialog(page);
+		// Open timeline
+		await openTimelineDialog(page);
 
-    // Get initial event count
-    const events = page.locator(selectors.timelineEvent);
-    const initialCount = await events.count();
+		// Get initial event count
+		const events = page.locator(selectors.timelineEvent);
+		const initialCount = await events.count();
 
-    // Apply filter if filter dropdown exists
-    const filterDropdown = page.locator(selectors.timelineFilterDropdown);
-    if (await filterDropdown.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await filterDropdown.click();
+		// Apply filter if filter dropdown exists
+		const filterDropdown = page.locator(selectors.timelineFilterDropdown);
+		if (await filterDropdown.isVisible({ timeout: 1000 }).catch(() => false)) {
+			await filterDropdown.click();
 
-      // Select a filter option
-      const firstOption = filterDropdown.locator('option').first();
-      await firstOption.click();
+			// Select a filter option
+			const firstOption = filterDropdown.locator("option").first();
+			await firstOption.click();
 
-      // Verify event count changed or stayed the same
-      const filteredCount = await events.count();
-      expect(filteredCount).toBeGreaterThanOrEqual(0);
-    }
+			// Verify event count changed or stayed the same
+			const filteredCount = await events.count();
+			expect(filteredCount).toBeGreaterThanOrEqual(0);
+		}
 
-    await closeDialog(page);
-  });
+		await closeDialog(page);
+	});
 
-  test('displays timeline statistics correctly', async ({ page }) => {
-    await page.goto('/');
+	test("displays timeline statistics correctly", async ({ page }) => {
+		await page.goto("/");
 
-    // Execute code
-    await executeRCode(page, 'a <- 10\nb <- 20\na + b');
-    await page.waitForTimeout(2000);
+		// Execute code
+		await executeRCode(page, "a <- 10\nb <- 20\na + b");
+		await page.waitForTimeout(2000);
 
-    // Open timeline
-    await openTimelineDialog(page);
+		// Open timeline
+		await openTimelineDialog(page);
 
-    // Verify stats exist and have valid values
-    const stats = page.locator(selectors.timelineStats);
-    const statsCount = await stats.count();
+		// Verify stats exist and have valid values
+		const stats = page.locator(selectors.timelineStats);
+		const statsCount = await stats.count();
 
-    if (statsCount > 0) {
-      // Check first stat has content
-      const firstStat = stats.first();
-      const statText = await firstStat.textContent();
-      expect(statText).not.toBeNull();
-      expect(statText?.length).toBeGreaterThan(0);
-    }
+		if (statsCount > 0) {
+			// Check first stat has content
+			const firstStat = stats.first();
+			const statText = await firstStat.textContent();
+			expect(statText).not.toBeNull();
+			expect(statText?.length).toBeGreaterThan(0);
+		}
 
-    await closeDialog(page);
-  });
+		await closeDialog(page);
+	});
 
-  test('navigates to code location when clicking timeline event', async ({ page }) => {
-    await page.goto('/');
+	test("navigates to code location when clicking timeline event", async ({ page }) => {
+		await page.goto("/");
 
-    // Execute code
-    await executeRCode(page, 'test_value <- 42\ntest_value');
-    await page.waitForTimeout(2000);
+		// Execute code
+		await executeRCode(page, "test_value <- 42\ntest_value");
+		await page.waitForTimeout(2000);
 
-    // Open timeline
-    await openTimelineDialog(page);
+		// Open timeline
+		await openTimelineDialog(page);
 
-    // Click on first event
-    const events = page.locator(selectors.timelineEvent);
-    const eventCount = await events.count();
+		// Click on first event
+		const events = page.locator(selectors.timelineEvent);
+		const eventCount = await events.count();
 
-    if (eventCount > 0) {
-      const firstEvent = events.first();
-      await firstEvent.click();
+		if (eventCount > 0) {
+			const firstEvent = events.first();
+			await firstEvent.click();
 
-      // Dialog should close after navigation
-      await page.waitForTimeout(500);
-      const dialog = page.locator(selectors.timelineDialog);
+			// Dialog should close after navigation
+			await page.waitForTimeout(500);
+			const dialog = page.locator(selectors.timelineDialog);
 
-      // Either dialog is closed or we navigated
-      const isDialogVisible = await dialog.isVisible().catch(() => false);
+			// Either dialog is closed or we navigated
+			const isDialogVisible = await dialog.isVisible().catch(() => false);
 
-      // This is acceptable - event click may close dialog or navigate
-      expect(true).toBeTruthy();
-    }
-  });
+			// This is acceptable - event click may close dialog or navigate
+			expect(true).toBeTruthy();
+		}
+	});
 });

--- a/desktop/e2e/tsconfig.json
+++ b/desktop/e2e/tsconfig.json
@@ -1,18 +1,18 @@
 {
-  "compilerOptions": {
-    "target": "ES2021",
-    "module": "commonjs",
-    "moduleResolution": "Node",
-    "lib": ["ES2021", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "types": ["node", "@wdio/globals/types", "@wdio/mocha-framework"]
-  },
-  "include": ["./**/*.ts"],
-  "ts-node": {
-    "compilerOptions": {
-      "module": "commonjs"
-    }
-  }
+	"compilerOptions": {
+		"target": "ES2021",
+		"module": "commonjs",
+		"moduleResolution": "Node",
+		"lib": ["ES2021", "DOM"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"types": ["node", "@wdio/globals/types", "@wdio/mocha-framework"]
+	},
+	"include": ["./**/*.ts"],
+	"ts-node": {
+		"compilerOptions": {
+			"module": "commonjs"
+		}
+	}
 }

--- a/desktop/e2e/wdio.conf.ts
+++ b/desktop/e2e/wdio.conf.ts
@@ -1,135 +1,135 @@
-import type { Options } from '@wdio/types';
-import { spawn, type ChildProcess } from 'node:child_process';
-import http from 'node:http';
-import path from 'node:path';
+import { type ChildProcess, spawn } from "node:child_process";
+import http from "node:http";
+import path from "node:path";
+import type { Options } from "@wdio/types";
 
-const driverHost = process.env.TAURI_DRIVER_HOST ?? '127.0.0.1';
-const driverPort = Number(process.env.TAURI_DRIVER_PORT ?? '9515');
-const driverPath = process.env.TAURI_DRIVER_PATH ?? '/';
-const driverReadyTimeout = Number(process.env.TAURI_DRIVER_READY_TIMEOUT ?? '15000');
+const driverHost = process.env.TAURI_DRIVER_HOST ?? "127.0.0.1";
+const driverPort = Number(process.env.TAURI_DRIVER_PORT ?? "9515");
+const driverPath = process.env.TAURI_DRIVER_PATH ?? "/";
+const driverReadyTimeout = Number(process.env.TAURI_DRIVER_READY_TIMEOUT ?? "15000");
 const binaryPath =
-  process.env.TAURI_DRIVER_APP ?? path.resolve(__dirname, '../target/debug/reprod-desktop');
-const driverExecutable = process.env.TAURI_DRIVER_EXECUTABLE ?? 'tauri-driver';
+	process.env.TAURI_DRIVER_APP ?? path.resolve(__dirname, "../target/debug/reprod-desktop");
+const driverExecutable = process.env.TAURI_DRIVER_EXECUTABLE ?? "tauri-driver";
 const driverArgs = process.env.TAURI_DRIVER_ARGS
-  ? process.env.TAURI_DRIVER_ARGS.split(' ').filter(Boolean)
-  : ['--port', driverPort.toString(), '--binary', binaryPath];
+	? process.env.TAURI_DRIVER_ARGS.split(" ").filter(Boolean)
+	: ["--port", driverPort.toString(), "--binary", binaryPath];
 
 let tauriOptions: Record<string, unknown> = {};
 if (process.env.TAURI_DRIVER_TAURI_OPTIONS) {
-  try {
-    tauriOptions = JSON.parse(process.env.TAURI_DRIVER_TAURI_OPTIONS);
-  } catch (error) {
-    console.warn('Unable to parse TAURI_DRIVER_TAURI_OPTIONS', error);
-  }
+	try {
+		tauriOptions = JSON.parse(process.env.TAURI_DRIVER_TAURI_OPTIONS);
+	} catch (error) {
+		console.warn("Unable to parse TAURI_DRIVER_TAURI_OPTIONS", error);
+	}
 }
 
 let driverProcess: ChildProcess | null = null;
 
 function startDriver(): void {
-  if (driverProcess) {
-    return;
-  }
+	if (driverProcess) {
+		return;
+	}
 
-  driverProcess = spawn(driverExecutable, driverArgs, {
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+	driverProcess = spawn(driverExecutable, driverArgs, {
+		stdio: ["ignore", "pipe", "pipe"],
+	});
 
-  if (driverProcess.stdout) {
-    driverProcess.stdout.on('data', (chunk) => {
-      process.stdout.write(`[tauri-driver] ${chunk}`);
-    });
-  }
+	if (driverProcess.stdout) {
+		driverProcess.stdout.on("data", (chunk) => {
+			process.stdout.write(`[tauri-driver] ${chunk}`);
+		});
+	}
 
-  if (driverProcess.stderr) {
-    driverProcess.stderr.on('data', (chunk) => {
-      process.stderr.write(`[tauri-driver] ${chunk}`);
-    });
-  }
+	if (driverProcess.stderr) {
+		driverProcess.stderr.on("data", (chunk) => {
+			process.stderr.write(`[tauri-driver] ${chunk}`);
+		});
+	}
 }
 
 function stopDriver(): void {
-  if (!driverProcess) {
-    return;
-  }
+	if (!driverProcess) {
+		return;
+	}
 
-  driverProcess.kill();
-  driverProcess = null;
+	driverProcess.kill();
+	driverProcess = null;
 }
 
 async function waitForDriverReady(): Promise<void> {
-  const deadline = Date.now() + driverReadyTimeout;
+	const deadline = Date.now() + driverReadyTimeout;
 
-  while (Date.now() < deadline) {
-    try {
-      await new Promise<void>((resolve, reject) => {
-        const req = http.request(
-          {
-            hostname: driverHost,
-            port: driverPort,
-            path: '/status',
-            method: 'GET',
-            timeout: 2000,
-          },
-          (res) => {
-            if (res.statusCode && res.statusCode < 500) {
-              resolve();
-            } else {
-              reject(new Error(`unexpected status ${res.statusCode}`));
-            }
-          }
-        );
+	while (Date.now() < deadline) {
+		try {
+			await new Promise<void>((resolve, reject) => {
+				const req = http.request(
+					{
+						hostname: driverHost,
+						port: driverPort,
+						path: "/status",
+						method: "GET",
+						timeout: 2000,
+					},
+					(res) => {
+						if (res.statusCode && res.statusCode < 500) {
+							resolve();
+						} else {
+							reject(new Error(`unexpected status ${res.statusCode}`));
+						}
+					},
+				);
 
-        req.on('error', reject);
-        req.on('timeout', () => {
-          req.destroy();
-          reject(new Error('timeout'));
-        });
-        req.end();
-      });
+				req.on("error", reject);
+				req.on("timeout", () => {
+					req.destroy();
+					reject(new Error("timeout"));
+				});
+				req.end();
+			});
 
-      return;
-    } catch {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
-  }
+			return;
+		} catch {
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		}
+	}
 
-  throw new Error('tauri-driver did not become ready in time');
+	throw new Error("tauri-driver did not become ready in time");
 }
 
 export const config: Options.Testrunner = {
-  runner: 'local',
-  specs: ['./webdriver-specs/**/*.ts'],
-  maxInstances: 1,
-  capabilities: [
-    {
-      browserName: 'tauri' as any,
-      'tauri:options': {
-        binaryPath,
-        ...tauriOptions,
-      },
-    } as any,
-  ],
-  logLevel: 'info',
-  bail: 0,
-  waitforTimeout: 30000,
-  connectionRetryTimeout: 120000,
-  connectionRetryCount: 2,
-  services: [],
-  framework: 'mocha',
-  reporters: ['spec' as any],
-  mochaOpts: {
-    ui: 'bdd',
-    timeout: 300000,
-  },
-  hostname: driverHost,
-  port: driverPort,
-  path: driverPath,
-  protocol: 'http' as any,
-  onPrepare: async () => {
-    startDriver();
-    await waitForDriverReady();
-  },
-  onComplete: () => {
-    stopDriver();
-  },
+	runner: "local",
+	specs: ["./webdriver-specs/**/*.ts"],
+	maxInstances: 1,
+	capabilities: [
+		{
+			browserName: "tauri" as any,
+			"tauri:options": {
+				binaryPath,
+				...tauriOptions,
+			},
+		} as any,
+	],
+	logLevel: "info",
+	bail: 0,
+	waitforTimeout: 30000,
+	connectionRetryTimeout: 120000,
+	connectionRetryCount: 2,
+	services: [],
+	framework: "mocha",
+	reporters: ["spec" as any],
+	mochaOpts: {
+		ui: "bdd",
+		timeout: 300000,
+	},
+	hostname: driverHost,
+	port: driverPort,
+	path: driverPath,
+	protocol: "http" as any,
+	onPrepare: async () => {
+		startDriver();
+		await waitForDriverReady();
+	},
+	onComplete: () => {
+		stopDriver();
+	},
 };

--- a/desktop/e2e/webdriver-specs/error-handling.e2e.ts
+++ b/desktop/e2e/webdriver-specs/error-handling.e2e.ts
@@ -1,313 +1,303 @@
-import assert from 'node:assert';
+import assert from "node:assert";
 
-const editorSelector = '.monaco-editor textarea';
+const editorSelector = ".monaco-editor textarea";
 const runAllSelector = 'button[title="Run All (Cmd/Ctrl+Shift+Enter)"]';
-const consoleOutputSelector = '.console-output, .console-entry';
-const consoleStderrSelector = '.console-stderr';
-const errorBadgeSelector = '.console-error-badge, .error-badge';
+const consoleOutputSelector = ".console-output, .console-entry";
+const consoleStderrSelector = ".console-stderr";
+const errorBadgeSelector = ".console-error-badge, .error-badge";
 
-describe('Error handling scenarios', () => {
-  it('displays R syntax errors in console', async () => {
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.waitForDisplayed({ timeout: 30000 });
-    await editorInput.click();
+describe("Error handling scenarios", () => {
+	it("displays R syntax errors in console", async () => {
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.waitForDisplayed({ timeout: 30000 });
+		await editorInput.click();
 
-    // Clear editor and enter invalid R syntax
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('x <- 1 +');  // Incomplete expression
+		// Clear editor and enter invalid R syntax
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("x <- 1 +"); // Incomplete expression
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.waitForClickable({ timeout: 15000 });
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.waitForClickable({ timeout: 15000 });
+		await runAllButton.click();
 
-    // Wait for error output to appear
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          // R typically shows "Error" or "unexpected end of input"
-          if (text.toLowerCase().includes('error') ||
-              text.toLowerCase().includes('unexpected')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected syntax error to be displayed in console',
-      },
-    );
+		// Wait for error output to appear
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					// R typically shows "Error" or "unexpected end of input"
+					if (text.toLowerCase().includes("error") || text.toLowerCase().includes("unexpected")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected syntax error to be displayed in console",
+			},
+		);
 
-    // Verify error appears in console
-    const outputs = await browser.$$(consoleOutputSelector);
-    const errorTexts = await Promise.all(
-      outputs.map(async (output) => await output.getText()),
-    );
-    const hasError = errorTexts.some(
-      (text) => text.toLowerCase().includes('error') ||
-                text.toLowerCase().includes('unexpected'),
-    );
+		// Verify error appears in console
+		const outputs = await browser.$$(consoleOutputSelector);
+		const errorTexts = await Promise.all(outputs.map(async (output) => await output.getText()));
+		const hasError = errorTexts.some(
+			(text) => text.toLowerCase().includes("error") || text.toLowerCase().includes("unexpected"),
+		);
 
-    assert.ok(hasError, 'Syntax error should be displayed in console');
-  });
+		assert.ok(hasError, "Syntax error should be displayed in console");
+	});
 
-  it('displays R runtime errors', async () => {
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.click();
+	it("displays R runtime errors", async () => {
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.click();
 
-    // Clear and enter code that will cause runtime error
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('x <- c(1, 2, 3)\nprint(x[10])'); // Accessing out-of-bounds index (returns NA, not error)
+		// Clear and enter code that will cause runtime error
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("x <- c(1, 2, 3)\nprint(x[10])"); // Accessing out-of-bounds index (returns NA, not error)
 
-    // Better runtime error: division by non-numeric
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('x <- "text"\ny <- x / 2'); // Type error
+		// Better runtime error: division by non-numeric
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys('x <- "text"\ny <- x / 2'); // Type error
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.click();
 
-    // Wait for error in console
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.toLowerCase().includes('error')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected runtime error to be displayed',
-      },
-    );
+		// Wait for error in console
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (text.toLowerCase().includes("error")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected runtime error to be displayed",
+			},
+		);
 
-    const outputs = await browser.$$(consoleOutputSelector);
-    const errorTexts = await Promise.all(
-      outputs.map(async (output) => await output.getText()),
-    );
-    const hasError = errorTexts.some((text) => text.toLowerCase().includes('error'));
+		const outputs = await browser.$$(consoleOutputSelector);
+		const errorTexts = await Promise.all(outputs.map(async (output) => await output.getText()));
+		const hasError = errorTexts.some((text) => text.toLowerCase().includes("error"));
 
-    assert.ok(hasError, 'Runtime error should be displayed in console');
-  });
+		assert.ok(hasError, "Runtime error should be displayed in console");
+	});
 
-  it('shows stderr output with error styling', async () => {
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.click();
+	it("shows stderr output with error styling", async () => {
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.click();
 
-    // Code that produces error
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('stop("Intentional error for testing")');
+		// Code that produces error
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys('stop("Intentional error for testing")');
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.click();
 
-    // Wait for stderr output
-    await browser.waitUntil(
-      async () => {
-        const stderrElements = await browser.$$(consoleStderrSelector);
-        if (stderrElements.length === 0) {
-          // Fallback: check any console output for error
-          const outputs = await browser.$$(consoleOutputSelector);
-          for (const output of outputs) {
-            const text = await output.getText();
-            if (text.includes('Intentional error') || text.includes('Error')) {
-              return true;
-            }
-          }
-        }
-        return stderrElements.length > 0;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected stderr output to appear',
-      },
-    );
+		// Wait for stderr output
+		await browser.waitUntil(
+			async () => {
+				const stderrElements = await browser.$$(consoleStderrSelector);
+				if (stderrElements.length === 0) {
+					// Fallback: check any console output for error
+					const outputs = await browser.$$(consoleOutputSelector);
+					for (const output of outputs) {
+						const text = await output.getText();
+						if (text.includes("Intentional error") || text.includes("Error")) {
+							return true;
+						}
+					}
+				}
+				return stderrElements.length > 0;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected stderr output to appear",
+			},
+		);
 
-    // Verify stderr is styled appropriately
-    const stderrElements = await browser.$$(consoleStderrSelector);
-    if (stderrElements.length > 0) {
-      const firstStderr = stderrElements[0];
-      const text = await firstStderr.getText();
+		// Verify stderr is styled appropriately
+		const stderrElements = await browser.$$(consoleStderrSelector);
+		if (stderrElements.length > 0) {
+			const firstStderr = stderrElements[0];
+			const text = await firstStderr.getText();
 
-      assert.ok(
-        text.toLowerCase().includes('error') || text.includes('Intentional error'),
-        'Stderr should contain error message',
-      );
-    } else {
-      // Verify error appears somewhere in console
-      const outputs = await browser.$$(consoleOutputSelector);
-      const errorTexts = await Promise.all(
-        outputs.map(async (output) => await output.getText()),
-      );
-      const hasError = errorTexts.some(
-        (text) => text.includes('Intentional error') || text.includes('Error'),
-      );
+			assert.ok(
+				text.toLowerCase().includes("error") || text.includes("Intentional error"),
+				"Stderr should contain error message",
+			);
+		} else {
+			// Verify error appears somewhere in console
+			const outputs = await browser.$$(consoleOutputSelector);
+			const errorTexts = await Promise.all(outputs.map(async (output) => await output.getText()));
+			const hasError = errorTexts.some(
+				(text) => text.includes("Intentional error") || text.includes("Error"),
+			);
 
-      assert.ok(hasError, 'Error message should appear in console output');
-    }
-  });
+			assert.ok(hasError, "Error message should appear in console output");
+		}
+	});
 
-  it('displays error badge for failed executions', async () => {
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.click();
+	it("displays error badge for failed executions", async () => {
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.click();
 
-    // Code that will error
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('undefined_variable');
+		// Code that will error
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("undefined_variable");
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.click();
 
-    // Wait for execution to complete
-    await browser.pause(3000);
+		// Wait for execution to complete
+		await browser.pause(3000);
 
-    // Check for error badge (if implemented)
-    const errorBadge = await browser.$(errorBadgeSelector);
-    const hasBadge = await errorBadge.isExisting();
+		// Check for error badge (if implemented)
+		const errorBadge = await browser.$(errorBadgeSelector);
+		const hasBadge = await errorBadge.isExisting();
 
-    if (hasBadge) {
-      assert.ok(await errorBadge.isDisplayed(), 'Error badge should be visible for failed executions');
-    }
+		if (hasBadge) {
+			assert.ok(
+				await errorBadge.isDisplayed(),
+				"Error badge should be visible for failed executions",
+			);
+		}
 
-    // At minimum, verify error appears in console
-    const outputs = await browser.$$(consoleOutputSelector);
-    const errorTexts = await Promise.all(
-      outputs.map(async (output) => await output.getText()),
-    );
-    const hasError = errorTexts.some(
-      (text) => text.toLowerCase().includes('error') ||
-                text.toLowerCase().includes('not found'),
-    );
+		// At minimum, verify error appears in console
+		const outputs = await browser.$$(consoleOutputSelector);
+		const errorTexts = await Promise.all(outputs.map(async (output) => await output.getText()));
+		const hasError = errorTexts.some(
+			(text) => text.toLowerCase().includes("error") || text.toLowerCase().includes("not found"),
+		);
 
-    assert.ok(hasError, 'Error should be visible in console output');
-  });
+		assert.ok(hasError, "Error should be visible in console output");
+	});
 
-  it('handles undefined function errors', async () => {
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.click();
+	it("handles undefined function errors", async () => {
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.click();
 
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('nonexistent_function()');
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("nonexistent_function()");
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.click();
 
-    // Wait for error
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.toLowerCase().includes('could not find function') ||
-              text.toLowerCase().includes('error')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected function not found error',
-      },
-    );
+		// Wait for error
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (
+						text.toLowerCase().includes("could not find function") ||
+						text.toLowerCase().includes("error")
+					) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected function not found error",
+			},
+		);
 
-    const outputs = await browser.$$(consoleOutputSelector);
-    const errorTexts = await Promise.all(
-      outputs.map(async (output) => await output.getText()),
-    );
-    const hasError = errorTexts.some(
-      (text) => text.toLowerCase().includes('could not find function') ||
-                text.toLowerCase().includes('error'),
-    );
+		const outputs = await browser.$$(consoleOutputSelector);
+		const errorTexts = await Promise.all(outputs.map(async (output) => await output.getText()));
+		const hasError = errorTexts.some(
+			(text) =>
+				text.toLowerCase().includes("could not find function") ||
+				text.toLowerCase().includes("error"),
+		);
 
-    assert.ok(hasError, 'Undefined function error should be displayed');
-  });
+		assert.ok(hasError, "Undefined function error should be displayed");
+	});
 
-  it('recovers from errors and allows subsequent executions', async () => {
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.click();
+	it("recovers from errors and allows subsequent executions", async () => {
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.click();
 
-    // First: Execute code that errors
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('stop("Error")');
+		// First: Execute code that errors
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys('stop("Error")');
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.click();
 
-    // Wait for error
-    await browser.pause(3000);
+		// Wait for error
+		await browser.pause(3000);
 
-    // Second: Execute valid code
-    await editorInput.click();
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('x <- 42\nprint(x)');
+		// Second: Execute valid code
+		await editorInput.click();
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("x <- 42\nprint(x)");
 
-    await runAllButton.click();
+		await runAllButton.click();
 
-    // Wait for successful output
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.includes('[1] 42')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected successful execution after error',
-      },
-    );
+		// Wait for successful output
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (text.includes("[1] 42")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected successful execution after error",
+			},
+		);
 
-    const outputs = await browser.$$(consoleOutputSelector);
-    const outputTexts = await Promise.all(
-      outputs.map(async (output) => await output.getText()),
-    );
-    const hasSuccess = outputTexts.some((text) => text.includes('[1] 42'));
+		const outputs = await browser.$$(consoleOutputSelector);
+		const outputTexts = await Promise.all(outputs.map(async (output) => await output.getText()));
+		const hasSuccess = outputTexts.some((text) => text.includes("[1] 42"));
 
-    assert.ok(hasSuccess, 'Application should recover from errors and execute new code');
-  });
+		assert.ok(hasSuccess, "Application should recover from errors and execute new code");
+	});
 
-  it('handles parse errors gracefully', async () => {
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.click();
+	it("handles parse errors gracefully", async () => {
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.click();
 
-    // Completely malformed R code
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('}{][)( <- %% !!!');
+		// Completely malformed R code
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("}{][)( <- %% !!!");
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.click();
 
-    // Wait for parse error
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.toLowerCase().includes('error') ||
-              text.toLowerCase().includes('unexpected')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected parse error to be displayed',
-      },
-    );
+		// Wait for parse error
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (text.toLowerCase().includes("error") || text.toLowerCase().includes("unexpected")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected parse error to be displayed",
+			},
+		);
 
-    // Verify application didn't crash
-    const editorStillVisible = await editorInput.isDisplayed();
-    assert.ok(editorStillVisible, 'Editor should still be functional after parse error');
-  });
+		// Verify application didn't crash
+		const editorStillVisible = await editorInput.isDisplayed();
+		assert.ok(editorStillVisible, "Editor should still be functional after parse error");
+	});
 });

--- a/desktop/e2e/webdriver-specs/export.e2e.ts
+++ b/desktop/e2e/webdriver-specs/export.e2e.ts
@@ -1,251 +1,241 @@
-import assert from 'node:assert';
-import fs from 'node:fs';
-import path from 'node:path';
-import os from 'node:os';
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-const editorSelector = '.monaco-editor textarea';
+const editorSelector = ".monaco-editor textarea";
 const runAllSelector = 'button[title="Run All (Cmd/Ctrl+Shift+Enter)"]';
-const exportDialogSelector = '.export-dialog';
+const exportDialogSelector = ".export-dialog";
 const exportButtonSelector = '.export-dialog button[type="submit"], .export-dialog .btn-primary';
-const consoleOutputSelector = '.console-stdout';
+const consoleOutputSelector = ".console-stdout";
 
-describe('Export functionality', () => {
-  let tempDir: string;
+describe("Export functionality", () => {
+	let tempDir: string;
 
-  before(() => {
-    // Create temporary directory for export tests
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reprod-e2e-export-'));
-  });
+	before(() => {
+		// Create temporary directory for export tests
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "reprod-e2e-export-"));
+	});
 
-  after(() => {
-    // Cleanup temporary directory
-    if (fs.existsSync(tempDir)) {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
+	after(() => {
+		// Cleanup temporary directory
+		if (fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
 
-  it('opens export dialog and displays export options', async () => {
-    // Execute some R code first
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.waitForDisplayed({ timeout: 30000 });
-    await editorInput.click();
+	it("opens export dialog and displays export options", async () => {
+		// Execute some R code first
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.waitForDisplayed({ timeout: 30000 });
+		await editorInput.click();
 
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('# Export test\nresult <- mean(c(1, 2, 3, 4, 5))\nprint(result)');
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("# Export test\nresult <- mean(c(1, 2, 3, 4, 5))\nprint(result)");
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.waitForClickable({ timeout: 15000 });
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.waitForClickable({ timeout: 15000 });
+		await runAllButton.click();
 
-    // Wait for execution to complete
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.includes('[1] 3')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected code execution to complete',
-      },
-    );
+		// Wait for execution to complete
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (text.includes("[1] 3")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected code execution to complete",
+			},
+		);
 
-    // Open export dialog via browser.execute
-    await browser.execute(() => {
-      (window as any).openExportDialog?.();
-    });
+		// Open export dialog via browser.execute
+		await browser.execute(() => {
+			(window as any).openExportDialog?.();
+		});
 
-    // Wait for export dialog to appear
-    const exportDialog = await browser.$(exportDialogSelector);
-    await exportDialog.waitForDisplayed({ timeout: 10000 });
+		// Wait for export dialog to appear
+		const exportDialog = await browser.$(exportDialogSelector);
+		await exportDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Verify dialog is visible
-    const isDialogVisible = await exportDialog.isDisplayed();
-    assert.ok(isDialogVisible, 'Export dialog should be visible');
+		// Verify dialog is visible
+		const isDialogVisible = await exportDialog.isDisplayed();
+		assert.ok(isDialogVisible, "Export dialog should be visible");
 
-    // Verify export format options exist
-    const bundleRadio = await browser.$('input[value="bundle"]');
-    const rmarkdownRadio = await browser.$('input[value="rmarkdown"]');
-    const bothRadio = await browser.$('input[value="both"]');
+		// Verify export format options exist
+		const bundleRadio = await browser.$('input[value="bundle"]');
+		const rmarkdownRadio = await browser.$('input[value="rmarkdown"]');
+		const bothRadio = await browser.$('input[value="both"]');
 
-    assert.ok(await bundleRadio.isExisting(), 'Bundle format option should exist');
-    assert.ok(await rmarkdownRadio.isExisting(), 'RMarkdown format option should exist');
-    assert.ok(await bothRadio.isExisting(), 'Both format option should exist');
+		assert.ok(await bundleRadio.isExisting(), "Bundle format option should exist");
+		assert.ok(await rmarkdownRadio.isExisting(), "RMarkdown format option should exist");
+		assert.ok(await bothRadio.isExisting(), "Both format option should exist");
 
-    // Close dialog with ESC key
-    await browser.keys('Escape');
+		// Close dialog with ESC key
+		await browser.keys("Escape");
 
-    // Verify dialog is closed
-    await browser.waitUntil(
-      async () => {
-        return !(await exportDialog.isDisplayed());
-      },
-      {
-        timeout: 5000,
-        timeoutMsg: 'Export dialog should close after pressing ESC',
-      },
-    );
-  });
+		// Verify dialog is closed
+		await browser.waitUntil(
+			async () => {
+				return !(await exportDialog.isDisplayed());
+			},
+			{
+				timeout: 5000,
+				timeoutMsg: "Export dialog should close after pressing ESC",
+			},
+		);
+	});
 
-  it('allows selecting different export formats', async () => {
-    // Open export dialog
-    await browser.execute(() => {
-      (window as any).openExportDialog?.();
-    });
+	it("allows selecting different export formats", async () => {
+		// Open export dialog
+		await browser.execute(() => {
+			(window as any).openExportDialog?.();
+		});
 
-    const exportDialog = await browser.$(exportDialogSelector);
-    await exportDialog.waitForDisplayed({ timeout: 10000 });
+		const exportDialog = await browser.$(exportDialogSelector);
+		await exportDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Test selecting RMarkdown format
-    const rmarkdownRadio = await browser.$('input[value="rmarkdown"]');
-    await rmarkdownRadio.click();
+		// Test selecting RMarkdown format
+		const rmarkdownRadio = await browser.$('input[value="rmarkdown"]');
+		await rmarkdownRadio.click();
 
-    // Verify selection
-    const isRmarkdownChecked = await rmarkdownRadio.isSelected();
-    assert.ok(isRmarkdownChecked, 'RMarkdown format should be selectable');
+		// Verify selection
+		const isRmarkdownChecked = await rmarkdownRadio.isSelected();
+		assert.ok(isRmarkdownChecked, "RMarkdown format should be selectable");
 
-    // Test selecting Bundle format
-    const bundleRadio = await browser.$('input[value="bundle"]');
-    await bundleRadio.click();
+		// Test selecting Bundle format
+		const bundleRadio = await browser.$('input[value="bundle"]');
+		await bundleRadio.click();
 
-    const isBundleChecked = await bundleRadio.isSelected();
-    assert.ok(isBundleChecked, 'Bundle format should be selectable');
+		const isBundleChecked = await bundleRadio.isSelected();
+		assert.ok(isBundleChecked, "Bundle format should be selectable");
 
-    // Close dialog
-    await browser.keys('Escape');
-  });
+		// Close dialog
+		await browser.keys("Escape");
+	});
 
-  it('displays export modes (standalone/linked)', async () => {
-    // Open export dialog
-    await browser.execute(() => {
-      (window as any).openExportDialog?.();
-    });
+	it("displays export modes (standalone/linked)", async () => {
+		// Open export dialog
+		await browser.execute(() => {
+			(window as any).openExportDialog?.();
+		});
 
-    const exportDialog = await browser.$(exportDialogSelector);
-    await exportDialog.waitForDisplayed({ timeout: 10000 });
+		const exportDialog = await browser.$(exportDialogSelector);
+		await exportDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Check for mode selection options
-    const standaloneMode = await browser.$('input[value="standalone"]');
-    const linkedMode = await browser.$('input[value="linked"]');
+		// Check for mode selection options
+		const standaloneMode = await browser.$('input[value="standalone"]');
+		const linkedMode = await browser.$('input[value="linked"]');
 
-    const hasStandaloneMode = await standaloneMode.isExisting();
-    const hasLinkedMode = await linkedMode.isExisting();
+		const hasStandaloneMode = await standaloneMode.isExisting();
+		const hasLinkedMode = await linkedMode.isExisting();
 
-    // At least one mode should be available
-    assert.ok(
-      hasStandaloneMode || hasLinkedMode,
-      'Export modes should be available',
-    );
+		// At least one mode should be available
+		assert.ok(hasStandaloneMode || hasLinkedMode, "Export modes should be available");
 
-    // Close dialog
-    await browser.keys('Escape');
-  });
+		// Close dialog
+		await browser.keys("Escape");
+	});
 
-  it('shows export button and validates form', async () => {
-    // Open export dialog
-    await browser.execute(() => {
-      (window as any).openExportDialog?.();
-    });
+	it("shows export button and validates form", async () => {
+		// Open export dialog
+		await browser.execute(() => {
+			(window as any).openExportDialog?.();
+		});
 
-    const exportDialog = await browser.$(exportDialogSelector);
-    await exportDialog.waitForDisplayed({ timeout: 10000 });
+		const exportDialog = await browser.$(exportDialogSelector);
+		await exportDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Find export button
-    const exportBtn = await browser.$(exportButtonSelector);
-    const buttonExists = await exportBtn.isExisting();
+		// Find export button
+		const exportBtn = await browser.$(exportButtonSelector);
+		const buttonExists = await exportBtn.isExisting();
 
-    if (buttonExists) {
-      // Verify button is displayed
-      assert.ok(await exportBtn.isDisplayed(), 'Export button should be visible');
+		if (buttonExists) {
+			// Verify button is displayed
+			assert.ok(await exportBtn.isDisplayed(), "Export button should be visible");
 
-      // Check if button text is appropriate
-      const buttonText = await exportBtn.getText();
-      assert.ok(
-        buttonText.toLowerCase().includes('export') ||
-          buttonText.toLowerCase().includes('save'),
-        'Export button should have appropriate text',
-      );
-    }
+			// Check if button text is appropriate
+			const buttonText = await exportBtn.getText();
+			assert.ok(
+				buttonText.toLowerCase().includes("export") || buttonText.toLowerCase().includes("save"),
+				"Export button should have appropriate text",
+			);
+		}
 
-    // Close dialog
-    await browser.keys('Escape');
-  });
+		// Close dialog
+		await browser.keys("Escape");
+	});
 
-  it('handles export errors gracefully', async () => {
-    // Open export dialog
-    await browser.execute(() => {
-      (window as any).openExportDialog?.();
-    });
+	it("handles export errors gracefully", async () => {
+		// Open export dialog
+		await browser.execute(() => {
+			(window as any).openExportDialog?.();
+		});
 
-    const exportDialog = await browser.$(exportDialogSelector);
-    await exportDialog.waitForDisplayed({ timeout: 10000 });
+		const exportDialog = await browser.$(exportDialogSelector);
+		await exportDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Try to export with invalid/empty path (if path input exists)
-    const pathInput = await browser.$('input[type="text"], input[placeholder*="path"]');
-    const pathInputExists = await pathInput.isExisting();
+		// Try to export with invalid/empty path (if path input exists)
+		const pathInput = await browser.$('input[type="text"], input[placeholder*="path"]');
+		const pathInputExists = await pathInput.isExisting();
 
-    if (pathInputExists) {
-      await pathInput.click();
-      await browser.keys(['Control', 'a', 'NULL']);
-      await browser.keys(''); // Clear input
+		if (pathInputExists) {
+			await pathInput.click();
+			await browser.keys(["Control", "a", "NULL"]);
+			await browser.keys(""); // Clear input
 
-      // Try to click export button
-      const exportBtn = await browser.$(exportButtonSelector);
-      if (await exportBtn.isExisting()) {
-        await exportBtn.click();
+			// Try to click export button
+			const exportBtn = await browser.$(exportButtonSelector);
+			if (await exportBtn.isExisting()) {
+				await exportBtn.click();
 
-        // Wait a moment for potential error message
-        await browser.pause(1000);
+				// Wait a moment for potential error message
+				await browser.pause(1000);
 
-        // Check if error message appears or button is disabled
-        const errorMessage = await browser.$('.export-error, .error-message, [role="alert"]');
-        const hasError = await errorMessage.isExisting();
+				// Check if error message appears or button is disabled
+				const errorMessage = await browser.$('.export-error, .error-message, [role="alert"]');
+				const hasError = await errorMessage.isExisting();
 
-        // Either error message should appear OR button should remain disabled
-        const isButtonDisabled = !(await exportBtn.isEnabled());
+				// Either error message should appear OR button should remain disabled
+				const isButtonDisabled = !(await exportBtn.isEnabled());
 
-        assert.ok(
-          hasError || isButtonDisabled,
-          'Export should handle invalid input gracefully',
-        );
-      }
-    }
+				assert.ok(hasError || isButtonDisabled, "Export should handle invalid input gracefully");
+			}
+		}
 
-    // Close dialog
-    await browser.keys('Escape');
-  });
+		// Close dialog
+		await browser.keys("Escape");
+	});
 
-  it('displays RMarkdown-specific options when RMarkdown is selected', async () => {
-    // Open export dialog
-    await browser.execute(() => {
-      (window as any).openExportDialog?.();
-    });
+	it("displays RMarkdown-specific options when RMarkdown is selected", async () => {
+		// Open export dialog
+		await browser.execute(() => {
+			(window as any).openExportDialog?.();
+		});
 
-    const exportDialog = await browser.$(exportDialogSelector);
-    await exportDialog.waitForDisplayed({ timeout: 10000 });
+		const exportDialog = await browser.$(exportDialogSelector);
+		await exportDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Select RMarkdown format
-    const rmarkdownRadio = await browser.$('input[value="rmarkdown"]');
-    await rmarkdownRadio.click();
+		// Select RMarkdown format
+		const rmarkdownRadio = await browser.$('input[value="rmarkdown"]');
+		await rmarkdownRadio.click();
 
-    // Wait for options to appear
-    await browser.pause(500);
+		// Wait for options to appear
+		await browser.pause(500);
 
-    // Check for RMarkdown-specific options (like document template)
-    const rmdOptions = await browser.$$('.export-section label, .export-checkbox');
+		// Check for RMarkdown-specific options (like document template)
+		const rmdOptions = await browser.$$(".export-section label, .export-checkbox");
 
-    // Should have some configuration options
-    assert.ok(
-      rmdOptions.length > 0,
-      'RMarkdown format should show additional options',
-    );
+		// Should have some configuration options
+		assert.ok(rmdOptions.length > 0, "RMarkdown format should show additional options");
 
-    // Close dialog
-    await browser.keys('Escape');
-  });
+		// Close dialog
+		await browser.keys("Escape");
+	});
 });

--- a/desktop/e2e/webdriver-specs/full-workflow.e2e.ts
+++ b/desktop/e2e/webdriver-specs/full-workflow.e2e.ts
@@ -1,11 +1,11 @@
-import assert from 'node:assert';
+import assert from "node:assert";
 
-const editorSelector = '.monaco-editor textarea';
+const editorSelector = ".monaco-editor textarea";
 const runAllSelector = 'button[title="Run All (Cmd/Ctrl+Shift+Enter)"]';
-const consoleOutputSelector = '.console-stdout';
-const timelineDialogSelector = '.timeline-dialog';
-const exportDialogSelector = '.export-dialog';
-const timelineEventSelector = '.timeline-event';
+const consoleOutputSelector = ".console-stdout";
+const timelineDialogSelector = ".timeline-dialog";
+const exportDialogSelector = ".export-dialog";
+const timelineEventSelector = ".timeline-event";
 
 /**
  * Full workflow E2E test
@@ -19,25 +19,25 @@ const timelineEventSelector = '.timeline-event';
  * 6. Execute more code
  * 7. Verify timeline updates
  */
-describe('Full user workflow', () => {
-  it('completes a full data analysis workflow', async () => {
-    // ========================================
-    // STEP 1: App Launch and Initial State
-    // ========================================
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.waitForDisplayed({ timeout: 30000 });
+describe("Full user workflow", () => {
+	it("completes a full data analysis workflow", async () => {
+		// ========================================
+		// STEP 1: App Launch and Initial State
+		// ========================================
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.waitForDisplayed({ timeout: 30000 });
 
-    const isEditorVisible = await editorInput.isDisplayed();
-    assert.ok(isEditorVisible, 'Editor should be visible after app launch');
+		const isEditorVisible = await editorInput.isDisplayed();
+		assert.ok(isEditorVisible, "Editor should be visible after app launch");
 
-    // ========================================
-    // STEP 2: Write and Execute R Code
-    // ========================================
-    await editorInput.click();
-    await browser.keys(['Control', 'a', 'NULL']);
+		// ========================================
+		// STEP 2: Write and Execute R Code
+		// ========================================
+		await editorInput.click();
+		await browser.keys(["Control", "a", "NULL"]);
 
-    // Write a simple data analysis workflow
-    const analysisCode = `# Data Analysis Workflow
+		// Write a simple data analysis workflow
+		const analysisCode = `# Data Analysis Workflow
 # Create sample data
 data <- c(23, 45, 67, 12, 89, 34, 56, 78)
 
@@ -51,281 +51,266 @@ cat("Mean:", mean_value, "\\n")
 cat("Median:", median_value, "\\n")
 cat("SD:", sd_value, "\\n")`;
 
-    await browser.keys(analysisCode);
+		await browser.keys(analysisCode);
 
-    // Execute the code
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.waitForClickable({ timeout: 15000 });
-    await runAllButton.click();
+		// Execute the code
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.waitForClickable({ timeout: 15000 });
+		await runAllButton.click();
 
-    // ========================================
-    // STEP 3: Verify Console Output
-    // ========================================
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.includes('Mean:') || text.includes('Median:')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected R execution output to appear in console',
-      },
-    );
+		// ========================================
+		// STEP 3: Verify Console Output
+		// ========================================
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (text.includes("Mean:") || text.includes("Median:")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected R execution output to appear in console",
+			},
+		);
 
-    const outputs = await browser.$$(consoleOutputSelector);
-    const outputTexts = await Promise.all(
-      outputs.map(async (output) => await output.getText()),
-    );
-    const hasOutput = outputTexts.some(
-      (text) => text.includes('Mean:') || text.includes('Median:'),
-    );
+		const outputs = await browser.$$(consoleOutputSelector);
+		const outputTexts = await Promise.all(outputs.map(async (output) => await output.getText()));
+		const hasOutput = outputTexts.some(
+			(text) => text.includes("Mean:") || text.includes("Median:"),
+		);
 
-    assert.ok(hasOutput, 'Console should display analysis results');
+		assert.ok(hasOutput, "Console should display analysis results");
 
-    // ========================================
-    // STEP 4: Check Timeline for Execution History
-    // ========================================
-    await browser.execute(() => {
-      (window as any).openTimelineDialog?.();
-    });
+		// ========================================
+		// STEP 4: Check Timeline for Execution History
+		// ========================================
+		await browser.execute(() => {
+			(window as any).openTimelineDialog?.();
+		});
 
-    const timelineDialog = await browser.$(timelineDialogSelector);
-    await timelineDialog.waitForDisplayed({ timeout: 10000 });
+		const timelineDialog = await browser.$(timelineDialogSelector);
+		await timelineDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Verify timeline shows the execution
-    const timelineEvents = await browser.$$(timelineEventSelector);
-    assert.ok(
-      timelineEvents.length > 0,
-      'Timeline should contain execution events',
-    );
+		// Verify timeline shows the execution
+		const timelineEvents = await browser.$$(timelineEventSelector);
+		assert.ok(timelineEvents.length > 0, "Timeline should contain execution events");
 
-    // Get first event and verify it contains our code
-    if (timelineEvents.length > 0) {
-      const firstEventText = await timelineEvents[0].getText();
-      // Timeline should reference our analysis
-      assert.ok(
-        firstEventText.length > 0,
-        'Timeline events should have content',
-      );
-    }
+		// Get first event and verify it contains our code
+		if (timelineEvents.length > 0) {
+			const firstEventText = await timelineEvents[0].getText();
+			// Timeline should reference our analysis
+			assert.ok(firstEventText.length > 0, "Timeline events should have content");
+		}
 
-    // Close timeline dialog
-    await browser.keys('Escape');
-    await browser.waitUntil(
-      async () => !(await timelineDialog.isDisplayed()),
-      { timeout: 5000 },
-    );
+		// Close timeline dialog
+		await browser.keys("Escape");
+		await browser.waitUntil(async () => !(await timelineDialog.isDisplayed()), {
+			timeout: 5000,
+		});
 
-    // ========================================
-    // STEP 5: Open Export Dialog
-    // ========================================
-    await browser.execute(() => {
-      (window as any).openExportDialog?.();
-    });
+		// ========================================
+		// STEP 5: Open Export Dialog
+		// ========================================
+		await browser.execute(() => {
+			(window as any).openExportDialog?.();
+		});
 
-    const exportDialog = await browser.$(exportDialogSelector);
-    await exportDialog.waitForDisplayed({ timeout: 10000 });
+		const exportDialog = await browser.$(exportDialogSelector);
+		await exportDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Verify export options are available
-    const bundleRadio = await browser.$('input[value="bundle"]');
-    const rmarkdownRadio = await browser.$('input[value="rmarkdown"]');
+		// Verify export options are available
+		const bundleRadio = await browser.$('input[value="bundle"]');
+		const rmarkdownRadio = await browser.$('input[value="rmarkdown"]');
 
-    assert.ok(
-      (await bundleRadio.isExisting()) || (await rmarkdownRadio.isExisting()),
-      'Export options should be available',
-    );
+		assert.ok(
+			(await bundleRadio.isExisting()) || (await rmarkdownRadio.isExisting()),
+			"Export options should be available",
+		);
 
-    // Close export dialog
-    await browser.keys('Escape');
-    await browser.waitUntil(
-      async () => !(await exportDialog.isDisplayed()),
-      { timeout: 5000 },
-    );
+		// Close export dialog
+		await browser.keys("Escape");
+		await browser.waitUntil(async () => !(await exportDialog.isDisplayed()), {
+			timeout: 5000,
+		});
 
-    // ========================================
-    // STEP 6: Execute Additional Code
-    // ========================================
-    await editorInput.click();
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys(`# Additional analysis
+		// ========================================
+		// STEP 6: Execute Additional Code
+		// ========================================
+		await editorInput.click();
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys(`# Additional analysis
 # Create a plot (won't display in console but will execute)
 result <- sum(data)
 cat("Total sum:", result, "\\n")`);
 
-    await runAllButton.click();
+		await runAllButton.click();
 
-    // Wait for new execution
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.includes('Total sum:')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected second execution output',
-      },
-    );
+		// Wait for new execution
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (text.includes("Total sum:")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected second execution output",
+			},
+		);
 
-    // ========================================
-    // STEP 7: Verify Timeline Updated
-    // ========================================
-    await browser.execute(() => {
-      (window as any).openTimelineDialog?.();
-    });
+		// ========================================
+		// STEP 7: Verify Timeline Updated
+		// ========================================
+		await browser.execute(() => {
+			(window as any).openTimelineDialog?.();
+		});
 
-    await timelineDialog.waitForDisplayed({ timeout: 10000 });
+		await timelineDialog.waitForDisplayed({ timeout: 10000 });
 
-    const updatedEvents = await browser.$$(timelineEventSelector);
-    assert.ok(
-      updatedEvents.length >= timelineEvents.length,
-      'Timeline should have been updated with new execution',
-    );
+		const updatedEvents = await browser.$$(timelineEventSelector);
+		assert.ok(
+			updatedEvents.length >= timelineEvents.length,
+			"Timeline should have been updated with new execution",
+		);
 
-    // Close timeline
-    await browser.keys('Escape');
+		// Close timeline
+		await browser.keys("Escape");
 
-    // ========================================
-    // STEP 8: Final Verification
-    // ========================================
-    // Verify app is still responsive
-    const finalOutputs = await browser.$$(consoleOutputSelector);
-    const finalTexts = await Promise.all(
-      finalOutputs.map(async (output) => await output.getText()),
-    );
+		// ========================================
+		// STEP 8: Final Verification
+		// ========================================
+		// Verify app is still responsive
+		const finalOutputs = await browser.$$(consoleOutputSelector);
+		const finalTexts = await Promise.all(
+			finalOutputs.map(async (output) => await output.getText()),
+		);
 
-    const hasBothOutputs = finalTexts.some((text) => text.includes('Mean:')) &&
-                           finalTexts.some((text) => text.includes('Total sum:'));
+		const hasBothOutputs =
+			finalTexts.some((text) => text.includes("Mean:")) &&
+			finalTexts.some((text) => text.includes("Total sum:"));
 
-    assert.ok(
-      hasBothOutputs,
-      'Console should contain outputs from both executions',
-    );
+		assert.ok(hasBothOutputs, "Console should contain outputs from both executions");
 
-    // Verify editor is still functional
-    await editorInput.click();
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('# Workflow complete');
+		// Verify editor is still functional
+		await editorInput.click();
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("# Workflow complete");
 
-    const editorStillWorks = await editorInput.isDisplayed();
-    assert.ok(editorStillWorks, 'Editor should remain functional after workflow');
-  });
+		const editorStillWorks = await editorInput.isDisplayed();
+		assert.ok(editorStillWorks, "Editor should remain functional after workflow");
+	});
 
-  it('handles workflow with errors and recovery', async () => {
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.click();
+	it("handles workflow with errors and recovery", async () => {
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.click();
 
-    // Execute code with error
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('x <- 1\ny <- x / 0  # Division by zero warning');
+		// Execute code with error
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("x <- 1\ny <- x / 0  # Division by zero warning");
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.click();
 
-    // Wait for execution (may have warning)
-    await browser.pause(3000);
+		// Wait for execution (may have warning)
+		await browser.pause(3000);
 
-    // Continue with valid code
-    await editorInput.click();
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('z <- 10\nprint(z * 2)');
+		// Continue with valid code
+		await editorInput.click();
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("z <- 10\nprint(z * 2)");
 
-    await runAllButton.click();
+		await runAllButton.click();
 
-    // Verify recovery
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.includes('[1] 20')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected successful execution after warning/error',
-      },
-    );
+		// Verify recovery
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (text.includes("[1] 20")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected successful execution after warning/error",
+			},
+		);
 
-    // Check timeline still works
-    await browser.execute(() => {
-      (window as any).openTimelineDialog?.();
-    });
+		// Check timeline still works
+		await browser.execute(() => {
+			(window as any).openTimelineDialog?.();
+		});
 
-    const timelineDialog = await browser.$(timelineDialogSelector);
-    await timelineDialog.waitForDisplayed({ timeout: 10000 });
+		const timelineDialog = await browser.$(timelineDialogSelector);
+		await timelineDialog.waitForDisplayed({ timeout: 10000 });
 
-    const events = await browser.$$(timelineEventSelector);
-    assert.ok(events.length > 0, 'Timeline should track all executions including errors');
+		const events = await browser.$$(timelineEventSelector);
+		assert.ok(events.length > 0, "Timeline should track all executions including errors");
 
-    await browser.keys('Escape');
-  });
+		await browser.keys("Escape");
+	});
 
-  it('completes workflow with multiple code blocks', async () => {
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.click();
+	it("completes workflow with multiple code blocks", async () => {
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.click();
 
-    // Execute first block
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('# Block 1\na <- 5');
+		// Execute first block
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("# Block 1\na <- 5");
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.click();
-    await browser.pause(2000);
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.click();
+		await browser.pause(2000);
 
-    // Execute second block
-    await editorInput.click();
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('# Block 2\nb <- a * 2\nprint(b)');
+		// Execute second block
+		await editorInput.click();
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("# Block 2\nb <- a * 2\nprint(b)");
 
-    await runAllButton.click();
+		await runAllButton.click();
 
-    // Wait for final output
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.includes('[1] 10')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected output from second code block',
-      },
-    );
+		// Wait for final output
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (text.includes("[1] 10")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected output from second code block",
+			},
+		);
 
-    // Verify timeline has both executions
-    await browser.execute(() => {
-      (window as any).openTimelineDialog?.();
-    });
+		// Verify timeline has both executions
+		await browser.execute(() => {
+			(window as any).openTimelineDialog?.();
+		});
 
-    const timelineDialog = await browser.$(timelineDialogSelector);
-    await timelineDialog.waitForDisplayed({ timeout: 10000 });
+		const timelineDialog = await browser.$(timelineDialogSelector);
+		await timelineDialog.waitForDisplayed({ timeout: 10000 });
 
-    const events = await browser.$$(timelineEventSelector);
-    assert.ok(
-      events.length >= 2,
-      'Timeline should contain multiple execution events',
-    );
+		const events = await browser.$$(timelineEventSelector);
+		assert.ok(events.length >= 2, "Timeline should contain multiple execution events");
 
-    await browser.keys('Escape');
-  });
+		await browser.keys("Escape");
+	});
 });

--- a/desktop/e2e/webdriver-specs/r-execution.e2e.ts
+++ b/desktop/e2e/webdriver-specs/r-execution.e2e.ts
@@ -1,40 +1,42 @@
-import assert from 'node:assert';
+import assert from "node:assert";
 
-const consoleOutputSelector = '.console-stdout';
+const consoleOutputSelector = ".console-stdout";
 const runAllSelector = 'button[title="Run All (Cmd/Ctrl+Shift+Enter)"]';
 
-describe('R execution flow', () => {
-  it('runs a simple expression and shows the result', async () => {
-    const editorInput = await browser.$('.monaco-editor textarea');
-    await editorInput.waitForDisplayed({ timeout: 30000 });
-    await editorInput.click();
+describe("R execution flow", () => {
+	it("runs a simple expression and shows the result", async () => {
+		const editorInput = await browser.$(".monaco-editor textarea");
+		await editorInput.waitForDisplayed({ timeout: 30000 });
+		await editorInput.click();
 
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('1 + 1');
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("1 + 1");
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.waitForClickable({ timeout: 15000 });
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.waitForClickable({ timeout: 15000 });
+		await runAllButton.click();
 
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.includes('[1] 2')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected R execution output to include [1] 2',
-      },
-    );
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (text.includes("[1] 2")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected R execution output to include [1] 2",
+			},
+		);
 
-    const outputs = await browser.$$(consoleOutputSelector);
-    const found = await Promise.all(outputs.map(async (output) => (await output.getText()).includes('[1] 2')));
-    assert.ok(found.some(Boolean), 'Console should show the result [1] 2');
-  });
+		const outputs = await browser.$$(consoleOutputSelector);
+		const found = await Promise.all(
+			outputs.map(async (output) => (await output.getText()).includes("[1] 2")),
+		);
+		assert.ok(found.some(Boolean), "Console should show the result [1] 2");
+	});
 });

--- a/desktop/e2e/webdriver-specs/timeline.e2e.ts
+++ b/desktop/e2e/webdriver-specs/timeline.e2e.ts
@@ -1,181 +1,175 @@
-import assert from 'node:assert';
+import assert from "node:assert";
 
-const editorSelector = '.monaco-editor textarea';
+const editorSelector = ".monaco-editor textarea";
 const runAllSelector = 'button[title="Run All (Cmd/Ctrl+Shift+Enter)"]';
-const timelineDialogSelector = '.timeline-dialog';
-const timelineEventSelector = '.timeline-event';
-const timelineStatsSelector = '.timeline-stat';
-const consoleOutputSelector = '.console-stdout';
+const timelineDialogSelector = ".timeline-dialog";
+const timelineEventSelector = ".timeline-event";
+const timelineStatsSelector = ".timeline-stat";
+const consoleOutputSelector = ".console-stdout";
 
-describe('Timeline feature', () => {
-  it('opens timeline dialog and displays execution history', async () => {
-    // Execute some R code to create timeline events
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.waitForDisplayed({ timeout: 30000 });
-    await editorInput.click();
+describe("Timeline feature", () => {
+	it("opens timeline dialog and displays execution history", async () => {
+		// Execute some R code to create timeline events
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.waitForDisplayed({ timeout: 30000 });
+		await editorInput.click();
 
-    // Clear editor and add code
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('x <- 1 + 1\nprint(x)');
+		// Clear editor and add code
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("x <- 1 + 1\nprint(x)");
 
-    // Run the code
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.waitForClickable({ timeout: 15000 });
-    await runAllButton.click();
+		// Run the code
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.waitForClickable({ timeout: 15000 });
+		await runAllButton.click();
 
-    // Wait for execution to complete
-    await browser.waitUntil(
-      async () => {
-        const outputs = await browser.$$(consoleOutputSelector);
-        for (const output of outputs) {
-          const text = await output.getText();
-          if (text.includes('[1] 2')) {
-            return true;
-          }
-        }
-        return false;
-      },
-      {
-        timeout: 30000,
-        timeoutMsg: 'Expected code execution to complete',
-      },
-    );
+		// Wait for execution to complete
+		await browser.waitUntil(
+			async () => {
+				const outputs = await browser.$$(consoleOutputSelector);
+				for (const output of outputs) {
+					const text = await output.getText();
+					if (text.includes("[1] 2")) {
+						return true;
+					}
+				}
+				return false;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected code execution to complete",
+			},
+		);
 
-    // Open timeline dialog via browser.execute
-    await browser.execute(() => {
-      (window as any).openTimelineDialog?.();
-    });
+		// Open timeline dialog via browser.execute
+		await browser.execute(() => {
+			(window as any).openTimelineDialog?.();
+		});
 
-    // Wait for timeline dialog to appear
-    const timelineDialog = await browser.$(timelineDialogSelector);
-    await timelineDialog.waitForDisplayed({ timeout: 10000 });
+		// Wait for timeline dialog to appear
+		const timelineDialog = await browser.$(timelineDialogSelector);
+		await timelineDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Verify dialog is visible
-    const isDialogVisible = await timelineDialog.isDisplayed();
-    assert.ok(isDialogVisible, 'Timeline dialog should be visible');
+		// Verify dialog is visible
+		const isDialogVisible = await timelineDialog.isDisplayed();
+		assert.ok(isDialogVisible, "Timeline dialog should be visible");
 
-    // Verify timeline events exist
-    const timelineEvents = await browser.$$(timelineEventSelector);
-    assert.ok(
-      timelineEvents.length > 0,
-      'Timeline should contain at least one event after code execution',
-    );
+		// Verify timeline events exist
+		const timelineEvents = await browser.$$(timelineEventSelector);
+		assert.ok(
+			timelineEvents.length > 0,
+			"Timeline should contain at least one event after code execution",
+		);
 
-    // Verify timeline stats are displayed
-    const timelineStats = await browser.$$(timelineStatsSelector);
-    assert.ok(timelineStats.length > 0, 'Timeline stats should be displayed');
+		// Verify timeline stats are displayed
+		const timelineStats = await browser.$$(timelineStatsSelector);
+		assert.ok(timelineStats.length > 0, "Timeline stats should be displayed");
 
-    // Close dialog with ESC key
-    await browser.keys('Escape');
+		// Close dialog with ESC key
+		await browser.keys("Escape");
 
-    // Verify dialog is closed
-    await browser.waitUntil(
-      async () => {
-        return !(await timelineDialog.isDisplayed());
-      },
-      {
-        timeout: 5000,
-        timeoutMsg: 'Timeline dialog should close after pressing ESC',
-      },
-    );
-  });
+		// Verify dialog is closed
+		await browser.waitUntil(
+			async () => {
+				return !(await timelineDialog.isDisplayed());
+			},
+			{
+				timeout: 5000,
+				timeoutMsg: "Timeline dialog should close after pressing ESC",
+			},
+		);
+	});
 
-  it('filters timeline events by type', async () => {
-    // Open timeline dialog
-    await browser.execute(() => {
-      (window as any).openTimelineDialog?.();
-    });
+	it("filters timeline events by type", async () => {
+		// Open timeline dialog
+		await browser.execute(() => {
+			(window as any).openTimelineDialog?.();
+		});
 
-    const timelineDialog = await browser.$(timelineDialogSelector);
-    await timelineDialog.waitForDisplayed({ timeout: 10000 });
+		const timelineDialog = await browser.$(timelineDialogSelector);
+		await timelineDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Find and click the event type filter dropdown
-    const eventTypeFilter = await browser.$('select[name="event-type"]');
-    const filterExists = await eventTypeFilter.isExisting();
+		// Find and click the event type filter dropdown
+		const eventTypeFilter = await browser.$('select[name="event-type"]');
+		const filterExists = await eventTypeFilter.isExisting();
 
-    if (filterExists) {
-      await eventTypeFilter.waitForClickable({ timeout: 5000 });
-      await eventTypeFilter.selectByAttribute('value', 'execution');
+		if (filterExists) {
+			await eventTypeFilter.waitForClickable({ timeout: 5000 });
+			await eventTypeFilter.selectByAttribute("value", "execution");
 
-      // Verify filtering works (events update)
-      await browser.pause(1000); // Wait for filter to apply
+			// Verify filtering works (events update)
+			await browser.pause(1000); // Wait for filter to apply
 
-      const eventsAfterFilter = await browser.$$(timelineEventSelector);
-      assert.ok(
-        eventsAfterFilter.length >= 0,
-        'Events should be filtered by type',
-      );
-    }
+			const eventsAfterFilter = await browser.$$(timelineEventSelector);
+			assert.ok(eventsAfterFilter.length >= 0, "Events should be filtered by type");
+		}
 
-    // Close dialog
-    await browser.keys('Escape');
-  });
+		// Close dialog
+		await browser.keys("Escape");
+	});
 
-  it('displays timeline statistics correctly', async () => {
-    // Open timeline dialog
-    await browser.execute(() => {
-      (window as any).openTimelineDialog?.();
-    });
+	it("displays timeline statistics correctly", async () => {
+		// Open timeline dialog
+		await browser.execute(() => {
+			(window as any).openTimelineDialog?.();
+		});
 
-    const timelineDialog = await browser.$(timelineDialogSelector);
-    await timelineDialog.waitForDisplayed({ timeout: 10000 });
+		const timelineDialog = await browser.$(timelineDialogSelector);
+		await timelineDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Check for stats elements
-    const totalStat = await browser.$('.timeline-stat-value');
-    if (await totalStat.isExisting()) {
-      const statValue = await totalStat.getText();
-      assert.ok(
-        parseInt(statValue, 10) >= 0,
-        'Timeline statistics should display valid numbers',
-      );
-    }
+		// Check for stats elements
+		const totalStat = await browser.$(".timeline-stat-value");
+		if (await totalStat.isExisting()) {
+			const statValue = await totalStat.getText();
+			assert.ok(parseInt(statValue, 10) >= 0, "Timeline statistics should display valid numbers");
+		}
 
-    // Close dialog
-    await browser.keys('Escape');
-  });
+		// Close dialog
+		await browser.keys("Escape");
+	});
 
-  it('navigates to code location when clicking timeline event', async () => {
-    // Execute code with specific content we can verify
-    const editorInput = await browser.$(editorSelector);
-    await editorInput.click();
+	it("navigates to code location when clicking timeline event", async () => {
+		// Execute code with specific content we can verify
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.click();
 
-    await browser.keys(['Control', 'a', 'NULL']);
-    await browser.keys('# Test navigation\ny <- 100');
+		await browser.keys(["Control", "a", "NULL"]);
+		await browser.keys("# Test navigation\ny <- 100");
 
-    const runAllButton = await browser.$(runAllSelector);
-    await runAllButton.click();
+		const runAllButton = await browser.$(runAllSelector);
+		await runAllButton.click();
 
-    // Wait for execution
-    await browser.pause(3000);
+		// Wait for execution
+		await browser.pause(3000);
 
-    // Open timeline
-    await browser.execute(() => {
-      (window as any).openTimelineDialog?.();
-    });
+		// Open timeline
+		await browser.execute(() => {
+			(window as any).openTimelineDialog?.();
+		});
 
-    const timelineDialog = await browser.$(timelineDialogSelector);
-    await timelineDialog.waitForDisplayed({ timeout: 10000 });
+		const timelineDialog = await browser.$(timelineDialogSelector);
+		await timelineDialog.waitForDisplayed({ timeout: 10000 });
 
-    // Click on a timeline event (if clickable events exist)
-    const timelineEvents = await browser.$$(timelineEventSelector);
-    if (timelineEvents.length > 0) {
-      const firstEvent = timelineEvents[0];
-      const clickableElement = await firstEvent.$('button, a, [role="button"]');
+		// Click on a timeline event (if clickable events exist)
+		const timelineEvents = await browser.$$(timelineEventSelector);
+		if (timelineEvents.length > 0) {
+			const firstEvent = timelineEvents[0];
+			const clickableElement = await firstEvent.$('button, a, [role="button"]');
 
-      if (await clickableElement.isExisting()) {
-        await clickableElement.click();
+			if (await clickableElement.isExisting()) {
+				await clickableElement.click();
 
-        // Dialog should close after navigation
-        await browser.waitUntil(
-          async () => {
-            return !(await timelineDialog.isDisplayed());
-          },
-          {
-            timeout: 5000,
-            timeoutMsg: 'Timeline dialog should close after clicking event',
-          },
-        );
-      }
-    }
-  });
+				// Dialog should close after navigation
+				await browser.waitUntil(
+					async () => {
+						return !(await timelineDialog.isDisplayed());
+					},
+					{
+						timeout: 5000,
+						timeoutMsg: "Timeline dialog should close after clicking event",
+					},
+				);
+			}
+		}
+	});
 });

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,39 +1,39 @@
 {
-  "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Re-prod",
-  "version": "0.1.0",
-  "identifier": "com.reprod.app",
-  "build": {
-    "beforeDevCommand": "pnpm --dir .. --filter client dev",
-    "devUrl": "http://localhost:5173",
-    "beforeBuildCommand": "pnpm --dir .. --filter client build",
-    "frontendDist": "../client/dist"
-  },
-  "bundle": {
-    "icon": [
-      "icons/icon-16x16.png",
-      "icons/icon-32x32.png",
-      "icons/icon-64x64.png",
-      "icons/icon-128x128.png",
-      "icons/icon-256x256.png",
-      "icons/icon-512x512.png",
-      "icons/icon.png",
-      "icons/icon.icns"
-    ]
-  },
-  "app": {
-    "windows": [
-      {
-        "title": "Re-prod",
-        "width": 1200,
-        "height": 800,
-        "minWidth": 800,
-        "minHeight": 600
-      }
-    ],
-    "security": {
-      "csp": null,
-      "capabilities": ["default"]
-    }
-  }
+	"$schema": "https://schema.tauri.app/config/2",
+	"productName": "Re-prod",
+	"version": "0.1.0",
+	"identifier": "com.reprod.app",
+	"build": {
+		"beforeDevCommand": "pnpm --dir .. --filter client dev",
+		"devUrl": "http://localhost:5173",
+		"beforeBuildCommand": "pnpm --dir .. --filter client build",
+		"frontendDist": "../client/dist"
+	},
+	"bundle": {
+		"icon": [
+			"icons/icon-16x16.png",
+			"icons/icon-32x32.png",
+			"icons/icon-64x64.png",
+			"icons/icon-128x128.png",
+			"icons/icon-256x256.png",
+			"icons/icon-512x512.png",
+			"icons/icon.png",
+			"icons/icon.icns"
+		]
+	},
+	"app": {
+		"windows": [
+			{
+				"title": "Re-prod",
+				"width": 1200,
+				"height": 800,
+				"minWidth": 800,
+				"minHeight": 600
+			}
+		],
+		"security": {
+			"csp": null,
+			"capabilities": ["default"]
+		}
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10764 @@
+{
+  "name": "re-prod",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "re-prod",
+      "version": "0.1.0",
+      "workspaces": [
+        "client",
+        "desktop/e2e",
+        "shared"
+      ],
+      "devDependencies": {
+        "@biomejs/biome": "2.3.7",
+        "@tauri-apps/cli": "^2.9.1",
+        "concurrently": "^8.2.2",
+        "husky": "^9.1.7",
+        "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "client": {
+      "version": "0.1.0",
+      "dependencies": {
+        "@monaco-editor/react": "^4.6.0",
+        "@tauri-apps/api": "^2",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-web-links": "^0.11.0",
+        "@xterm/xterm": "^5.3.0",
+        "allotment": "^1.20.0",
+        "monaco-editor": "^0.54.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "zustand": "^4.4.7"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/react": "^18.2.45",
+        "@types/react-dom": "^18.2.18",
+        "@vitejs/plugin-react": "^4.2.1",
+        "jsdom": "^24.1.3",
+        "typescript": "^5.3.3",
+        "vite": "^5.0.8",
+        "vitest": "^4.0.1"
+      }
+    },
+    "desktop/e2e": {
+      "name": "@reprod/e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.56.1",
+        "@types/mocha": "^10.0.0",
+        "@types/node": "^20.0.0",
+        "@wdio/cli": "^8.0.0",
+        "@wdio/globals": "^8.0.0",
+        "@wdio/local-runner": "^8.0.0",
+        "@wdio/mocha-framework": "^8.0.0",
+        "@wdio/spec-reporter": "^8.0.0",
+        "@wdio/types": "^8.0.0",
+        "ts-node": "^10.9.0",
+        "typescript": "^5.0.0",
+        "webdriverio": "^8.0.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
+      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
+      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.5",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.5",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.5",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.5",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.5",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.7.tgz",
+      "integrity": "sha512-CTbAS/jNAiUc6rcq94BrTB8z83O9+BsgWj2sBCQg9rD6Wkh2gjfR87usjx0Ncx0zGXP1NKgT7JNglay5Zfs9jw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.3.7",
+        "@biomejs/cli-darwin-x64": "2.3.7",
+        "@biomejs/cli-linux-arm64": "2.3.7",
+        "@biomejs/cli-linux-arm64-musl": "2.3.7",
+        "@biomejs/cli-linux-x64": "2.3.7",
+        "@biomejs/cli-linux-x64-musl": "2.3.7",
+        "@biomejs/cli-win32-arm64": "2.3.7",
+        "@biomejs/cli-win32-x64": "2.3.7"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.7.tgz",
+      "integrity": "sha512-LirkamEwzIUULhXcf2D5b+NatXKeqhOwilM+5eRkbrnr6daKz9rsBL0kNZ16Hcy4b8RFq22SG4tcLwM+yx/wFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.7.tgz",
+      "integrity": "sha512-Q4TO633kvrMQkKIV7wmf8HXwF0dhdTD9S458LGE24TYgBjSRbuhvio4D5eOQzirEYg6eqxfs53ga/rbdd8nBKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.7.tgz",
+      "integrity": "sha512-inHOTdlstUBzgjDcx0ge71U4SVTbwAljmkfi3MC5WzsYCRhancqfeL+sa4Ke6v2ND53WIwCFD5hGsYExoI3EZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.7.tgz",
+      "integrity": "sha512-/afy8lto4CB8scWfMdt+NoCZtatBUF62Tk3ilWH2w8ENd5spLhM77zKlFZEvsKJv9AFNHknMl03zO67CiklL2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.7.tgz",
+      "integrity": "sha512-fJMc3ZEuo/NaMYo5rvoWjdSS5/uVSW+HPRQujucpZqm2ZCq71b8MKJ9U4th9yrv2L5+5NjPF0nqqILCl8HY/fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.7.tgz",
+      "integrity": "sha512-CQUtgH1tIN6e5wiYSJqzSwJumHYolNtaj1dwZGCnZXm2PZU1jOJof9TsyiP3bXNDb+VOR7oo7ZvY01If0W3iFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.7.tgz",
+      "integrity": "sha512-aJAE8eCNyRpcfx2JJAtsPtISnELJ0H4xVVSwnxm13bzI8RwbXMyVtxy2r5DV1xT3WiSP+7LxORcApWw0LM8HiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.7.tgz",
+      "integrity": "sha512-pulzUshqv9Ed//MiE8MOUeeEkbkSHVDVY5Cz5wVAnH1DUqliCQG3j6s1POaITTFqFfo7AVIx2sWdKpx/GS+Nqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ljharb/through": {
+      "version": "2.3.14",
+      "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.14.tgz",
+      "integrity": "sha512-ajBvlKpWucBB17FuQYUShqpqy8GRgYEpJW0vWJbUu1CV9lWyrDCapy0lScU8T8Z6qn49sSwJB3+M+evYIdGg+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@promptbook/utils": {
+      "version": "0.69.5",
+      "resolved": "https://registry.npmjs.org/@promptbook/utils/-/utils-0.69.5.tgz",
+      "integrity": "sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/webgptorg/promptbook/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "dependencies": {
+        "spacetrim": "0.11.59"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@reprod/e2e": {
+      "resolved": "desktop/e2e",
+      "link": true
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
+      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
+      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
+      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
+      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
+      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
+      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
+      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
+      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
+      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
+      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
+      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
+      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
+      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
+      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
+      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
+      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
+      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
+      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
+      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
+      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.0.tgz",
+      "integrity": "sha512-qD5tMjh7utwBk9/5PrTA/aGr3i5QaJ/Mlt7p8NilQ45WgbifUNPyKWsA63iQ8YfQq6R8ajMapU+/Q8nMcPRLNw==",
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
+    },
+    "node_modules/@tauri-apps/cli": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.9.4.tgz",
+      "integrity": "sha512-pvylWC9QckrOS9ATWXIXcgu7g2hKK5xTL5ZQyZU/U0n9l88SEFGcWgLQNa8WZmd+wWIOWhkxOFcOl3i6ubDNNw==",
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "bin": {
+        "tauri": "tauri.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      },
+      "optionalDependencies": {
+        "@tauri-apps/cli-darwin-arm64": "2.9.4",
+        "@tauri-apps/cli-darwin-x64": "2.9.4",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.9.4",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.9.4",
+        "@tauri-apps/cli-linux-arm64-musl": "2.9.4",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.9.4",
+        "@tauri-apps/cli-linux-x64-gnu": "2.9.4",
+        "@tauri-apps/cli-linux-x64-musl": "2.9.4",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.9.4",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.9.4",
+        "@tauri-apps/cli-win32-x64-msvc": "2.9.4"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-arm64": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.9.4.tgz",
+      "integrity": "sha512-9rHkMVtbMhe0AliVbrGpzMahOBg3rwV46JYRELxR9SN6iu1dvPOaMaiC4cP6M/aD1424ziXnnMdYU06RAH8oIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-x64": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.9.4.tgz",
+      "integrity": "sha512-VT9ymNuT06f5TLjCZW2hfSxbVtZDhORk7CDUDYiq5TiSYQdxkl8MVBy0CCFFcOk4QAkUmqmVUA9r3YZ/N/vPRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.9.4.tgz",
+      "integrity": "sha512-tTWkEPig+2z3Rk0zqZYfjUYcgD+aSm72wdrIhdYobxbQZOBw0zfn50YtWv+av7bm0SHvv75f0l7JuwgZM1HFow==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.9.4.tgz",
+      "integrity": "sha512-ql6vJ611qoqRYHxkKPnb2vHa27U+YRKRmIpLMMBeZnfFtZ938eao7402AQCH1mO2+/8ioUhbpy9R/ZcLTXVmkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-musl": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.9.4.tgz",
+      "integrity": "sha512-vg7yNn7ICTi6hRrcA/6ff2UpZQP7un3xe3SEld5QM0prgridbKAiXGaCKr3BnUBx/rGXegQlD/wiLcWdiiraSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.9.4.tgz",
+      "integrity": "sha512-l8L+3VxNk6yv5T/Z/gv5ysngmIpsai40B9p6NQQyqYqxImqYX37pqREoEBl1YwG7szGnDibpWhidPrWKR59OJA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-gnu": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.9.4.tgz",
+      "integrity": "sha512-PepPhCXc/xVvE3foykNho46OmCyx47E/aG676vKTVp+mqin5d+IBqDL6wDKiGNT5OTTxKEyNlCQ81Xs2BQhhqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-musl": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.9.4.tgz",
+      "integrity": "sha512-zcd1QVffh5tZs1u1SCKUV/V7RRynebgYUNWHuV0FsIF1MjnULUChEXhAhug7usCDq4GZReMJOoXa6rukEozWIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.9.4.tgz",
+      "integrity": "sha512-/7ZhnP6PY04bEob23q8MH/EoDISdmR1wuNm0k9d5HV7TDMd2GGCDa8dPXA4vJuglJKXIfXqxFmZ4L+J+MO42+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.9.4.tgz",
+      "integrity": "sha512-1LmAfaC4Cq+3O1Ir1ksdhczhdtFSTIV51tbAGtbV/mr348O+M52A/xwCCXQank0OcdBxy5BctqkMtuZnQvA8uQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-x64-msvc": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.9.4.tgz",
+      "integrity": "sha512-EdYd4c9wGvtPB95kqtEyY+bUR+k4kRw3IA30mAQ1jPH6z57AftT8q84qwv0RDp6kkEqOBKxeInKfqi4BESYuqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.14.tgz",
+      "integrity": "sha512-RHk63V3zvRiYOWAV0rGEBRO820ce17hz7cI2kDmEdfQsBjT2luEKB5tCOc91u1oSQoUOZkSv3ZyzkdkSLD7lKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.14",
+        "@vitest/utils": "4.0.14",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.14.tgz",
+      "integrity": "sha512-BsAIk3FAqxICqREbX8SetIteT8PiaUL/tgJjmhxJhCsigmzzH8xeadtp7LRnTpCVzvf0ib9BgAfKJHuhNllKLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.14",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.14.tgz",
+      "integrity": "sha512-JmAZT1UtZooO0tpY3GRyiC/8W7dCs05UOq9rfsUUgEZEdq+DuHLmWhPsrTt0TiW7WYeL/hXpaE07AZ2RCk44hg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.14.tgz",
+      "integrity": "sha512-hLqXZKAWNg8pI+SQXyXxWCTOpA3MvsqcbVeNgSi8x/CSN2wi26dSzn1wrOhmCmFjEvN9p8/kLFRHa6PI8jHazw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.14",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.14.tgz",
+      "integrity": "sha512-SOYPgujB6TITcJxgd3wmsLl+wZv+fy3av2PpiPpsWPZ6J1ySUYfScfpIt2Yv56ShJXR2MOA6q2KjKHN4EpdyRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@wdio/cli": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-8.46.0.tgz",
+      "integrity": "sha512-ZT7z4buheFtoXmL8/EPyrspXSwrVRKUI27GLY34hGOjHAhry4dTJ1ODC5ARs0PbuM//yJcJb8q18wa+2xGqf3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0",
+        "@vitest/snapshot": "^2.0.4",
+        "@wdio/config": "8.46.0",
+        "@wdio/globals": "8.46.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/protocols": "8.44.0",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.46.0",
+        "async-exit-hook": "^2.0.1",
+        "chalk": "^5.2.0",
+        "chokidar": "^4.0.0",
+        "cli-spinners": "^2.9.0",
+        "dotenv": "^16.3.1",
+        "ejs": "^3.1.9",
+        "execa": "^8.0.1",
+        "import-meta-resolve": "^4.0.0",
+        "inquirer": "9.2.12",
+        "lodash.flattendeep": "^4.4.0",
+        "lodash.pickby": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "read-pkg-up": "10.0.0",
+        "recursive-readdir": "^2.2.3",
+        "webdriverio": "8.46.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "wdio": "bin/wdio.js"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@wdio/config": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.46.0.tgz",
+      "integrity": "sha512-WrNPCqm22vuNimGJc8UCc6duEcvOy2foY5I8mv2AUaoTtvCZOfVGRrFnPreypOKVdZChubFCaWrKVNqjgMK5RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.46.0",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.0.0",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/globals": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-8.46.0.tgz",
+      "integrity": "sha512-0VtP2BG3ImU/BQH0rMGhewuxogp5KPNUHYqDqGQ7GEYA0m2Z9V07sC71E2SBIXCpaNWBFYCfFejrDQAuKLhOIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.13 || >=18"
+      },
+      "optionalDependencies": {
+        "expect-webdriverio": "^4.11.2",
+        "webdriverio": "8.46.0"
+      }
+    },
+    "node_modules/@wdio/local-runner": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-8.46.0.tgz",
+      "integrity": "sha512-wbM00qCHGqiTvHykEYZQpQHVuaPANyql6VAuRSO+C32tVvU/rLRAYOo0Z6c3QkzfoNBw+jG4n8CySNhCBRrlfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/repl": "8.40.3",
+        "@wdio/runner": "8.46.0",
+        "@wdio/types": "8.41.0",
+        "async-exit-hook": "^2.0.1",
+        "split2": "^4.1.0",
+        "stream-buffers": "^3.0.2"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/local-runner/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/logger": {
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.38.0.tgz",
+      "integrity": "sha512-kcHL86RmNbcQP+Gq/vQUGlArfU6IIcbbnNp32rRIraitomZow+iEoc519rdQmSVusDozMS5DZthkgDdxK+vz6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/logger/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@wdio/logger/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@wdio/logger/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@wdio/mocha-framework": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-8.46.0.tgz",
+      "integrity": "sha512-vosPCWouz7eKd3mdVrmYQuBgd7Y7V1cvwWxhslBslH5BX9kiWeUABLmsGoGKsjHDyEl9goc1Hhv/GKgyvXmFFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mocha": "^10.0.0",
+        "@types/node": "^22.2.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.46.0",
+        "mocha": "^10.0.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/mocha-framework/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/protocols": {
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.44.0.tgz",
+      "integrity": "sha512-Do+AW3xuDUHWkrX++LeMBSrX2yRILlDqunRHPMv4adGFEA45m7r4WP8wGCDb+chrHGhXq5TwB9Ne4J7x1dHGng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wdio/repl": {
+      "version": "8.40.3",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-8.40.3.tgz",
+      "integrity": "sha512-mWEiBbaC7CgxvSd2/ozpbZWebnRIc8KRu/J81Hlw/txUWio27S7IpXBlZGVvhEsNzq0+cuxB/8gDkkXvMPbesw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/repl/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/reporter": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-8.43.0.tgz",
+      "integrity": "sha512-0ph8SabdMrgDmuLUEwA7yvkrvlCw4/EXttb3CGucjSkuiSbZNLhdTMXpyPoewh2soa253fIpnx79HztOsOzn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.41.0",
+        "diff": "^7.0.0",
+        "object-inspect": "^1.12.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/reporter/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/runner": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-8.46.0.tgz",
+      "integrity": "sha512-QnjaFGeDbvdl7WzIVQN6gf4974FUlZ2dS8mDoiPvt/8ZaTSNfwHvvRL93HpYduteWmVVrOK0WcNb54Q8yTqvkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0",
+        "@wdio/config": "8.46.0",
+        "@wdio/globals": "8.46.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.46.0",
+        "deepmerge-ts": "^5.1.0",
+        "expect-webdriverio": "^4.12.0",
+        "gaze": "^1.1.3",
+        "webdriver": "8.46.0",
+        "webdriverio": "8.46.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/spec-reporter": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-8.43.0.tgz",
+      "integrity": "sha512-Qy5LsGrGHbXJdj2PveNV7CD5g1XpLPvd7wH8bAd9OtuZRTPknyZqYSvB8TlZIV/SfiNlWEJ/05mI/FcixNJ6Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/reporter": "8.43.0",
+        "@wdio/types": "8.41.0",
+        "chalk": "^5.1.2",
+        "easy-table": "^1.2.0",
+        "pretty-ms": "^7.0.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/spec-reporter/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@wdio/types": {
+      "version": "8.41.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.41.0.tgz",
+      "integrity": "sha512-t4NaNTvJZci3Xv/yUZPH4eTL0hxrVTf5wdwNnYIBrzMnlRDbNefjQ0P7FM7ZjQCLaH92AEH6t/XanUId7Webug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@wdio/types/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/utils": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.46.0.tgz",
+      "integrity": "sha512-C94kJjZhEfPUNbOA69BQr1SgziQYgjNXK8S1GJXQKuwxN/24PQkYCzeBqXstfxyTXyOwoQCcEZAQ/qJccboufQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@puppeteer/browsers": "^1.6.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.41.0",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^5.1.0",
+        "edgedriver": "^5.5.0",
+        "geckodriver": "~4.2.0",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.1.0",
+        "safaridriver": "^0.1.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.0.4"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.11.0.tgz",
+      "integrity": "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.11.tgz",
+      "integrity": "sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/allotment": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/allotment/-/allotment-1.20.4.tgz",
+      "integrity": "sha512-LMM5Xe5nLePFOLAlW/5k3ARqznYGUyNekV4xJrfDKn1jimW3nlZE6hT/Tu0T8s0VgAkr9s2P7+uM0WvJKn5DAw==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.3.0",
+        "eventemitter3": "^5.0.0",
+        "lodash.clamp": "^4.0.0",
+        "lodash.debounce": "^4.0.0",
+        "lodash.isequal": "^4.5.0",
+        "use-resize-observer": "^9.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.31.tgz",
+      "integrity": "sha512-a28v2eWrrRWPpJSzxc+mKwm0ZtVx/G8SepdQZDArnXYU/XS+IF6mp8aB/4E+hH1tyGCoDo3KlUCdlSxGDsRkAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
+      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.25",
+        "caniuse-lite": "^1.0.30001754",
+        "electron-to-chromium": "^1.5.249",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.1.4"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "10.2.14",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.0.2",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001757",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001757.tgz",
+      "integrity": "sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
+      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/client": {
+      "resolved": "client",
+      "link": true
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/cross-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-shorthand-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.2.tgz",
+      "integrity": "sha512-C2AugXIpRGQTxaCW0N7n5jD/p5irUmCrwl03TrnMFBHDbdq44CFWR2zO7rK9xPN4Eo3pUxC4vQzQgbIpzrD1PQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-value": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+      "integrity": "sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q==",
+      "dev": true
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
+      "integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1400418",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1400418.tgz",
+      "integrity": "sha512-U8j75zDOXF8IP3o0Cgb7K4tFA9uUHEOru2Wx64+EUqL4LNOh9dRe1i8WKR1k3mSpjcCe3aIkTDvEwq0YkI4hfw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/easy-table": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
+      "integrity": "sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "optionalDependencies": {
+        "wcwidth": "^1.0.1"
+      }
+    },
+    "node_modules/edge-paths": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
+      "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/which": "^2.0.1",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/shirshak55"
+      }
+    },
+    "node_modules/edge-paths/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/edge-paths/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/edgedriver": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-5.6.1.tgz",
+      "integrity": "sha512-3Ve9cd5ziLByUdigw6zovVeWJjVs8QHVmqOB0sJ0WNeVPcwf4p18GnxMmVvlFmYRloUwf5suNuorea4QzwBIOA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "^8.38.0",
+        "@zip.js/zip.js": "^2.7.48",
+        "decamelize": "^6.0.0",
+        "edge-paths": "^3.0.5",
+        "fast-xml-parser": "^4.4.1",
+        "node-fetch": "^3.3.2",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "edgedriver": "bin/edgedriver.js"
+      }
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.260",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.260.tgz",
+      "integrity": "sha512-ov8rBoOBhVawpzdre+Cmz4FB+y66Eqrk6Gwqd8NGxuhv99GQ8XqMAr351KEkOt7gukXWDg6gJWEMKgL2RLMPtA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/expect-webdriverio": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-4.15.4.tgz",
+      "integrity": "sha512-Op1xZoevlv1pohCq7g2Og5Gr3xP2NhY7MQueOApmopVxgweoJ/BqJxyvMNP0A//QsMg8v0WsN/1j81Sx2er9Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/snapshot": "^2.0.3",
+        "expect": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=16 || >=18 || >=20"
+      },
+      "optionalDependencies": {
+        "@wdio/globals": "^8.29.3",
+        "@wdio/logger": "^8.28.0",
+        "webdriverio": "^8.29.3"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/figures": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "is-unicode-supported": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaze": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globule": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/geckodriver": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
+      "integrity": "sha512-4m/CRk0OI8MaANRuFIahvOxYTSjlNAO2p9JmE14zxueknq6cdtB5M9UGRQ8R9aMV0bLGNVHHDnDXmoXdOwJfWg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@wdio/logger": "^8.11.0",
+        "decamelize": "^6.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.1",
+        "tar-fs": "^3.0.4",
+        "unzipper": "^0.10.14",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": "^16.13 || >=18 || >=20"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globule": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.4.tgz",
+      "integrity": "sha512-OPTIfhMBh7JbBYDpa5b+Q5ptmMWKwcNcFSR/0c6t8V4f3ZAVBEsKNY37QdVqmLRYSMhOUGYrY0QhSoEpzGr/Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "~7.1.1",
+        "lodash": "^4.17.21",
+        "minimatch": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/globule/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/globule/node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globule/node_modules/minimatch": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inquirer": {
+      "version": "9.2.12",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.12.tgz",
+      "integrity": "sha512-mg3Fh9g2zfuVWJn6lhST0O7x4n03k7G8Tx5nvikJkbq8/CK47WDVm+UznF0G6s5Zi0KcyUisr6DU8T67N5U+1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ljharb/through": "^2.3.11",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^5.3.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^4.1.0",
+        "external-editor": "^3.1.0",
+        "figures": "^5.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "1.0.0",
+        "ora": "^5.4.1",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.1",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/ky": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.33.3.tgz",
+      "integrity": "sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/locate-app": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.5.0.tgz",
+      "integrity": "sha512-xIqbzPMBYArJRmPGUZD9CzV9wOqmVtQnaAn3wrj3s6WYW0bQvPI7x+sPYUGmDTYMHefVK//zc6HEYZ1qnxIK+Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/hejny/locate-app/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@promptbook/utils": "0.69.5",
+        "type-fest": "4.26.0",
+        "userhome": "1.0.1"
+      }
+    },
+    "node_modules/locate-app/node_modules/type-fest": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
+      "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.clamp": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
+      "integrity": "sha512-HvzRFWjtcguTW7yd8NJBshuNaCa8aqNFtnswdT7f/cMd/1YKy5Zzoq4W/Oxvnx9l7aeY258uSdDfM793+eLsVg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loglevel-plugin-prefix": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
+      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.1.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.0.tgz",
+      "integrity": "sha512-X06Mfd/5aKsRHc0O0J5CUedwnPmnDtLF2+nq+KN9KSDlJHkPuh0JUviWjEWMe0SW/9TDdSLVPuk7L5gGTIA1/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-json": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
+      "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.21.4",
+        "error-ex": "^1.3.2",
+        "json-parse-even-better-errors": "^3.0.0",
+        "lines-and-columns": "^2.0.3",
+        "type-fest": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "1.9.1",
+        "chromium-bidi": "0.5.8",
+        "cross-fetch": "4.0.0",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1232444",
+        "ws": "8.16.0"
+      },
+      "engines": {
+        "node": ">=16.13.2"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer-core/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
+      "integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.1",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^7.0.0",
+        "type-fest": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.0.0.tgz",
+      "integrity": "sha512-jgmKiS//w2Zs+YbX039CorlkOp8FIVbSAN8r8GJHDsGlmNPXo+VeHkqAwCiQVTTx5/LwLZTcEw59z3DvcLbr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^6.3.0",
+        "read-pkg": "^8.0.0",
+        "type-fest": "^3.12.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recursive-readdir": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/recursive-readdir/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/recursive-readdir/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/resq": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resq/-/resq-1.11.0.tgz",
+      "integrity": "sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/rgb2hex": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.5.tgz",
+      "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
+      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.53.3",
+        "@rollup/rollup-android-arm64": "4.53.3",
+        "@rollup/rollup-darwin-arm64": "4.53.3",
+        "@rollup/rollup-darwin-x64": "4.53.3",
+        "@rollup/rollup-freebsd-arm64": "4.53.3",
+        "@rollup/rollup-freebsd-x64": "4.53.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
+        "@rollup/rollup-linux-arm64-musl": "4.53.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-musl": "4.53.3",
+        "@rollup/rollup-openharmony-arm64": "4.53.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
+        "@rollup/rollup-win32-x64-gnu": "4.53.3",
+        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safaridriver": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-0.1.2.tgz",
+      "integrity": "sha512-4R309+gWflJktzPXBQCobbWEHlzC4aK3a+Ov3tz2Ib2aBxiwd11phkdIBH1l0EO22x24CJMUQkpKFumRriCSRg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
+      "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^2.12.2"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shared": {
+      "resolved": "shared",
+      "link": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spacetrim": {
+      "version": "0.11.59",
+      "resolved": "https://registry.npmjs.org/spacetrim/-/spacetrim-0.11.59.tgz",
+      "integrity": "sha512-lLYsktklSRKprreOm7NXReW8YiX2VBjbgmXYEziOoGf/qsJqAEACaDvoTtUOycwjpaSh+bT8eu0KrJn7UNxiCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/hejny/spacetrim/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "Apache-2.0"
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tar-fs": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
+      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/use-resize-observer": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
+      "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
+      "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "16.8.0 - 18",
+        "react-dom": "16.8.0 - 18"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/userhome": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.1.tgz",
+      "integrity": "sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.14.tgz",
+      "integrity": "sha512-d9B2J9Cm9dN9+6nxMnnNJKJCtcyKfnHj15N6YNJfaFHRLua/d3sRKU9RuKmO9mB0XdFtUizlxfz/VPbd3OxGhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.14",
+        "@vitest/mocker": "4.0.14",
+        "@vitest/pretty-format": "4.0.14",
+        "@vitest/runner": "4.0.14",
+        "@vitest/snapshot": "4.0.14",
+        "@vitest/spy": "4.0.14",
+        "@vitest/utils": "4.0.14",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.14",
+        "@vitest/browser-preview": "4.0.14",
+        "@vitest/browser-webdriverio": "4.0.14",
+        "@vitest/ui": "4.0.14",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.14.tgz",
+      "integrity": "sha512-RzS5NujlCzeRPF1MK7MXLiEFpkIXeMdQ+rN3Kk3tDI9j0mtbr7Nmuq67tpkOJQpgyClbOltCXMjLZicJHsH5Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.14",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.14.tgz",
+      "integrity": "sha512-SOYPgujB6TITcJxgd3wmsLl+wZv+fy3av2PpiPpsWPZ6J1ySUYfScfpIt2Yv56ShJXR2MOA6q2KjKHN4EpdyRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/snapshot": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.14.tgz",
+      "integrity": "sha512-aQVBfT1PMzDSA16Y3Fp45a0q8nKexx6N5Amw3MX55BeTeZpoC08fGqEZqVmPcqN0ueZsuUQ9rriPMhZ3Mu19Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.14",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/vitest/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wait-port": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
+      "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "wait-port": "bin/wait-port.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webdriver": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.46.0.tgz",
+      "integrity": "sha512-ucb+ow6QHTBBDAdpV1AAKPY+un2cv23QU/rsSJBmuDZi8lZc5NluWz16qVVbdD1+Hn45PXfpxQcBaAkavStORA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0",
+        "@types/ws": "^8.5.3",
+        "@wdio/config": "8.46.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/protocols": "8.44.0",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.46.0",
+        "deepmerge-ts": "^5.1.0",
+        "got": "^12.6.1",
+        "ky": "^0.33.0",
+        "ws": "^8.8.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      }
+    },
+    "node_modules/webdriver/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/webdriverio": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-8.46.0.tgz",
+      "integrity": "sha512-SyrSVpygEdPzvgpapVZRQCy8XIOecadp56bPQewpfSfo9ypB6wdOUkx13NBu2ANDlUAtJX7KaLJpTtywVHNlVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.2.0",
+        "@wdio/config": "8.46.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/protocols": "8.44.0",
+        "@wdio/repl": "8.40.3",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.46.0",
+        "archiver": "^7.0.0",
+        "aria-query": "^5.0.0",
+        "css-shorthand-properties": "^1.1.1",
+        "css-value": "^0.0.1",
+        "devtools-protocol": "^0.0.1400418",
+        "grapheme-splitter": "^1.0.2",
+        "import-meta-resolve": "^4.0.0",
+        "is-plain-obj": "^4.1.0",
+        "jszip": "^3.10.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.zip": "^4.2.0",
+        "minimatch": "^9.0.0",
+        "puppeteer-core": "^21.11.0",
+        "query-selector-shadow-dom": "^1.0.0",
+        "resq": "^1.9.1",
+        "rgb2hex": "0.2.5",
+        "serialize-error": "^11.0.1",
+        "webdriver": "8.46.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
+      },
+      "peerDependencies": {
+        "devtools": "^8.14.0"
+      },
+      "peerDependenciesMeta": {
+        "devtools": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webdriverio/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yauzl/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "shared": {
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,44 +1,49 @@
 {
-  "name": "re-prod",
-  "version": "0.1.0",
-  "packageManager": "pnpm@9.12.1",
-  "private": true,
-  "description": "AI-Powered R Analysis IDE",
-  "workspaces": [
-    "client",
-    "desktop/e2e",
-    "shared"
-  ],
-  "scripts": {
-    "prepare": "husky",
-    "dev": "concurrently \"RUST_LOG=info cargo run -p reprod-server\" \"pnpm --filter client dev\"",
-    "dev:client": "pnpm --filter client dev",
-    "build": "pnpm -r build",
-    "build:client": "pnpm --filter client build",
-    "lint": "pnpm -r --if-present lint"
-  },
-  "devDependencies": {
-    "@tauri-apps/cli": "^2.9.1",
-    "concurrently": "^8.2.2",
-    "husky": "^9.1.7",
-    "typescript": "^5.3.3"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@shared/*": [
-        "shared/src/*"
-      ],
-      "@server/*": [
-        "server/src/*"
-      ]
-    },
-    "rootDirs": [
-      "server/src",
-      "shared/src"
-    ]
-  }
+	"name": "re-prod",
+	"version": "0.1.0",
+	"packageManager": "pnpm@9.12.1",
+	"private": true,
+	"description": "AI-Powered R Analysis IDE",
+	"workspaces": [
+		"client",
+		"desktop/e2e",
+		"shared"
+	],
+	"scripts": {
+		"prepare": "husky",
+		"dev": "concurrently \"RUST_LOG=info cargo run -p reprod-server\" \"pnpm --filter client dev\"",
+		"dev:client": "pnpm --filter client dev",
+		"build": "pnpm -r build",
+		"build:client": "pnpm --filter client build",
+		"lint": "pnpm -r --if-present lint",
+		"format": "biome format --write",
+		"format:check": "biome format",
+		"biome:check": "biome check",
+		"biome:fix": "biome check --write"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.7",
+		"@tauri-apps/cli": "^2.9.1",
+		"concurrently": "^8.2.2",
+		"husky": "^9.1.7",
+		"typescript": "^5.3.3"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"@shared/*": [
+				"shared/src/*"
+			],
+			"@server/*": [
+				"server/src/*"
+			]
+		},
+		"rootDirs": [
+			"server/src",
+			"shared/src"
+		]
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.3.7
+        version: 2.3.7
       '@tauri-apps/cli':
         specifier: ^2.9.1
         version: 2.9.3
@@ -224,6 +227,59 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.3.7':
+    resolution: {integrity: sha512-CTbAS/jNAiUc6rcq94BrTB8z83O9+BsgWj2sBCQg9rD6Wkh2gjfR87usjx0Ncx0zGXP1NKgT7JNglay5Zfs9jw==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.3.7':
+    resolution: {integrity: sha512-LirkamEwzIUULhXcf2D5b+NatXKeqhOwilM+5eRkbrnr6daKz9rsBL0kNZ16Hcy4b8RFq22SG4tcLwM+yx/wFA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.3.7':
+    resolution: {integrity: sha512-Q4TO633kvrMQkKIV7wmf8HXwF0dhdTD9S458LGE24TYgBjSRbuhvio4D5eOQzirEYg6eqxfs53ga/rbdd8nBKg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.3.7':
+    resolution: {integrity: sha512-/afy8lto4CB8scWfMdt+NoCZtatBUF62Tk3ilWH2w8ENd5spLhM77zKlFZEvsKJv9AFNHknMl03zO67CiklL2Q==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.3.7':
+    resolution: {integrity: sha512-inHOTdlstUBzgjDcx0ge71U4SVTbwAljmkfi3MC5WzsYCRhancqfeL+sa4Ke6v2ND53WIwCFD5hGsYExoI3EZQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.3.7':
+    resolution: {integrity: sha512-CQUtgH1tIN6e5wiYSJqzSwJumHYolNtaj1dwZGCnZXm2PZU1jOJof9TsyiP3bXNDb+VOR7oo7ZvY01If0W3iFQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.3.7':
+    resolution: {integrity: sha512-fJMc3ZEuo/NaMYo5rvoWjdSS5/uVSW+HPRQujucpZqm2ZCq71b8MKJ9U4th9yrv2L5+5NjPF0nqqILCl8HY/fg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.3.7':
+    resolution: {integrity: sha512-aJAE8eCNyRpcfx2JJAtsPtISnELJ0H4xVVSwnxm13bzI8RwbXMyVtxy2r5DV1xT3WiSP+7LxORcApWw0LM8HiA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.3.7':
+    resolution: {integrity: sha512-pulzUshqv9Ed//MiE8MOUeeEkbkSHVDVY5Cz5wVAnH1DUqliCQG3j6s1POaITTFqFfo7AVIx2sWdKpx/GS+Nqw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -3234,7 +3290,7 @@ snapshots:
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3318,7 +3374,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3326,6 +3382,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@biomejs/biome@2.3.7':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.3.7
+      '@biomejs/cli-darwin-x64': 2.3.7
+      '@biomejs/cli-linux-arm64': 2.3.7
+      '@biomejs/cli-linux-arm64-musl': 2.3.7
+      '@biomejs/cli-linux-x64': 2.3.7
+      '@biomejs/cli-linux-x64-musl': 2.3.7
+      '@biomejs/cli-win32-arm64': 2.3.7
+      '@biomejs/cli-win32-x64': 2.3.7
+
+  '@biomejs/cli-darwin-arm64@2.3.7':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.3.7':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.3.7':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.3.7':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.3.7':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.3.7':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.3.7':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.3.7':
+    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -4472,10 +4563,6 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -4995,7 +5082,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5007,7 +5094,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6088,7 +6175,7 @@ snapshots:
       '@vitest/snapshot': 4.0.7
       '@vitest/spy': 4.0.7
       '@vitest/utils': 4.0.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       expect-type: 1.2.2
       magic-string: 0.30.21

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "shared",
-  "version": "0.1.0",
-  "private": true,
-  "description": "Shared types and utilities for Re-prod",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc",
-    "type-check": "tsc --noEmit"
-  },
-  "devDependencies": {
-    "typescript": "^5.3.3"
-  }
+	"name": "shared",
+	"version": "0.1.0",
+	"private": true,
+	"description": "Shared types and utilities for Re-prod",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "tsc",
+		"type-check": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"typescript": "^5.3.3"
+	}
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,6 +1,6 @@
-export * from './types';
-export * from './tools';
-export * from './timeline';
-export * from './ws';
 // Export protocol types under a namespace to avoid name collisions with UI types
-export * as protocol from './protocol-types';
+export * as protocol from "./protocol-types";
+export * from "./timeline";
+export * from "./tools";
+export * from "./types";
+export * from "./ws";

--- a/shared/src/protocol-types.ts
+++ b/shared/src/protocol-types.ts
@@ -3,94 +3,94 @@
 // When updating, verify with `cargo check --workspace` and `pnpm -r lint`.
 
 // Execution metadata shared between frontend and backend (protocol layer)
-export type ExecutionSource = 'selection' | 'cell' | 'whole_document' | 'unknown';
-export type ExecutionActor = 'user' | 'ai';
-export type CodeBlockKind = 'section' | 'chunk' | 'document' | 'selection';
+export type ExecutionSource = "selection" | "cell" | "whole_document" | "unknown";
+export type ExecutionActor = "user" | "ai";
+export type CodeBlockKind = "section" | "chunk" | "document" | "selection";
 
 export interface CodeBlockMetadata {
-  id: string;
-  index: number;
-  kind: CodeBlockKind;
-  label?: string | null;
-  start_line: number;
-  end_line: number;
-  code: string;
+	id: string;
+	index: number;
+	kind: CodeBlockKind;
+	label?: string | null;
+	start_line: number;
+	end_line: number;
+	code: string;
 }
 
 export interface ExecutionContext {
-  source: ExecutionSource;
-  document_path?: string | null;
-  cell_index?: number | null;
-  triggered_at_ms: number; // epoch ms (0 if unknown)
-  actor: ExecutionActor;
+	source: ExecutionSource;
+	document_path?: string | null;
+	cell_index?: number | null;
+	triggered_at_ms: number; // epoch ms (0 if unknown)
+	actor: ExecutionActor;
 }
 
 export interface ExecutionRequest {
-  code: string;
-  context: ExecutionContext;
-  blocks: CodeBlockMetadata[];
+	code: string;
+	context: ExecutionContext;
+	blocks: CodeBlockMetadata[];
 }
 
 export interface EnvironmentSnapshot {
-  r_path: string;
-  working_dir: string;
-  temp_dir: string;
+	r_path: string;
+	working_dir: string;
+	temp_dir: string;
 }
 
 export interface PlotInfo {
-  filename: string;
-  base64_data: string;
-  index: number;
+	filename: string;
+	base64_data: string;
+	index: number;
 }
 
 export interface ExecutionResult {
-  success: boolean;
-  output: string;
-  error?: string | null;
-  plots: PlotInfo[];
-  execution_time_ms: number;
+	success: boolean;
+	output: string;
+	error?: string | null;
+	plots: PlotInfo[];
+	execution_time_ms: number;
 }
 
 export interface ExecutionEvent {
-  event_id: string;
-  context: ExecutionContext;
-  blocks: CodeBlockMetadata[];
-  result: ExecutionResult;
-  environment: EnvironmentSnapshot;
-  created_at_ms: number;
+	event_id: string;
+	context: ExecutionContext;
+	blocks: CodeBlockMetadata[];
+	result: ExecutionResult;
+	environment: EnvironmentSnapshot;
+	created_at_ms: number;
 }
 
 export interface ChatMessage {
-  role: string;
-  content: string;
+	role: string;
+	content: string;
 }
 
 export interface FileChangeEvent {
-  event_type: string;
-  path: string;
+	event_type: string;
+	path: string;
 }
 
 export interface ToolExecutionRequest {
-  tool_id: string;
-  capability_id: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  parameters: Record<string, any>;
+	tool_id: string;
+	capability_id: string;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	parameters: Record<string, any>;
 }
 
 export interface ArtifactInfo {
-  path: string;
-  artifact_type: string;
-  label?: string | null;
-  record_as: string;
+	path: string;
+	artifact_type: string;
+	label?: string | null;
+	record_as: string;
 }
 
 export interface ToolExecutionResult {
-  tool_id: string;
-  capability_id: string;
-  success: boolean;
-  stdout?: string | null;
-  stderr?: string | null;
-  artifacts: ArtifactInfo[];
-  execution_time_ms: number;
-  error?: string | null;
+	tool_id: string;
+	capability_id: string;
+	success: boolean;
+	stdout?: string | null;
+	stderr?: string | null;
+	artifacts: ArtifactInfo[];
+	execution_time_ms: number;
+	error?: string | null;
 }

--- a/shared/src/timeline.ts
+++ b/shared/src/timeline.ts
@@ -4,133 +4,133 @@
  */
 
 // Import for use in interfaces
-import type { ExecutionEventPayload } from './types';
+import type { ExecutionEventPayload } from "./types";
 
 // Re-export existing execution types for convenience
 export type {
-  ExecutionEventPayload,
-  ExecutionContextPayload,
-  ExecutionSource,
-  ExecutionActor,
-  CodeBlockMetadataPayload,
-  CodeBlockKind,
-  ExecutionResultPayload,
-  PlotInfoPayload,
-  EnvironmentSnapshotPayload,
-} from './types';
+	CodeBlockKind,
+	CodeBlockMetadataPayload,
+	EnvironmentSnapshotPayload,
+	ExecutionActor,
+	ExecutionContextPayload,
+	ExecutionEventPayload,
+	ExecutionResultPayload,
+	ExecutionSource,
+	PlotInfoPayload,
+} from "./types";
 
 /**
  * Query parameters for fetching timeline events.
  * Used by UI to request filtered/sorted/paginated events from backend.
  */
 export interface TimelineQuery {
-  filters?: {
-    /** Filter by actor (user or AI) */
-    actor?: 'user' | 'ai';
+	filters?: {
+		/** Filter by actor (user or AI) */
+		actor?: "user" | "ai";
 
-    /** Filter by execution source */
-    source?: 'selection' | 'cell' | 'whole_document';
+		/** Filter by execution source */
+		source?: "selection" | "cell" | "whole_document";
 
-    /** Filter by time range (epoch milliseconds) */
-    startTime?: number;
-    endTime?: number;
+		/** Filter by time range (epoch milliseconds) */
+		startTime?: number;
+		endTime?: number;
 
-    /** Only events with plots */
-    hasPlots?: boolean;
+		/** Only events with plots */
+		hasPlots?: boolean;
 
-    /** Only events with errors */
-    hasErrors?: boolean;
+		/** Only events with errors */
+		hasErrors?: boolean;
 
-    /** Text search in code blocks */
-    codeContains?: string;
-  };
+		/** Text search in code blocks */
+		codeContains?: string;
+	};
 
-  /** Sort order (default: desc, newest first) */
-  sort?: 'asc' | 'desc';
+	/** Sort order (default: desc, newest first) */
+	sort?: "asc" | "desc";
 
-  /** Pagination limit (default: 50, max: 200) */
-  limit?: number;
+	/** Pagination limit (default: 50, max: 200) */
+	limit?: number;
 
-  /** Pagination offset (default: 0) */
-  offset?: number;
+	/** Pagination offset (default: 0) */
+	offset?: number;
 }
 
 /**
  * Response containing timeline events with pagination metadata.
  */
 export interface TimelineResponse {
-  /** Array of execution events matching the query */
-  events: ExecutionEventPayload[];
+	/** Array of execution events matching the query */
+	events: ExecutionEventPayload[];
 
-  /** Total number of events matching filters (ignoring pagination) */
-  total: number;
+	/** Total number of events matching filters (ignoring pagination) */
+	total: number;
 
-  /** Whether more events exist beyond current page */
-  hasMore: boolean;
+	/** Whether more events exist beyond current page */
+	hasMore: boolean;
 
-  /** Query that produced this response (for debugging) */
-  query: TimelineQuery;
+	/** Query that produced this response (for debugging) */
+	query: TimelineQuery;
 }
 
 /**
  * Statistics about the timeline for UI summary display.
  */
 export interface TimelineStats {
-  totalEvents: number;
-  totalPlots: number;
-  totalErrors: number;
-  userActions: number;
-  aiActions: number;
-  sessionStartTime: number; // epoch ms
-  sessionEndTime: number; // epoch ms
-  sessionDuration: number; // milliseconds
+	totalEvents: number;
+	totalPlots: number;
+	totalErrors: number;
+	userActions: number;
+	aiActions: number;
+	sessionStartTime: number; // epoch ms
+	sessionEndTime: number; // epoch ms
+	sessionDuration: number; // milliseconds
 }
 
 /**
  * Client → Server: Request timeline events
  */
 export interface TimelineQueryMessage {
-  type: 'timeline_query';
-  query: TimelineQuery;
+	type: "timeline_query";
+	query: TimelineQuery;
 }
 
 /**
  * Server → Client: Timeline query response
  */
 export interface TimelineResponseMessage {
-  type: 'timeline_response';
-  data: TimelineResponse;
+	type: "timeline_response";
+	data: TimelineResponse;
 }
 
 /**
  * Server → Client: New event added to timeline (real-time push)
  */
 export interface TimelineEventAddedMessage {
-  type: 'timeline_event_added';
-  event: ExecutionEventPayload;
+	type: "timeline_event_added";
+	event: ExecutionEventPayload;
 }
 
 /**
  * Client → Server: Request timeline statistics
  */
 export interface TimelineStatsQueryMessage {
-  type: 'timeline_stats_query';
+	type: "timeline_stats_query";
 }
 
 /**
  * Server → Client: Timeline statistics response
  */
 export interface TimelineStatsResponseMessage {
-  type: 'timeline_stats_response';
-  stats: TimelineStats;
+	type: "timeline_stats_response";
+	stats: TimelineStats;
 }
 
 /**
  * Union type of all timeline-related WebSocket messages
  */
 export type TimelineMessage =
-  | TimelineQueryMessage
-  | TimelineResponseMessage
-  | TimelineEventAddedMessage
-  | TimelineStatsQueryMessage
-  | TimelineStatsResponseMessage;
+	| TimelineQueryMessage
+	| TimelineResponseMessage
+	| TimelineEventAddedMessage
+	| TimelineStatsQueryMessage
+	| TimelineStatsResponseMessage;

--- a/shared/src/tools.ts
+++ b/shared/src/tools.ts
@@ -1,83 +1,83 @@
-export type ToolKind = 'r-package' | 'cli';
-export type CapabilityKind = 'r-function' | 'r-snippet' | 'cli-command';
+export type ToolKind = "r-package" | "cli";
+export type CapabilityKind = "r-function" | "r-snippet" | "cli-command";
 
 export interface ToolManifest {
-  id: string;
-  displayName: string;
-  kind: ToolKind;
-  description: string;
-  version?: string;
-  homepage?: string;
-  tags: string[];
-  runtime: RuntimeConfig;
-  validation: ValidationConfig;
-  capabilities: CapabilityDescriptor[];
+	id: string;
+	displayName: string;
+	kind: ToolKind;
+	description: string;
+	version?: string;
+	homepage?: string;
+	tags: string[];
+	runtime: RuntimeConfig;
+	validation: ValidationConfig;
+	capabilities: CapabilityDescriptor[];
 }
 
 export interface RuntimeConfig {
-  rLibrary?: string;
-  imports: string[];
-  cliBinary?: string;
-  args: string[];
+	rLibrary?: string;
+	imports: string[];
+	cliBinary?: string;
+	args: string[];
 }
 
 export interface ValidationConfig {
-  requiresPackages: string[];
-  requiresCli: string[];
-  preflightR?: string;
-  preflightCli?: string;
+	requiresPackages: string[];
+	requiresCli: string[];
+	preflightR?: string;
+	preflightCli?: string;
 }
 
 export interface CapabilityDescriptor {
-  id: string;
-  displayName: string;
-  kind: CapabilityKind;
-  description: string;
-  entrypoint: string;
-  template?: string;
-  inputSpec: ParameterSpec[];
-  outputSpec: OutputSpec[];
-  postValidation?: string;
+	id: string;
+	displayName: string;
+	kind: CapabilityKind;
+	description: string;
+	entrypoint: string;
+	template?: string;
+	inputSpec: ParameterSpec[];
+	outputSpec: OutputSpec[];
+	postValidation?: string;
 }
 
-export type ParameterType = 'string' | 'integer' | 'float' | 'enum' | 'file';
-export type OutputType = 'stdout' | 'stderr' | 'file' | 'r-object';
-export type ArtifactRecord = 'artifact' | 'preview' | 'internal';
+export type ParameterType = "string" | "integer" | "float" | "enum" | "file";
+export type OutputType = "stdout" | "stderr" | "file" | "r-object";
+export type ArtifactRecord = "artifact" | "preview" | "internal";
 
 export interface ParameterSpec {
-  name: string;
-  type: ParameterType;
-  format?: string;
-  options?: string[];
-  default?: string | number | boolean | null;
-  min?: number;
-  max?: number;
-  role?: 'generated';
+	name: string;
+	type: ParameterType;
+	format?: string;
+	options?: string[];
+	default?: string | number | boolean | null;
+	min?: number;
+	max?: number;
+	role?: "generated";
 }
 
 export interface OutputSpec {
-  type: OutputType;
-  path?: string;
-  class?: string;
-  recordAs?: ArtifactRecord;
+	type: OutputType;
+	path?: string;
+	class?: string;
+	recordAs?: ArtifactRecord;
 }
 
 export interface ToolExecutionRequest {
-  toolId: string;
-  capabilityId: string;
-  parameters: Record<string, string>;
+	toolId: string;
+	capabilityId: string;
+	parameters: Record<string, string>;
 }
 
 export interface ArtifactSummary {
-  path: string;
-  type: 'file' | 'plot';
-  label?: string;
+	path: string;
+	type: "file" | "plot";
+	label?: string;
 }
 
 export interface ToolExecutionResult {
-  toolId: string;
-  capabilityId: string;
-  stdout?: string;
-  stderr?: string;
-  artifacts?: ArtifactSummary[];
+	toolId: string;
+	capabilityId: string;
+	stdout?: string;
+	stderr?: string;
+	artifacts?: ArtifactSummary[];
 }

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -1,20 +1,20 @@
 import type {
-  ExecutionSource as ProtocolExecutionSource,
-  ExecutionActor as ProtocolExecutionActor,
-  CodeBlockKind as ProtocolCodeBlockKind,
-  CodeBlockMetadata as ProtocolCodeBlockMetadata,
-  ExecutionContext as ProtocolExecutionContext,
-  ExecutionRequest as ProtocolExecutionRequest,
-  ExecutionEvent as ProtocolExecutionEvent,
-  ExecutionResult as ProtocolExecutionResult,
-  PlotInfo as ProtocolPlotInfo,
-  EnvironmentSnapshot as ProtocolEnvironmentSnapshot,
-  ChatMessage as ProtocolChatMessage,
-  FileChangeEvent as ProtocolFileChangeEvent,
-  ArtifactInfo as ProtocolArtifactInfo,
-  ToolExecutionRequest as ProtocolToolExecutionRequest,
-  ToolExecutionResult as ProtocolToolExecutionResult,
-} from './protocol-types';
+	ArtifactInfo as ProtocolArtifactInfo,
+	ChatMessage as ProtocolChatMessage,
+	CodeBlockKind as ProtocolCodeBlockKind,
+	CodeBlockMetadata as ProtocolCodeBlockMetadata,
+	EnvironmentSnapshot as ProtocolEnvironmentSnapshot,
+	ExecutionActor as ProtocolExecutionActor,
+	ExecutionContext as ProtocolExecutionContext,
+	ExecutionEvent as ProtocolExecutionEvent,
+	ExecutionRequest as ProtocolExecutionRequest,
+	ExecutionResult as ProtocolExecutionResult,
+	ExecutionSource as ProtocolExecutionSource,
+	FileChangeEvent as ProtocolFileChangeEvent,
+	PlotInfo as ProtocolPlotInfo,
+	ToolExecutionRequest as ProtocolToolExecutionRequest,
+	ToolExecutionResult as ProtocolToolExecutionResult,
+} from "./protocol-types";
 
 // Protocol aliases to keep existing payload naming conventions in the client.
 export type ExecutionSource = ProtocolExecutionSource;
@@ -34,177 +34,177 @@ export type ToolExecutionRequestPayload = ProtocolToolExecutionRequest;
 export type ToolExecutionResultPayload = ProtocolToolExecutionResult;
 // Project metadata shared between frontend and backend
 export interface ProjectRecord {
-  id: string;
-  name: string;
-  path: string;
-  created_at: number;
-  last_opened_at?: number | null;
-  git_remote?: string | null;
+	id: string;
+	name: string;
+	path: string;
+	created_at: number;
+	last_opened_at?: number | null;
+	git_remote?: string | null;
 }
 
-export type AIMode = 'agent' | 'chat';
+export type AIMode = "agent" | "chat";
 
 export interface FileEntryPayload {
-  path: string;
-  name: string;
-  is_dir: boolean;
-  size?: number;
-  children?: FileEntryPayload[] | null;
+	path: string;
+	name: string;
+	is_dir: boolean;
+	size?: number;
+	children?: FileEntryPayload[] | null;
 }
 
 export type FileSystemEventPayload =
-  | { type: 'created'; path: string }
-  | { type: 'deleted'; path: string }
-  | { type: 'modified'; path: string }
-  | { type: 'renamed'; from: string; to: string }
-  | { type: 'error'; message: string };
+	| { type: "created"; path: string }
+	| { type: "deleted"; path: string }
+	| { type: "modified"; path: string }
+	| { type: "renamed"; from: string; to: string }
+	| { type: "error"; message: string };
 
 export type FileSystemAction =
-  | 'list'
-  | 'read'
-  | 'write'
-  | 'delete'
-  | 'rename'
-  | 'create_dir'
-  | 'copy'
-  | 'root';
+	| "list"
+	| "read"
+	| "write"
+	| "delete"
+	| "rename"
+	| "create_dir"
+	| "copy"
+	| "root";
 
 // UI-facing execution log structures
 export interface ExecutionLogPlot {
-  id: string;
-  path: string;
-  data: string; // base64 encoded image
-  timestamp: number;
+	id: string;
+	path: string;
+	data: string; // base64 encoded image
+	timestamp: number;
 }
 
 export interface ExecutionLogEntry {
-  stdout: string;
-  stderr: string;
-  plots: ExecutionLogPlot[];
-  timestamp: number;
-  duration: number;
-  success: boolean;
+	stdout: string;
+	stderr: string;
+	plots: ExecutionLogPlot[];
+	timestamp: number;
+	duration: number;
+	success: boolean;
 }
 
 export type CodeChangeAction =
-  | 'replace-all'
-  | 'replace-range'
-  | 'insert'
-  | 'create-file'
-  | 'delete-range';
+	| "replace-all"
+	| "replace-range"
+	| "insert"
+	| "create-file"
+	| "delete-range";
 
 export interface PatchChunk {
-  context?: string;
-  oldLines: string[];
-  newLines: string[];
+	context?: string;
+	oldLines: string[];
+	newLines: string[];
 }
 
 export interface SimpleCodeChange {
-  beforeContext: string[];
-  afterContext: string[];
-  oldLines: string[];
-  newLines: string[];
+	beforeContext: string[];
+	afterContext: string[];
+	oldLines: string[];
+	newLines: string[];
 }
 
 export interface CodeRange {
-  startLine: number;
-  startColumn: number;
-  endLine: number;
-  endColumn: number;
+	startLine: number;
+	startColumn: number;
+	endLine: number;
+	endColumn: number;
 }
 
 export interface CodeBlock {
-  id: string;
-  code: string;
-  language: 'r';
-  action: CodeChangeAction;
-  targetRange?: CodeRange;
-  filepath?: string;
-  patchChunks?: PatchChunk[];
-  simpleChanges?: SimpleCodeChange[];
-  patchText?: string;
-  checksum?: string;
-  explanation?: string;
-  originalCode?: string;
+	id: string;
+	code: string;
+	language: "r";
+	action: CodeChangeAction;
+	targetRange?: CodeRange;
+	filepath?: string;
+	patchChunks?: PatchChunk[];
+	simpleChanges?: SimpleCodeChange[];
+	patchText?: string;
+	checksum?: string;
+	explanation?: string;
+	originalCode?: string;
 }
 
-export type PlanStepStatus = 'pending' | 'running' | 'done' | 'error';
+export type PlanStepStatus = "pending" | "running" | "done" | "error";
 
 export interface PlanStep {
-  id: string;
-  title: string;
-  status: PlanStepStatus;
+	id: string;
+	title: string;
+	status: PlanStepStatus;
 }
 
-export type ToolCallStatus = 'pending' | 'running' | 'done' | 'error';
+export type ToolCallStatus = "pending" | "running" | "done" | "error";
 
 export interface ToolCallLog {
-  id: string;
-  name: string;
-  status: ToolCallStatus;
-  input?: Record<string, unknown>;
-  output?: Record<string, unknown>;
-  error?: string;
-  startedAt?: number;
-  finishedAt?: number;
+	id: string;
+	name: string;
+	status: ToolCallStatus;
+	input?: Record<string, unknown>;
+	output?: Record<string, unknown>;
+	error?: string;
+	startedAt?: number;
+	finishedAt?: number;
 }
 
 export interface AIResponse {
-  message: string;
-  suggestedCode?: string; // Deprecated: use codeBlocks instead
-  codeBlocks?: CodeBlock[];
-  explanation?: string;
-  timestamp: number;
+	message: string;
+	suggestedCode?: string; // Deprecated: use codeBlocks instead
+	codeBlocks?: CodeBlock[];
+	explanation?: string;
+	timestamp: number;
 }
 
 // UI State Types
 export interface LayoutState {
-  editorWidth: number;
-  rightPanelWidth: number;
-  aiPanelHeight: number;
-  consoleHeight: number;
+	editorWidth: number;
+	rightPanelWidth: number;
+	aiPanelHeight: number;
+	consoleHeight: number;
 }
 
 export interface EditorState {
-  content: string;
-  filepath: string;
-  isDirty: boolean;
-  cursorPosition: { line: number; column: number };
+	content: string;
+	filepath: string;
+	isDirty: boolean;
+	cursorPosition: { line: number; column: number };
 }
 
 export interface ExecutionState {
-  isRunning: boolean;
-  currentCell?: number;
-  results: ExecutionLogEntry[];
-  history: ExecutionLogEntry[];
+	isRunning: boolean;
+	currentCell?: number;
+	results: ExecutionLogEntry[];
+	history: ExecutionLogEntry[];
 }
 
 export interface AIState {
-  messages: AIMessage[];
-  isLoading: boolean;
-  suggestions: string[];
+	messages: AIMessage[];
+	isLoading: boolean;
+	suggestions: string[];
 }
 
 export interface AIMessage {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  mode?: AIMode;
-  code?: string; // Deprecated: use codeBlocks instead
-  codeBlocks?: CodeBlock[];
-  planSteps?: PlanStep[];
-  toolLogs?: ToolCallLog[];
-  streamingId?: string;
-  isComplete?: boolean;
-  timestamp: number;
+	id: string;
+	role: "user" | "assistant";
+	content: string;
+	mode?: AIMode;
+	code?: string; // Deprecated: use codeBlocks instead
+	codeBlocks?: CodeBlock[];
+	planSteps?: PlanStep[];
+	toolLogs?: ToolCallLog[];
+	streamingId?: string;
+	isComplete?: boolean;
+	timestamp: number;
 }
 
 export interface AppSettings {
-  autoRun: boolean;
-  theme: 'light' | 'dark' | 'phylo';
-  rPath: string;
-  fontSize: number;
-  // Cell execution features (easy to disable)
-  showCellDecorations: boolean;
-  highlightExecutingCell: boolean;
+	autoRun: boolean;
+	theme: "light" | "dark" | "phylo";
+	rPath: string;
+	fontSize: number;
+	// Cell execution features (easy to disable)
+	showCellDecorations: boolean;
+	highlightExecutingCell: boolean;
 }

--- a/shared/src/ws.ts
+++ b/shared/src/ws.ts
@@ -1,123 +1,149 @@
-import type { ToolManifest } from './tools';
+import type { TimelineMessage, TimelineQuery, TimelineResponse, TimelineStats } from "./timeline";
+import type { ToolManifest } from "./tools";
 import type {
-  AIMode,
-  ChatMessagePayload,
-  CodeBlock,
-  ExecutionRequestPayload,
-  ExecutionResultPayload,
-  FileEntryPayload,
-  FileSystemAction,
-  FileSystemEventPayload,
-  PlanStep,
-  ProjectRecord,
-  ToolCallLog,
-  ToolExecutionRequestPayload,
-} from './types';
-import type { TimelineMessage, TimelineQuery, TimelineResponse, TimelineStats } from './timeline';
+	AIMode,
+	ChatMessagePayload,
+	CodeBlock,
+	ExecutionRequestPayload,
+	ExecutionResultPayload,
+	FileEntryPayload,
+	FileSystemAction,
+	FileSystemEventPayload,
+	PlanStep,
+	ProjectRecord,
+	ToolCallLog,
+	ToolExecutionRequestPayload,
+} from "./types";
 
 type ToolExecutionResponse = {
-  tool_id: string;
-  capability_id: string;
-  success: boolean;
-  stdout?: string | null;
-  stderr?: string | null;
-  execution_time_ms: number;
-  error?: string | null;
+	tool_id: string;
+	capability_id: string;
+	success: boolean;
+	stdout?: string | null;
+	stderr?: string | null;
+	execution_time_ms: number;
+	error?: string | null;
 };
 
-export type ExportMode = 'timeline' | 'document';
+export type ExportMode = "timeline" | "document";
 
 export interface ExportRMarkdownRequestPayload {
-  mode: ExportMode;
-  outputPath: string;
-  documentPath?: string;
-  includeTimestamps: boolean;
-  showActor: boolean;
-  embedPlots: boolean;
-  includeOutputs: boolean;
-  includeErrors: boolean;
-  includeSummary: boolean;
+	mode: ExportMode;
+	outputPath: string;
+	documentPath?: string;
+	includeTimestamps: boolean;
+	showActor: boolean;
+	embedPlots: boolean;
+	includeOutputs: boolean;
+	includeErrors: boolean;
+	includeSummary: boolean;
 }
 
 export interface ExportRMarkdownResponsePayload {
-  success: boolean;
-  outputPath: string;
-  error?: string | null;
+	success: boolean;
+	outputPath: string;
+	error?: string | null;
 }
 
 export type ClientMessage =
-  | { type: 'execute'; request: ExecutionRequestPayload }
-  | {
-      type: 'ai_message';
-      messages: ChatMessagePayload[];
-      enable_tools?: boolean;
-      request_id?: string;
-      stream?: boolean;
-      mode?: AIMode;
-    }
-  | { type: 'list_tools' }
-  | ({ type: 'execute_tool' } & ToolExecutionRequestPayload)
-  | { type: 'timeline_query'; query: TimelineQuery }
-  | { type: 'timeline_stats_query' }
-  | {
-      type: 'export_rmarkdown';
-      request: ExportRMarkdownRequestPayload;
-    }
-  | { type: 'interrupt_execution' }
-  | { type: 'restart_session' }
-  | {
-      type: 'fs_action';
-      action: FileSystemAction;
-      path: string;
-      content?: string;
-      to?: string;
-    }
-  | { type: 'project_list' }
-  | { type: 'project_open'; projectId: string }
-  | { type: 'project_create'; name: string; path: string }
-  | { type: 'project_add_existing'; path: string }
-  | { type: 'project_clone'; remote: string; path: string; name?: string }
-  | { type: 'project_state_load'; projectId: string }
-  | { type: 'project_state_save'; projectId: string; state: Record<string, unknown> };
+	| { type: "execute"; request: ExecutionRequestPayload }
+	| {
+			type: "ai_message";
+			messages: ChatMessagePayload[];
+			enable_tools?: boolean;
+			request_id?: string;
+			stream?: boolean;
+			mode?: AIMode;
+	  }
+	| { type: "list_tools" }
+	| ({ type: "execute_tool" } & ToolExecutionRequestPayload)
+	| { type: "timeline_query"; query: TimelineQuery }
+	| { type: "timeline_stats_query" }
+	| {
+			type: "export_rmarkdown";
+			request: ExportRMarkdownRequestPayload;
+	  }
+	| { type: "interrupt_execution" }
+	| { type: "restart_session" }
+	| {
+			type: "fs_action";
+			action: FileSystemAction;
+			path: string;
+			content?: string;
+			to?: string;
+	  }
+	| { type: "project_list" }
+	| { type: "project_open"; projectId: string }
+	| { type: "project_create"; name: string; path: string }
+	| { type: "project_add_existing"; path: string }
+	| { type: "project_clone"; remote: string; path: string; name?: string }
+	| { type: "project_state_load"; projectId: string }
+	| {
+			type: "project_state_save";
+			projectId: string;
+			state: Record<string, unknown>;
+	  };
 
-type TimelineEventPush = Extract<TimelineMessage, { type: 'timeline_event_added' }>;
+type TimelineEventPush = Extract<TimelineMessage, { type: "timeline_event_added" }>;
 
 export type ServerMessage =
-  | { type: 'execution_result'; result: ExecutionResultPayload }
-  | { type: 'ai_response'; response: string }
-  | { type: 'ai_response_with_tools'; response: { content: string; tool_calls?: Array<{ name: string; input: Record<string, any> }> } }
-  | { type: 'ai_response_chunk'; id: string; chunk: string }
-  | { type: 'ai_response_complete'; id: string; final: string; codeBlocks?: CodeBlock[] }
-  | { type: 'ai_plan_updated'; id: string; plan: PlanStep[] }
-  | { type: 'ai_tool_started'; id: string; tool: ToolCallLog }
-  | { type: 'ai_tool_finished'; id: string; tool: ToolCallLog }
-  | { type: 'error'; message: string }
-  | { type: 'tools'; tools: ToolManifest[] }
-  | ({ type: 'tool_execution_result' } & ToolExecutionResponse)
-  | { type: 'timeline_response'; data: TimelineResponse }
-  | { type: 'timeline_stats_response'; stats: TimelineStats }
-  | { type: 'export_rmarkdown_response'; response: ExportRMarkdownResponsePayload }
-  | { type: 'execution_interrupted'; success: boolean }
-  | { type: 'session_restarted'; cleared_events: number }
-  | { type: 'fs_event'; event: FileSystemEventPayload }
-  | {
-      type: 'fs_result';
-      action: FileSystemAction;
-      path: string;
-      to?: string;
-      success: boolean;
-      data?: FileEntryPayload[] | string | null;
-      error?: string | null;
-    }
-  | { type: 'project_list'; projects: ProjectRecord[] }
-  | { type: 'project_opened'; project: ProjectRecord; state?: Record<string, unknown> | null }
-  | { type: 'project_state'; project_id: string; state?: Record<string, unknown> | null }
-  | { type: 'project_state_saved'; project_id: string }
-  | TimelineEventPush;
+	| { type: "execution_result"; result: ExecutionResultPayload }
+	| { type: "ai_response"; response: string }
+	| {
+			type: "ai_response_with_tools";
+			response: {
+				content: string;
+				tool_calls?: Array<{ name: string; input: Record<string, any> }>;
+			};
+	  }
+	| { type: "ai_response_chunk"; id: string; chunk: string }
+	| {
+			type: "ai_response_complete";
+			id: string;
+			final: string;
+			codeBlocks?: CodeBlock[];
+	  }
+	| { type: "ai_plan_updated"; id: string; plan: PlanStep[] }
+	| { type: "ai_tool_started"; id: string; tool: ToolCallLog }
+	| { type: "ai_tool_finished"; id: string; tool: ToolCallLog }
+	| { type: "error"; message: string }
+	| { type: "tools"; tools: ToolManifest[] }
+	| ({ type: "tool_execution_result" } & ToolExecutionResponse)
+	| { type: "timeline_response"; data: TimelineResponse }
+	| { type: "timeline_stats_response"; stats: TimelineStats }
+	| {
+			type: "export_rmarkdown_response";
+			response: ExportRMarkdownResponsePayload;
+	  }
+	| { type: "execution_interrupted"; success: boolean }
+	| { type: "session_restarted"; cleared_events: number }
+	| { type: "fs_event"; event: FileSystemEventPayload }
+	| {
+			type: "fs_result";
+			action: FileSystemAction;
+			path: string;
+			to?: string;
+			success: boolean;
+			data?: FileEntryPayload[] | string | null;
+			error?: string | null;
+	  }
+	| { type: "project_list"; projects: ProjectRecord[] }
+	| {
+			type: "project_opened";
+			project: ProjectRecord;
+			state?: Record<string, unknown> | null;
+	  }
+	| {
+			type: "project_state";
+			project_id: string;
+			state?: Record<string, unknown> | null;
+	  }
+	| { type: "project_state_saved"; project_id: string }
+	| TimelineEventPush;
 
-export type ServerMessageType = ServerMessage['type'];
+export type ServerMessageType = ServerMessage["type"];
 
 export type ExtractServerMessage<TType extends ServerMessageType> = Extract<
-  ServerMessage,
-  { type: TType }
+	ServerMessage,
+	{ type: TType }
 >;

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "declaration": true,
-    "declarationMap": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"declaration": true,
+		"declarationMap": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,37 +1,33 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["client/src/*"],
-      "@/components/*": ["client/src/components/*"],
-      "@/core/*": ["client/src/core/*"],
-      "@/hooks/*": ["client/src/hooks/*"],
-      "@/utils/*": ["client/src/utils/*"],
-      "@/css/*": ["client/src/css/*"],
-      "@server/*": ["server/src/*"],
-      "@shared/*": ["shared/src/*"]
-    },
-    "rootDirs": [
-      "client/src",
-      "server/src",
-      "shared/src"
-    ]
-  },
-  "include": ["client/src", "server/src", "shared/src"],
-  "references": [{ "path": "client/tsconfig.node.json" }]
+	"compilerOptions": {
+		"target": "ES2020",
+		"useDefineForClassFields": true,
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"module": "ESNext",
+		"skipLibCheck": true,
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"jsx": "react-jsx",
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true,
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["client/src/*"],
+			"@/components/*": ["client/src/components/*"],
+			"@/core/*": ["client/src/core/*"],
+			"@/hooks/*": ["client/src/hooks/*"],
+			"@/utils/*": ["client/src/utils/*"],
+			"@/css/*": ["client/src/css/*"],
+			"@server/*": ["server/src/*"],
+			"@shared/*": ["shared/src/*"]
+		},
+		"rootDirs": ["client/src", "server/src", "shared/src"]
+	},
+	"include": ["client/src", "server/src", "shared/src"],
+	"references": [{ "path": "client/tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
Implements Biome as the auto-formatter for TypeScript/React code with automatic formatting via pre-commit hooks.

## Changes
- ✅ Installed `@biomejs/biome` v2.3.7 as dev dependency (using pnpm)
- ✅ Created `biome.json` configuration:
  - Tab indentation, 100 character line width
  - Double quotes, semicolons always
  - Automatic import organization
  - VCS integration enabled (respects .gitignore)
  - Lint rules with warnings for `any` and a11y issues
- ✅ Added pre-commit hook to auto-format staged files:
  - Runs `biome format --write` for TS/JS/JSON files
  - Runs `cargo fmt` for Rust files
  - Automatically re-stages formatted files
- ✅ Updated pre-push hook to verify formatting
- ✅ Added npm scripts:
  - `pnpm format` - Format all files
  - `pnpm format:check` - Check formatting without writing
  - `pnpm biome:check` - Run full Biome check (format + lint)
  - `pnpm biome:fix` - Fix all Biome issues
- ✅ Formatted entire codebase (193 files)

## Why Biome?
- **10x faster** than Prettier
- Written in Rust (aligns with backend)
- Formats + lints in one tool
- Drop-in Prettier replacement
- Zero config needed

## Testing
- ✅ Pre-commit hook successfully formats files before commit
- ✅ Pre-push hook verifies formatting is applied
- ✅ All TypeScript/JavaScript/JSON files properly formatted

## Notes
- Pre-commit hook now **only formats** (no type checking) for faster commits
- Type checking still runs in pre-push hook
- Formatting is automatic and transparent to developers
- Pre-existing TypeScript lint errors not addressed in this PR (separate issue)

Resolves #138