### PR TITLE
feature/issue 136 generate pdf from r markdown export

### DIFF
--- a/client/src/components/export/ExportDialog.tsx
+++ b/client/src/components/export/ExportDialog.tsx
@@ -13,6 +13,8 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
     setMode,
     options,
     setOption,
+    codeFolding,
+    setCodeFolding,
     pdfOptions,
     setPdfOption,
     documentPath,
@@ -238,6 +240,21 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
                 <label className="export-label" id="options-label">
                   Options
                 </label>
+                <div className="export-field">
+                  <label className="export-field-label" htmlFor="codeFolding">
+                    Code Folding
+                  </label>
+                  <select
+                    id="codeFolding"
+                    className="export-input"
+                    value={codeFolding}
+                    onChange={(e) => setCodeFolding(e.target.value as typeof codeFolding)}
+                    disabled={exporting}
+                  >
+                    <option value="show">Show code by default</option>
+                    <option value="hide">Hide code by default</option>
+                  </select>
+                </div>
                 <div
                   className="export-checkbox-group"
                   role="group"
@@ -319,7 +336,7 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
                   value={outputPath}
                   onChange={(e) => setOutputPath(e.target.value)}
                   disabled={exporting}
-                aria-required="true"
+                  aria-required="true"
                 aria-describedby="outputPath-hint"
               />
               <p id="outputPath-hint" className="export-hint">

--- a/client/src/components/export/ExportDialog.tsx
+++ b/client/src/components/export/ExportDialog.tsx
@@ -13,6 +13,8 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
     setMode,
     options,
     setOption,
+    pdfOptions,
+    setPdfOption,
     documentPath,
     setDocumentPath,
     outputPath,
@@ -89,6 +91,18 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
                 <input
                   type="radio"
                   name="format"
+                  value="pdf"
+                  checked={format === 'pdf'}
+                  onChange={(e) => setFormat(e.target.value as typeof format)}
+                  disabled={exporting}
+                  aria-label="PDF Document"
+                />
+                <span>PDF Document (.pdf)</span>
+              </label>
+              <label className="export-radio">
+                <input
+                  type="radio"
+                  name="format"
                   value="both"
                   checked={format === 'both'}
                   onChange={(e) => setFormat(e.target.value as typeof format)}
@@ -100,7 +114,7 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
             </div>
           </div>
 
-          {(format === 'rmarkdown' || format === 'both') && (
+          {format !== 'bundle' && (
             <>
               <div className="export-section">
                 <label className="export-label" id="mode-label">
@@ -167,6 +181,59 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
                 </div>
               )}
 
+              {format === 'pdf' && (
+                <>
+                  <div className="export-section">
+                    <p className="export-hint">
+                      PDF export requires LaTeX (TinyTeX recommended). If you hit compilation errors,
+                      install TinyTeX inside R with <code>tinytex::install_tinytex()</code>.
+                    </p>
+                  </div>
+
+                  <div className="export-section">
+                    <label className="export-label" id="pdf-options-label">
+                      PDF Options
+                    </label>
+                    <div
+                      className="export-checkbox-group"
+                      role="group"
+                      aria-labelledby="pdf-options-label"
+                    >
+                      <label className="export-checkbox">
+                        <input
+                          type="checkbox"
+                          checked={pdfOptions.toc}
+                          onChange={(e) => setPdfOption('toc', e.target.checked)}
+                          disabled={exporting}
+                          aria-label="Include table of contents"
+                        />
+                        <span>Include table of contents</span>
+                      </label>
+                      <label className="export-checkbox">
+                        <input
+                          type="checkbox"
+                          checked={pdfOptions.includeSource}
+                          onChange={(e) => setPdfOption('includeSource', e.target.checked)}
+                          disabled={exporting}
+                          aria-label="Include source code"
+                        />
+                        <span>Include source code</span>
+                      </label>
+                      <label className="export-checkbox">
+                        <input
+                          type="checkbox"
+                          checked={options.embedPlots}
+                          onChange={(e) => setOption('embedPlots', e.target.checked)}
+                          disabled={exporting}
+                          aria-label="Embed plot images inline"
+                        />
+                        <span>Embed plot images inline</span>
+                      </label>
+                    </div>
+                  </div>
+                </>
+              )}
+
               <div className="export-section">
                 <label className="export-label" id="options-label">
                   Options
@@ -196,16 +263,18 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
                     />
                     <span>Show actor (User/AI) for each chunk</span>
                   </label>
-                  <label className="export-checkbox">
-                    <input
-                      type="checkbox"
-                      checked={options.embedPlots}
-                      onChange={(e) => setOption('embedPlots', e.target.checked)}
-                      disabled={exporting}
-                      aria-label="Embed plot images inline"
-                    />
-                    <span>Embed plot images inline</span>
-                  </label>
+                  {format !== 'pdf' && (
+                    <label className="export-checkbox">
+                      <input
+                        type="checkbox"
+                        checked={options.embedPlots}
+                        onChange={(e) => setOption('embedPlots', e.target.checked)}
+                        disabled={exporting}
+                        aria-label="Embed plot images inline"
+                      />
+                      <span>Embed plot images inline</span>
+                    </label>
+                  )}
                   <label className="export-checkbox">
                     <input
                       type="checkbox"
@@ -250,15 +319,15 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
                   value={outputPath}
                   onChange={(e) => setOutputPath(e.target.value)}
                   disabled={exporting}
-                  aria-required="true"
-                  aria-describedby="outputPath-hint"
-                />
-                <p id="outputPath-hint" className="export-hint">
-                  File path where the RMarkdown will be saved
-                </p>
-              </div>
-            </>
-          )}
+                aria-required="true"
+                aria-describedby="outputPath-hint"
+              />
+              <p id="outputPath-hint" className="export-hint">
+                  File path where the {format === 'pdf' ? 'PDF file' : 'RMarkdown'} will be saved
+              </p>
+            </div>
+          </>
+        )}
 
           {error && (
             <div className="export-error" role="alert" aria-live="polite">

--- a/client/src/components/export/__tests__/ExportDialog.test.tsx
+++ b/client/src/components/export/__tests__/ExportDialog.test.tsx
@@ -36,12 +36,18 @@ describe('ExportDialog', () => {
       mode: 'timeline',
       format: 'rmarkdown',
       outputPath: 'analysis_report.Rmd',
+      codeFolding: 'show',
       includeTimestamps: true,
       showActor: true,
       embedPlots: true,
       includeOutputs: true,
       includeErrors: false,
       includeSummary: true,
+      outputTruncation: {
+        headLines: 20,
+        tailLines: 8,
+        maxLines: 200,
+      },
     });
     expect(sentRequest.request.pdfOptions).toBeUndefined();
     expect(sentRequest.request.documentPath).toBeUndefined();

--- a/client/src/components/export/__tests__/ExportDialog.test.tsx
+++ b/client/src/components/export/__tests__/ExportDialog.test.tsx
@@ -34,6 +34,7 @@ describe('ExportDialog', () => {
     expect(sentRequest.type).toBe('export_rmarkdown');
     expect(sentRequest.request).toMatchObject({
       mode: 'timeline',
+      format: 'rmarkdown',
       outputPath: 'analysis_report.Rmd',
       includeTimestamps: true,
       showActor: true,
@@ -42,6 +43,7 @@ describe('ExportDialog', () => {
       includeErrors: false,
       includeSummary: true,
     });
+    expect(sentRequest.request.pdfOptions).toBeUndefined();
     expect(sentRequest.request.documentPath).toBeUndefined();
   });
 
@@ -76,6 +78,44 @@ describe('ExportDialog', () => {
     expect(onClose).not.toHaveBeenCalled();
     const [sentRequest] = sendMock.mock.calls[0];
     expect(sentRequest.request.documentPath).toBe('/tmp/report.R');
+  });
+
+  it('sends PDF export requests with PDF options and updated output path', async () => {
+    const sendMock = vi.fn((request, handler) => {
+      handler({
+        type: 'export_rmarkdown_response',
+        response: { success: true, outputPath: 'analysis_report.pdf' },
+      });
+      return true;
+    });
+
+    vi.spyOn(socketService, 'send').mockImplementation(sendMock);
+    const onClose = vi.fn();
+
+    render(<ExportDialog open onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('radio', { name: /PDF Document/i }));
+    const outputPathInput = screen.getByLabelText('Output Path') as HTMLInputElement;
+    expect(outputPathInput.value).toBe('analysis_report.pdf');
+
+    const includeSourceCheckbox = screen.getByLabelText('Include source code');
+    fireEvent.click(includeSourceCheckbox); // disable source code
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+
+    const [sentRequest] = sendMock.mock.calls[0];
+    expect(sentRequest.request.format).toBe('pdf');
+    expect(sentRequest.request.outputPath).toBe('analysis_report.pdf');
+    expect(sentRequest.request.pdfOptions).toMatchObject({
+      toc: true,
+      includeSource: false,
+      highlightTheme: 'tango',
+      figWidth: 7,
+      figHeight: 5,
+    });
+    expect(sentRequest.request.embedPlots).toBe(true);
   });
 
   it('toggles includeTimestamps option correctly', async () => {

--- a/client/src/hooks/useExportDialog.ts
+++ b/client/src/hooks/useExportDialog.ts
@@ -13,7 +13,7 @@ import type {
   ExportPdfOptionKey,
   ExportPdfOptions,
 } from '@/types/exportDialog';
-import type { ExportRMarkdownRequestPayload } from 'shared';
+import type { ExportRMarkdownRequestPayload, CodeFolding } from 'shared';
 
 function reducer(state: ExportDialogState, action: ExportDialogAction): ExportDialogState {
   switch (action.type) {
@@ -35,6 +35,8 @@ function reducer(state: ExportDialogState, action: ExportDialogAction): ExportDi
         ...state,
         pdfOptions: { ...state.pdfOptions, [action.key]: action.value },
       };
+    case 'set-code-folding':
+      return { ...state, codeFolding: action.payload };
     case 'set-document-path':
       return { ...state, documentPath: action.payload };
     case 'set-output-path':
@@ -57,6 +59,8 @@ interface UseExportDialogReturn {
   setMode: (next: ExportRMarkdownRequestPayload['mode']) => void;
   options: ExportDialogOptions;
   setOption: (key: ExportOptionKey, value: boolean) => void;
+  codeFolding: CodeFolding;
+  setCodeFolding: (next: CodeFolding) => void;
   pdfOptions: ExportPdfOptions;
   setPdfOption: <TKey extends ExportPdfOptionKey>(key: TKey, value: ExportPdfOptions[TKey]) => void;
   documentPath: string;
@@ -75,7 +79,7 @@ interface UseExportDialogProps {
 
 export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExportDialogReturn {
   const [state, dispatch] = useReducer(reducer, exportDialogInitialState);
-  const { format, mode, options, pdfOptions, documentPath, outputPath, exporting, error } = state;
+  const { format, mode, options, codeFolding, pdfOptions, documentPath, outputPath, exporting, error } = state;
 
   useEffect(() => {
     if (!open) {
@@ -134,12 +138,18 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
       format: format === 'pdf' ? 'pdf' : 'rmarkdown',
       outputPath,
       documentPath: mode === 'document' ? trimmedDocumentPath : undefined,
+      codeFolding,
       includeTimestamps: options.includeTimestamps,
       showActor: options.showActor,
       embedPlots: options.embedPlots,
       includeOutputs: options.includeOutputs,
       includeErrors: options.includeErrors,
       includeSummary: options.includeSummary,
+      outputTruncation: {
+        headLines: 20,
+        tailLines: 8,
+        maxLines: 200,
+      },
       pdfOptions:
         format === 'pdf'
           ? {
@@ -174,6 +184,8 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
     setMode: (next) => dispatch({ type: 'set-mode', payload: next }),
     options,
     setOption,
+    codeFolding,
+    setCodeFolding: (next) => dispatch({ type: 'set-code-folding', payload: next }),
     pdfOptions,
     setPdfOption,
     documentPath,

--- a/client/src/hooks/useExportDialog.ts
+++ b/client/src/hooks/useExportDialog.ts
@@ -1,25 +1,39 @@
 import { useCallback, useEffect, useReducer } from 'react';
 import { exportRMarkdown, ExportServiceError } from '@/services/exportService';
+import {
+  adjustOutputPathForFormat,
+  exportDialogInitialState,
+} from '@/types/exportDialog';
 import type {
   ExportDialogAction,
   ExportDialogOptions,
   ExportFormat,
   ExportDialogState,
   ExportOptionKey,
+  ExportPdfOptionKey,
+  ExportPdfOptions,
 } from '@/types/exportDialog';
-import { exportDialogInitialState } from '@/types/exportDialog';
 import type { ExportRMarkdownRequestPayload } from 'shared';
 
 function reducer(state: ExportDialogState, action: ExportDialogAction): ExportDialogState {
   switch (action.type) {
     case 'set-format':
-      return { ...state, format: action.payload };
+      return {
+        ...state,
+        format: action.payload,
+        outputPath: adjustOutputPathForFormat(state.outputPath, action.payload),
+      };
     case 'set-mode':
       return { ...state, mode: action.payload };
     case 'set-option':
       return {
         ...state,
         options: { ...state.options, [action.key]: action.value },
+      };
+    case 'set-pdf-option':
+      return {
+        ...state,
+        pdfOptions: { ...state.pdfOptions, [action.key]: action.value },
       };
     case 'set-document-path':
       return { ...state, documentPath: action.payload };
@@ -43,6 +57,8 @@ interface UseExportDialogReturn {
   setMode: (next: ExportRMarkdownRequestPayload['mode']) => void;
   options: ExportDialogOptions;
   setOption: (key: ExportOptionKey, value: boolean) => void;
+  pdfOptions: ExportPdfOptions;
+  setPdfOption: <TKey extends ExportPdfOptionKey>(key: TKey, value: ExportPdfOptions[TKey]) => void;
   documentPath: string;
   setDocumentPath: (value: string) => void;
   outputPath: string;
@@ -59,7 +75,7 @@ interface UseExportDialogProps {
 
 export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExportDialogReturn {
   const [state, dispatch] = useReducer(reducer, exportDialogInitialState);
-  const { format, mode, options, documentPath, outputPath, exporting, error } = state;
+  const { format, mode, options, pdfOptions, documentPath, outputPath, exporting, error } = state;
 
   useEffect(() => {
     if (!open) {
@@ -88,6 +104,13 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
     dispatch({ type: 'set-option', key, value });
   }, []);
 
+  const setPdfOption = useCallback(
+    <TKey extends ExportPdfOptionKey>(key: TKey, value: ExportPdfOptions[TKey]) => {
+      dispatch({ type: 'set-pdf-option', key, value });
+    },
+    []
+  );
+
   const handleExport = useCallback(async (): Promise<void> => {
     dispatch({ type: 'set-exporting', payload: true });
     dispatch({ type: 'set-error', payload: '' });
@@ -108,6 +131,7 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
 
     const payload: ExportRMarkdownRequestPayload = {
       mode,
+      format: format === 'pdf' ? 'pdf' : 'rmarkdown',
       outputPath,
       documentPath: mode === 'document' ? trimmedDocumentPath : undefined,
       includeTimestamps: options.includeTimestamps,
@@ -116,6 +140,17 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
       includeOutputs: options.includeOutputs,
       includeErrors: options.includeErrors,
       includeSummary: options.includeSummary,
+      pdfOptions:
+        format === 'pdf'
+          ? {
+              toc: pdfOptions.toc,
+              includeSource: pdfOptions.includeSource,
+              highlightTheme: pdfOptions.highlightTheme,
+              figWidth: pdfOptions.figWidth,
+              figHeight: pdfOptions.figHeight,
+              latexPreamble: pdfOptions.latexPreamble || undefined,
+            }
+          : undefined,
     };
 
     try {
@@ -130,7 +165,7 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
     } finally {
       dispatch({ type: 'set-exporting', payload: false });
     }
-  }, [format, mode, options, documentPath, outputPath, onClose]);
+  }, [format, mode, options, pdfOptions, documentPath, outputPath, onClose]);
 
   return {
     format,
@@ -139,6 +174,8 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
     setMode: (next) => dispatch({ type: 'set-mode', payload: next }),
     options,
     setOption,
+    pdfOptions,
+    setPdfOption,
     documentPath,
     setDocumentPath: (value) => dispatch({ type: 'set-document-path', payload: value }),
     outputPath,

--- a/client/src/types/exportDialog.ts
+++ b/client/src/types/exportDialog.ts
@@ -1,4 +1,4 @@
-import type { ExportRMarkdownRequestPayload } from 'shared';
+import type { ExportRMarkdownRequestPayload, PdfExportOptions } from 'shared';
 
 export type ExportDialogOptions = Pick<
   ExportRMarkdownRequestPayload,
@@ -7,12 +7,24 @@ export type ExportDialogOptions = Pick<
 
 export type ExportOptionKey = keyof ExportDialogOptions;
 
-export type ExportFormat = 'bundle' | 'rmarkdown' | 'both';
+export type ExportPdfOptions = Required<
+  Pick<PdfExportOptions, 'toc' | 'includeSource'> & {
+    highlightTheme: string;
+    figWidth: number;
+    figHeight: number;
+    latexPreamble: string;
+  }
+>;
+
+export type ExportPdfOptionKey = keyof ExportPdfOptions;
+
+export type ExportFormat = 'bundle' | 'rmarkdown' | 'pdf' | 'both';
 
 export interface ExportDialogState {
   format: ExportFormat;
   mode: ExportRMarkdownRequestPayload['mode'];
   options: ExportDialogOptions;
+  pdfOptions: ExportPdfOptions;
   documentPath: string;
   outputPath: string;
   exporting: boolean;
@@ -23,6 +35,7 @@ export type ExportDialogAction =
   | { type: 'set-format'; payload: ExportFormat }
   | { type: 'set-mode'; payload: ExportRMarkdownRequestPayload['mode'] }
   | { type: 'set-option'; key: ExportOptionKey; value: boolean }
+  | { type: 'set-pdf-option'; key: ExportPdfOptionKey; value: ExportPdfOptions[ExportPdfOptionKey] }
   | { type: 'set-document-path'; payload: string }
   | { type: 'set-output-path'; payload: string }
   | { type: 'set-exporting'; payload: boolean }
@@ -38,10 +51,31 @@ export const exportDialogDefaultOptions: ExportDialogOptions = {
   includeSummary: true,
 };
 
+export const exportDialogDefaultPdfOptions: ExportPdfOptions = {
+  toc: true,
+  includeSource: true,
+  highlightTheme: 'tango',
+  figWidth: 7,
+  figHeight: 5,
+  latexPreamble: '',
+};
+
+export function adjustOutputPathForFormat(outputPath: string, format: ExportFormat): string {
+  const trimmed = outputPath.trim();
+  if (format === 'pdf' && trimmed.toLowerCase().endsWith('.rmd')) {
+    return trimmed.replace(/\.rmd$/i, '.pdf');
+  }
+  if ((format === 'rmarkdown' || format === 'both') && trimmed.toLowerCase().endsWith('.pdf')) {
+    return trimmed.replace(/\.pdf$/i, '.Rmd');
+  }
+  return trimmed;
+}
+
 export const exportDialogInitialState: ExportDialogState = {
   format: 'rmarkdown',
   mode: 'timeline',
   options: exportDialogDefaultOptions,
+  pdfOptions: exportDialogDefaultPdfOptions,
   documentPath: '',
   outputPath: 'analysis_report.Rmd',
   exporting: false,

--- a/client/src/types/exportDialog.ts
+++ b/client/src/types/exportDialog.ts
@@ -1,4 +1,4 @@
-import type { ExportRMarkdownRequestPayload, PdfExportOptions } from 'shared';
+import type { CodeFolding, ExportRMarkdownRequestPayload, PdfExportOptions } from 'shared';
 
 export type ExportDialogOptions = Pick<
   ExportRMarkdownRequestPayload,
@@ -24,6 +24,7 @@ export interface ExportDialogState {
   format: ExportFormat;
   mode: ExportRMarkdownRequestPayload['mode'];
   options: ExportDialogOptions;
+  codeFolding: CodeFolding;
   pdfOptions: ExportPdfOptions;
   documentPath: string;
   outputPath: string;
@@ -36,6 +37,7 @@ export type ExportDialogAction =
   | { type: 'set-mode'; payload: ExportRMarkdownRequestPayload['mode'] }
   | { type: 'set-option'; key: ExportOptionKey; value: boolean }
   | { type: 'set-pdf-option'; key: ExportPdfOptionKey; value: ExportPdfOptions[ExportPdfOptionKey] }
+  | { type: 'set-code-folding'; payload: CodeFolding }
   | { type: 'set-document-path'; payload: string }
   | { type: 'set-output-path'; payload: string }
   | { type: 'set-exporting'; payload: boolean }
@@ -75,6 +77,7 @@ export const exportDialogInitialState: ExportDialogState = {
   format: 'rmarkdown',
   mode: 'timeline',
   options: exportDialogDefaultOptions,
+  codeFolding: 'show',
   pdfOptions: exportDialogDefaultPdfOptions,
   documentPath: '',
   outputPath: 'analysis_report.Rmd',

--- a/core/src/api/timeline.rs
+++ b/core/src/api/timeline.rs
@@ -3,7 +3,7 @@ use crate::{
     executor::timeline::{
         SortOrder, TimelineFilters, TimelineQuery, TimelineResponse, TimelineStats,
     },
-    export::{ExportFormat, ExportMode, PdfRenderOptions, RMarkdownOptions},
+    export::{CodeFolding, ExportFormat, ExportMode, PdfRenderOptions, RMarkdownOptions},
     ExecutionActor, ExecutionEvent, ExecutionSource,
 };
 use serde::{Deserialize, Serialize};
@@ -892,6 +892,8 @@ pub struct ExportRMarkdownRequest {
     pub output_path: String,
     #[serde(rename = "documentPath")]
     pub document_path: Option<String>,
+    #[serde(rename = "codeFolding")]
+    pub code_folding: Option<String>,
     #[serde(rename = "includeTimestamps")]
     pub include_timestamps: bool,
     #[serde(rename = "showActor")]
@@ -904,6 +906,8 @@ pub struct ExportRMarkdownRequest {
     pub include_errors: bool,
     #[serde(rename = "includeSummary")]
     pub include_summary: bool,
+    #[serde(rename = "outputTruncation")]
+    pub output_truncation: Option<OutputTruncationPayload>,
     #[serde(rename = "pdfOptions")]
     pub pdf_options: Option<PdfOptionsPayload>,
 }
@@ -954,15 +958,32 @@ impl ExportRMarkdownRequest {
             .map(|options: &PdfRenderOptions| options.include_source)
             .unwrap_or(true);
 
+        let code_folding = match self.code_folding.as_deref() {
+            Some("hide") => CodeFolding::Hide,
+            Some("show") | None => CodeFolding::Show,
+            Some(other) => {
+                return Err(ReprodError::ProtocolError(format!(
+                    "Invalid code folding option: {}",
+                    other
+                )))
+            }
+        };
+
+        let truncation = self.output_truncation.unwrap_or_default();
+
         let options = RMarkdownOptions {
             mode,
             show_code,
+            code_folding,
             include_timestamps: self.include_timestamps,
             show_actor: self.show_actor,
             embed_plots: self.embed_plots,
             include_outputs: self.include_outputs,
             include_errors: self.include_errors,
             include_summary: self.include_summary,
+            output_head_lines: truncation.head_lines,
+            output_tail_lines: truncation.tail_lines,
+            output_max_lines: truncation.max_lines,
         };
 
         Ok((mode, format, options, pdf_options, self.output_path))
@@ -1008,6 +1029,38 @@ impl From<PdfOptionsPayload> for PdfRenderOptions {
 
 const fn bool_true() -> bool {
     true
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OutputTruncationPayload {
+    #[serde(default = "default_head_lines")]
+    pub head_lines: usize,
+    #[serde(default = "default_tail_lines")]
+    pub tail_lines: usize,
+    #[serde(default = "default_max_lines")]
+    pub max_lines: usize,
+}
+
+impl Default for OutputTruncationPayload {
+    fn default() -> Self {
+        Self {
+            head_lines: default_head_lines(),
+            tail_lines: default_tail_lines(),
+            max_lines: default_max_lines(),
+        }
+    }
+}
+
+const fn default_head_lines() -> usize {
+    20
+}
+
+const fn default_tail_lines() -> usize {
+    8
+}
+
+const fn default_max_lines() -> usize {
+    200
 }
 
 const fn default_fig_width() -> f64 {

--- a/core/src/api/timeline.rs
+++ b/core/src/api/timeline.rs
@@ -3,7 +3,7 @@ use crate::{
     executor::timeline::{
         SortOrder, TimelineFilters, TimelineQuery, TimelineResponse, TimelineStats,
     },
-    export::{ExportMode, RMarkdownOptions},
+    export::{ExportFormat, ExportMode, PdfRenderOptions, RMarkdownOptions},
     ExecutionActor, ExecutionEvent, ExecutionSource,
 };
 use serde::{Deserialize, Serialize};
@@ -886,6 +886,8 @@ mod tests {
 #[derive(Debug, Deserialize)]
 pub struct ExportRMarkdownRequest {
     pub mode: String, // "timeline" or "document"
+    #[serde(default = "default_export_format")]
+    pub format: String, // "rmarkdown" or "pdf"
     #[serde(rename = "outputPath")]
     pub output_path: String,
     #[serde(rename = "documentPath")]
@@ -902,6 +904,8 @@ pub struct ExportRMarkdownRequest {
     pub include_errors: bool,
     #[serde(rename = "includeSummary")]
     pub include_summary: bool,
+    #[serde(rename = "pdfOptions")]
+    pub pdf_options: Option<PdfOptionsPayload>,
 }
 
 impl ExportRMarkdownRequest {
@@ -909,7 +913,18 @@ impl ExportRMarkdownRequest {
         &self.mode
     }
 
-    pub fn into_options(self) -> Result<(ExportMode, RMarkdownOptions, String), ReprodError> {
+    pub fn into_options(
+        self,
+    ) -> Result<
+        (
+            ExportMode,
+            ExportFormat,
+            RMarkdownOptions,
+            Option<PdfRenderOptions>,
+            String,
+        ),
+        ReprodError,
+    > {
         let mode = match self.mode.as_str() {
             "timeline" => ExportMode::Timeline,
             "document" => ExportMode::Document,
@@ -921,8 +936,27 @@ impl ExportRMarkdownRequest {
             }
         };
 
+        let format = match self.format.as_str() {
+            "rmarkdown" => ExportFormat::RMarkdown,
+            "pdf" => ExportFormat::Pdf,
+            other => {
+                return Err(ReprodError::ProtocolError(format!(
+                    "Invalid export format: {}",
+                    other
+                )))
+            }
+        };
+
+        let pdf_options: Option<PdfRenderOptions> =
+            self.pdf_options.as_ref().map(|options| options.clone().into());
+        let show_code = pdf_options
+            .as_ref()
+            .map(|options: &PdfRenderOptions| options.include_source)
+            .unwrap_or(true);
+
         let options = RMarkdownOptions {
             mode,
+            show_code,
             include_timestamps: self.include_timestamps,
             show_actor: self.show_actor,
             embed_plots: self.embed_plots,
@@ -931,12 +965,61 @@ impl ExportRMarkdownRequest {
             include_summary: self.include_summary,
         };
 
-        Ok((mode, options, self.output_path))
+        Ok((mode, format, options, pdf_options, self.output_path))
     }
 
     pub fn document_path(&self) -> Option<String> {
         self.document_path.clone()
     }
+}
+
+fn default_export_format() -> String {
+    "rmarkdown".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PdfOptionsPayload {
+    #[serde(default = "bool_true")]
+    pub toc: bool,
+    #[serde(rename = "includeSource", default = "bool_true")]
+    pub include_source: bool,
+    #[serde(rename = "highlightTheme", default = "default_highlight_theme")]
+    pub highlight_theme: String,
+    #[serde(rename = "figWidth", default = "default_fig_width")]
+    pub fig_width: f64,
+    #[serde(rename = "figHeight", default = "default_fig_height")]
+    pub fig_height: f64,
+    #[serde(rename = "latexPreamble")]
+    pub latex_preamble: Option<String>,
+}
+
+impl From<PdfOptionsPayload> for PdfRenderOptions {
+    fn from(payload: PdfOptionsPayload) -> Self {
+        Self {
+            toc: payload.toc,
+            include_source: payload.include_source,
+            highlight_theme: payload.highlight_theme,
+            fig_width: payload.fig_width,
+            fig_height: payload.fig_height,
+            latex_preamble: payload.latex_preamble,
+        }
+    }
+}
+
+const fn bool_true() -> bool {
+    true
+}
+
+const fn default_fig_width() -> f64 {
+    7.0
+}
+
+const fn default_fig_height() -> f64 {
+    5.0
+}
+
+fn default_highlight_theme() -> String {
+    "tango".to_string()
 }
 
 /// Response from RMarkdown export operation.

--- a/core/src/api/timeline.rs
+++ b/core/src/api/timeline.rs
@@ -951,8 +951,10 @@ impl ExportRMarkdownRequest {
             }
         };
 
-        let pdf_options: Option<PdfRenderOptions> =
-            self.pdf_options.as_ref().map(|options| options.clone().into());
+        let pdf_options: Option<PdfRenderOptions> = self
+            .pdf_options
+            .as_ref()
+            .map(|options| options.clone().into());
         let show_code = pdf_options
             .as_ref()
             .map(|options: &PdfRenderOptions| options.include_source)

--- a/core/src/export/mod.rs
+++ b/core/src/export/mod.rs
@@ -36,6 +36,9 @@ pub mod writer;
 
 pub use bundle::{ReproductionBundle, TimelineExport, ValidationReport};
 pub use metadata::{BundleFiles, BundleMetadata, EnvironmentInfo, SessionInfo, Statistics};
-pub use rmarkdown::{ExportMode, RMarkdownGenerator, RMarkdownOptions};
+pub use rmarkdown::{
+    render_pdf_document, ExportFormat, ExportMode, PdfRenderOptions, RMarkdownGenerator,
+    RMarkdownOptions,
+};
 pub use scripts::{generate_readme, generate_replay_script, generate_validation_script};
 pub use writer::{BundleWriter, WriterError};

--- a/core/src/export/mod.rs
+++ b/core/src/export/mod.rs
@@ -37,8 +37,8 @@ pub mod writer;
 pub use bundle::{ReproductionBundle, TimelineExport, ValidationReport};
 pub use metadata::{BundleFiles, BundleMetadata, EnvironmentInfo, SessionInfo, Statistics};
 pub use rmarkdown::{
-    render_pdf_document, ExportFormat, ExportMode, PdfRenderOptions, RMarkdownGenerator,
-    RMarkdownOptions,
+    render_pdf_document, CodeFolding, ExportFormat, ExportMode, PdfRenderOptions,
+    RMarkdownGenerator, RMarkdownOptions,
 };
 pub use scripts::{generate_readme, generate_replay_script, generate_validation_script};
 pub use writer::{BundleWriter, WriterError};

--- a/core/src/export/rmarkdown.rs
+++ b/core/src/export/rmarkdown.rs
@@ -59,6 +59,20 @@ impl Default for ExportFormat {
     }
 }
 
+/// Code folding preference for HTML output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodeFolding {
+    Show,
+    Hide,
+}
+
+impl Default for CodeFolding {
+    fn default() -> Self {
+        Self::Show
+    }
+}
+
 /// Options specific to PDF rendering.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PdfRenderOptions {
@@ -89,12 +103,16 @@ impl Default for PdfRenderOptions {
 pub struct RMarkdownOptions {
     pub mode: ExportMode,
     pub show_code: bool,
+    pub code_folding: CodeFolding,
     pub include_timestamps: bool,
     pub show_actor: bool,
     pub embed_plots: bool,
     pub include_outputs: bool,
     pub include_errors: bool,
     pub include_summary: bool,
+    pub output_head_lines: usize,
+    pub output_tail_lines: usize,
+    pub output_max_lines: usize,
 }
 
 impl Default for RMarkdownOptions {
@@ -102,12 +120,16 @@ impl Default for RMarkdownOptions {
         Self {
             mode: ExportMode::Timeline,
             show_code: true,
+            code_folding: CodeFolding::Show,
             include_timestamps: true,
             show_actor: true,
             embed_plots: true,
             include_outputs: true,
             include_errors: false,
             include_summary: true,
+            output_head_lines: 20,
+            output_tail_lines: 8,
+            output_max_lines: 200,
         }
     }
 }
@@ -160,6 +182,11 @@ impl RMarkdownGenerator {
     }
 
     fn generate_yaml_header_timeline(&self, bundle: &ReproductionBundle) -> String {
+        let code_folding = match self.options.code_folding {
+            CodeFolding::Show => "show",
+            CodeFolding::Hide => "hide",
+        };
+
         format!(
             r#"---
 title: "Re-prod Analysis Report (Timeline Export)"
@@ -169,12 +196,22 @@ output:
   html_document:
     toc: true
     toc_depth: 2
-    code_folding: show
+    code_folding: {}
     theme: united
+header-includes:
+  - |
+    <style>
+      .rp-output {{ background: #f6f8fa; padding: 10px 12px; border-radius: 6px; }}
+      .rp-error {{ background: #fff2f0; padding: 10px 12px; border-left: 4px solid #d93025; border-radius: 6px; }}
+    </style>
+  - |
+    \usepackage{{xcolor}}
+    \newenvironment{{rpoutput}}{{\begin{{quote}}\colorbox{{gray!10}}{{\begin{{minipage}}{{0.97\linewidth}}}}}}{{\end{{minipage}}\end{{quote}}}}
+    \newenvironment{{rperror}}{{\begin{{quote}}\colorbox{{red!5}}{{\begin{{minipage}}{{0.97\linewidth}}}}}}{{\end{{minipage}}\end{{quote}}}}
 ---
 
 "#,
-            bundle.metadata.created_at
+            bundle.metadata.created_at, code_folding
         )
     }
 
@@ -250,23 +287,31 @@ output:
 
             // Output
             if self.options.include_outputs && !event.result.output.is_empty() {
-                section.push_str("**Output**:\n```\n");
-                section.push_str(&event.result.output);
-                if !event.result.output.ends_with('\n') {
+                let (trimmed, truncated) = self.trim_output(&event.result.output);
+                section.push_str("::: {.rp-output}\n```\n");
+                section.push_str(&trimmed);
+                if !trimmed.ends_with('\n') {
                     section.push('\n');
                 }
-                section.push_str("```\n\n");
+                if truncated {
+                    section.push_str("... (output truncated)\n");
+                }
+                section.push_str("```\n:::\n\n");
             }
 
             // Error
             if self.options.include_errors {
                 if let Some(error) = &event.result.error {
-                    section.push_str("**Error**:\n```\n");
-                    section.push_str(error);
-                    if !error.ends_with('\n') {
+                    let (trimmed, truncated) = self.trim_output(error);
+                    section.push_str("::: {.rp-error}\n```\n");
+                    section.push_str(&trimmed);
+                    if !trimmed.ends_with('\n') {
                         section.push('\n');
                     }
-                    section.push_str("```\n\n");
+                    if truncated {
+                        section.push_str("... (error truncated)\n");
+                    }
+                    section.push_str("```\n:::\n\n");
                 }
             }
         }
@@ -280,6 +325,39 @@ output:
 
         section.push_str("---\n\n");
         section
+    }
+
+    fn trim_output(&self, text: &str) -> (String, bool) {
+        let lines: Vec<&str> = text.lines().collect();
+        let total = lines.len();
+        if total <= self.options.output_max_lines {
+            return (text.to_string(), false);
+        }
+
+        let head = self.options.output_head_lines.min(total);
+        let tail = self
+            .options
+            .output_tail_lines
+            .min(total.saturating_sub(head));
+
+        if head + tail >= total {
+            return (text.to_string(), false);
+        }
+
+        let mut result = String::new();
+        for line in lines.iter().take(head) {
+            result.push_str(line);
+            result.push('\n');
+        }
+        let skipped = total.saturating_sub(head + tail);
+        result.push_str(&format!("... ({} lines truncated) ...\n", skipped));
+        if tail > 0 {
+            for line in lines.iter().skip(total - tail) {
+                result.push_str(line);
+                result.push('\n');
+            }
+        }
+        (result, true)
     }
 
     fn generate_summary(&self, bundle: &ReproductionBundle) -> String {
@@ -342,6 +420,11 @@ output:
     // ===== Document Mode Helpers =====
 
     fn generate_yaml_header_document(&self, document_path: &str) -> String {
+        let code_folding = match self.options.code_folding {
+            CodeFolding::Show => "show",
+            CodeFolding::Hide => "hide",
+        };
+
         let title = std::path::Path::new(document_path)
             .file_stem()
             .and_then(|s| s.to_str())
@@ -355,12 +438,23 @@ date: "{}"
 output:
   html_document:
     toc: true
-    code_folding: show
+    code_folding: {}
+header-includes:
+  - |
+    <style>
+      .rp-output {{ background: #f6f8fa; padding: 10px 12px; border-radius: 6px; }}
+      .rp-error {{ background: #fff2f0; padding: 10px 12px; border-left: 4px solid #d93025; border-radius: 6px; }}
+    </style>
+  - |
+    \usepackage{{xcolor}}
+    \newenvironment{{rpoutput}}{{\begin{{quote}}\colorbox{{gray!10}}{{\begin{{minipage}}{{0.97\linewidth}}}}}}{{\end{{minipage}}\end{{quote}}}}
+    \newenvironment{{rperror}}{{\begin{{quote}}\colorbox{{red!5}}{{\begin{{minipage}}{{0.97\linewidth}}}}}}{{\end{{minipage}}\end{{quote}}}}
 ---
 
 "#,
             title,
-            chrono::Utc::now().format("%Y-%m-%d")
+            chrono::Utc::now().format("%Y-%m-%d"),
+            code_folding
         )
     }
 
@@ -924,11 +1018,15 @@ ggplot(mtcars, aes(x = wt, y = mpg)) + geom_point()
         let options = RMarkdownOptions::default();
         assert_eq!(options.mode, ExportMode::Timeline);
         assert!(options.show_code);
+        assert_eq!(options.code_folding, CodeFolding::Show);
         assert!(options.include_timestamps);
         assert!(options.show_actor);
         assert!(options.embed_plots);
         assert!(options.include_outputs);
         assert!(!options.include_errors);
         assert!(options.include_summary);
+        assert_eq!(options.output_head_lines, 20);
+        assert_eq!(options.output_tail_lines, 8);
+        assert_eq!(options.output_max_lines, 200);
     }
 }

--- a/core/src/export/rmarkdown.rs
+++ b/core/src/export/rmarkdown.rs
@@ -932,7 +932,7 @@ mod tests {
         let bundle = ReproductionBundle::from_events(vec![event]);
         let rmd = generator.from_timeline(&bundle);
 
-        assert!(rmd.contains("**Error**:"));
+        assert!(rmd.contains("::: {.rp-error}"));
         assert!(rmd.contains("Error: object not found"));
     }
 

--- a/core/src/export/rmarkdown.rs
+++ b/core/src/export/rmarkdown.rs
@@ -29,6 +29,9 @@ use super::bundle::ReproductionBundle;
 use super::metadata::BundleMetadata;
 use crate::protocol::{ExecutionActor, ExecutionEvent};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
+use tempfile::tempdir;
+use tokio::{fs, process::Command};
 
 /// Export mode for RMarkdown generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -42,10 +45,50 @@ pub enum ExportMode {
     Document,
 }
 
+/// Output format for exports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportFormat {
+    RMarkdown,
+    Pdf,
+}
+
+impl Default for ExportFormat {
+    fn default() -> Self {
+        Self::RMarkdown
+    }
+}
+
+/// Options specific to PDF rendering.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PdfRenderOptions {
+    pub toc: bool,
+    pub include_source: bool,
+    pub highlight_theme: String,
+    pub fig_width: f64,
+    pub fig_height: f64,
+    #[serde(default)]
+    pub latex_preamble: Option<String>,
+}
+
+impl Default for PdfRenderOptions {
+    fn default() -> Self {
+        Self {
+            toc: true,
+            include_source: true,
+            highlight_theme: "tango".to_string(),
+            fig_width: 7.0,
+            fig_height: 5.0,
+            latex_preamble: None,
+        }
+    }
+}
+
 /// Options for RMarkdown export.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RMarkdownOptions {
     pub mode: ExportMode,
+    pub show_code: bool,
     pub include_timestamps: bool,
     pub show_actor: bool,
     pub embed_plots: bool,
@@ -58,6 +101,7 @@ impl Default for RMarkdownOptions {
     fn default() -> Self {
         Self {
             mode: ExportMode::Timeline,
+            show_code: true,
             include_timestamps: true,
             show_actor: true,
             embed_plots: true,
@@ -106,6 +150,14 @@ impl RMarkdownGenerator {
     }
 
     // ===== Timeline Mode Helpers =====
+
+    fn chunk_header(&self, chunk_id: &str) -> String {
+        if self.options.show_code {
+            format!("```{{r {}}}\n", chunk_id)
+        } else {
+            format!("```{{r {}, echo=FALSE}}\n", chunk_id)
+        }
+    }
 
     fn generate_yaml_header_timeline(&self, bundle: &ReproductionBundle) -> String {
         format!(
@@ -189,7 +241,7 @@ output:
         // Code chunks
         for (block_idx, block) in event.blocks.iter().enumerate() {
             let chunk_id = format!("event-{}-block-{}", index, block_idx);
-            section.push_str(&format!("```{{r {}}}\n", chunk_id));
+            section.push_str(&self.chunk_header(&chunk_id));
             section.push_str(&block.code);
             if !block.code.ends_with('\n') {
                 section.push('\n');
@@ -337,7 +389,7 @@ This document contains the R code from `{}`.
                 // Flush previous section if any
                 if !current_section.trim().is_empty() {
                     section_number += 1;
-                    content.push_str(&format!("```{{r chunk-{}}}\n", section_number));
+                    content.push_str(&self.chunk_header(&format!("chunk-{}", section_number)));
                     content.push_str(&current_section);
                     if !current_section.ends_with('\n') {
                         content.push('\n');
@@ -365,7 +417,7 @@ This document contains the R code from `{}`.
         // Flush final section
         if !current_section.trim().is_empty() {
             section_number += 1;
-            content.push_str(&format!("```{{r chunk-{}}}\n", section_number));
+            content.push_str(&self.chunk_header(&format!("chunk-{}", section_number)));
             content.push_str(&current_section);
             if !current_section.ends_with('\n') {
                 content.push('\n');
@@ -399,6 +451,188 @@ fn format_timestamp(ms: u64) -> String {
     .unwrap_or_else(chrono::Utc::now);
 
     datetime.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+}
+
+/// Render a PDF from RMarkdown content using R.
+pub async fn render_pdf_document(
+    r_path: &str,
+    working_dir: &Path,
+    rmd_content: &str,
+    output_path: &Path,
+    pdf_options: &PdfRenderOptions,
+) -> Result<(), String> {
+    let resolved_output = if output_path.is_relative() {
+        working_dir.join(output_path)
+    } else {
+        output_path.to_path_buf()
+    };
+    let output_dir = resolved_output
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| working_dir.to_path_buf());
+
+    if let Some(parent) = resolved_output.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Failed to create output directory {}: {}", parent.display(), e))?;
+    }
+
+    let temp_dir = tempdir().map_err(|e| format!("Failed to create temp directory: {}", e))?;
+    let rmd_path = temp_dir.path().join("export.Rmd");
+    let script_path = temp_dir.path().join("render.R");
+
+    fs::write(&rmd_path, rmd_content)
+        .await
+        .map_err(|e| format!("Failed to write temporary RMarkdown: {}", e))?;
+
+    let preamble_path = if let Some(preamble) = &pdf_options.latex_preamble {
+        let path = temp_dir.path().join("preamble.tex");
+        fs::write(&path, preamble)
+            .await
+            .map_err(|e| format!("Failed to write LaTeX preamble: {}", e))?;
+        Some(path)
+    } else {
+        None
+    };
+
+    let script = build_pdf_render_script(
+        &rmd_path,
+        &resolved_output,
+        working_dir,
+        &output_dir,
+        pdf_options,
+        preamble_path.as_ref().map(|p| p.as_path()),
+    );
+
+    fs::write(&script_path, script)
+        .await
+        .map_err(|e| format!("Failed to write render script: {}", e))?;
+
+    let output = Command::new(r_path)
+        .args(["--vanilla", "--quiet", script_path.to_string_lossy().as_ref()])
+        .current_dir(working_dir)
+        .output()
+        .await
+        .map_err(|e| format!("Failed to start Rscript for PDF export: {}", e))?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let combined = [stdout.trim(), stderr.trim()]
+            .iter()
+            .filter(|s| !s.is_empty())
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n");
+        let message = if combined.is_empty() {
+            "PDF export failed. Check R logs for details.".to_string()
+        } else {
+            combined
+        };
+        return Err(message);
+    }
+
+    Ok(())
+}
+
+fn build_pdf_render_script(
+    rmd_path: &Path,
+    output_path: &Path,
+    working_dir: &Path,
+    output_dir: &Path,
+    options: &PdfRenderOptions,
+    preamble_path: Option<&Path>,
+) -> String {
+    let include_source = if options.include_source { "TRUE" } else { "FALSE" };
+    let toc = if options.toc { "TRUE" } else { "FALSE" };
+    let includes = preamble_path.map_or_else(
+        || "rmarkdown::includes()".to_string(),
+        |path| {
+            format!(
+                "rmarkdown::includes(in_header = \"{}\")",
+                escape_r_string(&path.to_string_lossy())
+            )
+        },
+    );
+
+    let root_dir = escape_r_string(&working_dir.to_string_lossy());
+    let rmd_path = escape_r_string(&rmd_path.to_string_lossy());
+    let output_dir = escape_r_string(&output_dir.to_string_lossy());
+    let output_file = output_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(escape_r_string)
+        .unwrap_or_else(|| "analysis.pdf".to_string());
+    let highlight = escape_r_string(&options.highlight_theme);
+
+    format!(
+        r#"
+render_pdf <- function() {{
+  old_wd <- getwd()
+  on.exit(setwd(old_wd), add = TRUE)
+  setwd("{root_dir}")
+
+  if (!requireNamespace("rmarkdown", quietly = TRUE)) {{
+    stop("PDF export requires the 'rmarkdown' package. Install it with install.packages('rmarkdown').")
+  }}
+
+  has_latex <- nzchar(Sys.which("pdflatex"))
+  if (!has_latex && requireNamespace("tinytex", quietly = TRUE)) {{
+    has_latex <- tinytex::is_tinytex_installed() || tinytex::is_latex_installed()
+  }}
+
+  if (!has_latex) {{
+    stop("PDF export requires LaTeX. Install TinyTeX by running: tinytex::install_tinytex()")
+  }}
+
+  knitr::opts_knit$set(root.dir = "{root_dir}")
+  knitr::opts_chunk$set(
+    echo = {include_source},
+    fig.width = {fig_width},
+    fig.height = {fig_height}
+  )
+
+  output_format <- rmarkdown::pdf_document(
+    toc = {toc},
+    highlight = "{highlight}",
+    fig_width = {fig_width},
+    fig_height = {fig_height},
+    includes = {includes}
+  )
+
+  rmarkdown::render(
+    input = "{rmd_path}",
+    output_file = "{output_file}",
+    output_dir = "{output_dir}",
+    output_format = output_format,
+    quiet = TRUE,
+    envir = new.env(parent = globalenv())
+  )
+}}
+
+tryCatch(
+  render_pdf(),
+  error = function(e) {{
+    message(e$message)
+    quit(status = 1)
+  }}
+)
+"#,
+        root_dir = root_dir,
+        include_source = include_source,
+        fig_width = options.fig_width,
+        fig_height = options.fig_height,
+        toc = toc,
+        highlight = highlight,
+        includes = includes,
+        rmd_path = rmd_path,
+        output_file = output_file,
+        output_dir = output_dir
+    )
+}
+
+fn escape_r_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 #[cfg(test)]
@@ -689,6 +923,7 @@ ggplot(mtcars, aes(x = wt, y = mpg)) + geom_point()
     fn test_rmarkdown_options_default() {
         let options = RMarkdownOptions::default();
         assert_eq!(options.mode, ExportMode::Timeline);
+        assert!(options.show_code);
         assert!(options.include_timestamps);
         assert!(options.show_actor);
         assert!(options.embed_plots);

--- a/core/src/export/rmarkdown.rs
+++ b/core/src/export/rmarkdown.rs
@@ -566,9 +566,13 @@ pub async fn render_pdf_document(
         .unwrap_or_else(|| working_dir.to_path_buf());
 
     if let Some(parent) = resolved_output.parent() {
-        fs::create_dir_all(parent)
-            .await
-            .map_err(|e| format!("Failed to create output directory {}: {}", parent.display(), e))?;
+        fs::create_dir_all(parent).await.map_err(|e| {
+            format!(
+                "Failed to create output directory {}: {}",
+                parent.display(),
+                e
+            )
+        })?;
     }
 
     let temp_dir = tempdir().map_err(|e| format!("Failed to create temp directory: {}", e))?;
@@ -603,7 +607,11 @@ pub async fn render_pdf_document(
         .map_err(|e| format!("Failed to write render script: {}", e))?;
 
     let output = Command::new(r_path)
-        .args(["--vanilla", "--quiet", script_path.to_string_lossy().as_ref()])
+        .args([
+            "--vanilla",
+            "--quiet",
+            script_path.to_string_lossy().as_ref(),
+        ])
         .current_dir(working_dir)
         .output()
         .await
@@ -637,7 +645,11 @@ fn build_pdf_render_script(
     options: &PdfRenderOptions,
     preamble_path: Option<&Path>,
 ) -> String {
-    let include_source = if options.include_source { "TRUE" } else { "FALSE" };
+    let include_source = if options.include_source {
+        "TRUE"
+    } else {
+        "FALSE"
+    };
     let toc = if options.toc { "TRUE" } else { "FALSE" };
     let includes = preamble_path.map_or_else(
         || "rmarkdown::includes()".to_string(),

--- a/core/src/export/rmarkdown.rs
+++ b/core/src/export/rmarkdown.rs
@@ -898,7 +898,7 @@ mod tests {
         let bundle = ReproductionBundle::from_events(events);
         let rmd = generator.from_timeline(&bundle);
 
-        assert!(rmd.contains("**Output**:"));
+        assert!(rmd.contains("::: {.rp-output}"));
         assert!(rmd.contains("[1] 1 2 3 4 5"));
     }
 

--- a/core/tests/rmarkdown_integration_test.rs
+++ b/core/tests/rmarkdown_integration_test.rs
@@ -177,7 +177,7 @@ fn test_rmarkdown_timeline_export_integration() {
     assert!(rmd_content.contains("ggplot(data_clean, aes(x, y)) + geom_point()"));
 
     // Verify outputs
-    assert!(rmd_content.contains("**Output**:"));
+    assert!(rmd_content.contains("::: {.rp-output}"));
     assert!(rmd_content.contains("[1] Success"));
 
     // Verify plots

--- a/core/tests/rmarkdown_integration_test.rs
+++ b/core/tests/rmarkdown_integration_test.rs
@@ -354,7 +354,7 @@ fn test_rmarkdown_export_with_errors() {
     let generator = RMarkdownGenerator::new(options_with_errors.clone());
     let rmd_with_errors = generator.from_timeline(&bundle);
 
-    assert!(rmd_with_errors.contains("**Error**:"));
+    assert!(rmd_with_errors.contains("::: {.rp-error}"));
     assert!(rmd_with_errors.contains("Error: test error"));
 
     // Test with errors excluded
@@ -366,7 +366,7 @@ fn test_rmarkdown_export_with_errors() {
     let generator = RMarkdownGenerator::new(options_without_errors);
     let rmd_without_errors = generator.from_timeline(&bundle);
 
-    assert!(!rmd_without_errors.contains("**Error**:"));
+    assert!(!rmd_without_errors.contains("::: {.rp-error}"));
 
     println!("✓ RMarkdown error handling integration test passed!");
 }
@@ -421,7 +421,7 @@ fn test_rmarkdown_export_options_combinations() {
     assert!(minimal_rmd.contains("x <- rnorm(100)"));
     assert!(!minimal_rmd.contains("User"));
     assert!(!minimal_rmd.contains("AI Assistant"));
-    assert!(!minimal_rmd.contains("**Output**:"));
+    assert!(!minimal_rmd.contains("::: {.rp-output}"));
     assert!(!minimal_rmd.contains("![Plot]"));
     assert!(!minimal_rmd.contains("# Session Summary"));
 
@@ -447,7 +447,7 @@ fn test_rmarkdown_export_options_combinations() {
     assert!(full_rmd.contains("Event 1 - User"));
     assert!(full_rmd.contains("Event 2 - AI Assistant"));
     assert!(full_rmd.contains("**Executed**:"));
-    assert!(full_rmd.contains("**Output**:"));
+    assert!(full_rmd.contains("::: {.rp-output}"));
     assert!(full_rmd.contains("![Plot](evt-002_plot.png)"));
     assert!(full_rmd.contains("# Session Summary"));
 

--- a/core/tests/rmarkdown_integration_test.rs
+++ b/core/tests/rmarkdown_integration_test.rs
@@ -1,5 +1,6 @@
 use reprod_core::export::{
-    BundleMetadata, CodeFolding, ExportMode, RMarkdownGenerator, RMarkdownOptions, ReproductionBundle,
+    BundleMetadata, CodeFolding, ExportMode, RMarkdownGenerator, RMarkdownOptions,
+    ReproductionBundle,
 };
 use reprod_core::protocol::{
     CodeBlockKind, CodeBlockMetadata, EnvironmentSnapshot, ExecutionActor, ExecutionContext,

--- a/core/tests/rmarkdown_integration_test.rs
+++ b/core/tests/rmarkdown_integration_test.rs
@@ -1,5 +1,5 @@
 use reprod_core::export::{
-    BundleMetadata, ExportMode, RMarkdownGenerator, RMarkdownOptions, ReproductionBundle,
+    BundleMetadata, CodeFolding, ExportMode, RMarkdownGenerator, RMarkdownOptions, ReproductionBundle,
 };
 use reprod_core::protocol::{
     CodeBlockKind, CodeBlockMetadata, EnvironmentSnapshot, ExecutionActor, ExecutionContext,
@@ -128,12 +128,16 @@ fn test_rmarkdown_timeline_export_integration() {
     let options = RMarkdownOptions {
         mode: ExportMode::Timeline,
         show_code: true,
+        code_folding: CodeFolding::Show,
         include_timestamps: true,
         show_actor: true,
         embed_plots: true,
         include_outputs: true,
         include_errors: true,
         include_summary: true,
+        output_head_lines: 20,
+        output_tail_lines: 8,
+        output_max_lines: 200,
     };
 
     let generator = RMarkdownGenerator::new(options);
@@ -229,6 +233,7 @@ ggplot(data_clean, aes(x = x, y = y)) +
 
     let options = RMarkdownOptions {
         mode: ExportMode::Document,
+        code_folding: CodeFolding::Show,
         show_code: true,
         include_timestamps: false,
         show_actor: false,
@@ -236,6 +241,9 @@ ggplot(data_clean, aes(x = x, y = y)) +
         include_outputs: false,
         include_errors: false,
         include_summary: false,
+        output_head_lines: 20,
+        output_tail_lines: 8,
+        output_max_lines: 200,
     };
 
     let generator = RMarkdownGenerator::new(options);
@@ -329,6 +337,7 @@ fn test_rmarkdown_export_with_errors() {
     // Test with errors included
     let options_with_errors = RMarkdownOptions {
         mode: ExportMode::Timeline,
+        code_folding: CodeFolding::Show,
         show_code: true,
         include_timestamps: false,
         show_actor: false,
@@ -336,6 +345,9 @@ fn test_rmarkdown_export_with_errors() {
         include_outputs: false,
         include_errors: true,
         include_summary: false,
+        output_head_lines: 20,
+        output_tail_lines: 8,
+        output_max_lines: 200,
     };
 
     let generator = RMarkdownGenerator::new(options_with_errors.clone());
@@ -388,6 +400,7 @@ fn test_rmarkdown_export_options_combinations() {
     // Test 1: Minimal options
     let minimal_options = RMarkdownOptions {
         mode: ExportMode::Timeline,
+        code_folding: CodeFolding::Show,
         show_code: true,
         include_timestamps: false,
         show_actor: false,
@@ -395,6 +408,9 @@ fn test_rmarkdown_export_options_combinations() {
         include_outputs: false,
         include_errors: false,
         include_summary: false,
+        output_head_lines: 20,
+        output_tail_lines: 8,
+        output_max_lines: 200,
     };
 
     let generator = RMarkdownGenerator::new(minimal_options);
@@ -411,6 +427,7 @@ fn test_rmarkdown_export_options_combinations() {
     // Test 2: Full options
     let full_options = RMarkdownOptions {
         mode: ExportMode::Timeline,
+        code_folding: CodeFolding::Show,
         show_code: true,
         include_timestamps: true,
         show_actor: true,
@@ -418,6 +435,9 @@ fn test_rmarkdown_export_options_combinations() {
         include_outputs: true,
         include_errors: true,
         include_summary: true,
+        output_head_lines: 20,
+        output_tail_lines: 8,
+        output_max_lines: 200,
     };
 
     let generator = RMarkdownGenerator::new(full_options);

--- a/core/tests/rmarkdown_integration_test.rs
+++ b/core/tests/rmarkdown_integration_test.rs
@@ -127,6 +127,7 @@ fn test_rmarkdown_timeline_export_integration() {
     // Generate RMarkdown with all options enabled
     let options = RMarkdownOptions {
         mode: ExportMode::Timeline,
+        show_code: true,
         include_timestamps: true,
         show_actor: true,
         embed_plots: true,
@@ -228,6 +229,7 @@ ggplot(data_clean, aes(x = x, y = y)) +
 
     let options = RMarkdownOptions {
         mode: ExportMode::Document,
+        show_code: true,
         include_timestamps: false,
         show_actor: false,
         embed_plots: false,
@@ -327,6 +329,7 @@ fn test_rmarkdown_export_with_errors() {
     // Test with errors included
     let options_with_errors = RMarkdownOptions {
         mode: ExportMode::Timeline,
+        show_code: true,
         include_timestamps: false,
         show_actor: false,
         embed_plots: false,
@@ -385,6 +388,7 @@ fn test_rmarkdown_export_options_combinations() {
     // Test 1: Minimal options
     let minimal_options = RMarkdownOptions {
         mode: ExportMode::Timeline,
+        show_code: true,
         include_timestamps: false,
         show_actor: false,
         embed_plots: false,
@@ -407,6 +411,7 @@ fn test_rmarkdown_export_options_combinations() {
     // Test 2: Full options
     let full_options = RMarkdownOptions {
         mode: ExportMode::Timeline,
+        show_code: true,
         include_timestamps: true,
         show_actor: true,
         embed_plots: true,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
+base64 = { workspace = true }
 
 # Logging
 tracing = { workspace = true }

--- a/server/src/handlers/export_handler.rs
+++ b/server/src/handlers/export_handler.rs
@@ -154,9 +154,13 @@ async fn materialize_plots(bundle: &ReproductionBundle, working_dir: &Path) -> R
 
             for target_path in targets {
                 if let Some(parent) = target_path.parent() {
-                    tokio::fs::create_dir_all(parent)
-                        .await
-                        .map_err(|e| format!("Failed to create plot directory {}: {}", parent.display(), e))?;
+                    tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                        format!(
+                            "Failed to create plot directory {}: {}",
+                            parent.display(),
+                            e
+                        )
+                    })?;
                 }
 
                 tokio::fs::write(&target_path, &bytes)

--- a/server/src/handlers/export_handler.rs
+++ b/server/src/handlers/export_handler.rs
@@ -1,25 +1,37 @@
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::projects::ProjectRuntime;
 
 use super::common::{error_response, single_response, AppState, WSResponse};
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
 use reprod_core::{
     api::timeline::{ExportRMarkdownRequest, ExportRMarkdownResponse},
     executor::timeline::{SortOrder, TimelineQuery},
-    export::{BundleMetadata, ExportMode, RMarkdownGenerator, ReproductionBundle},
+    export::{
+        render_pdf_document, BundleMetadata, ExportFormat, ExportMode, PdfRenderOptions,
+        RMarkdownGenerator, ReproductionBundle,
+    },
 };
 
 pub(super) async fn handle_export_request(
-    _state: &AppState,
+    state: &AppState,
     runtime: &Arc<ProjectRuntime>,
     request: ExportRMarkdownRequest,
 ) -> Vec<WSResponse> {
     eprintln!(
-        "[handlers] Processing export_rmarkdown request: mode={:?}",
-        request.mode()
+        "[handlers] Processing export_rmarkdown request: mode={:?}, format={}",
+        request.mode(),
+        request.format
     );
 
-    match process_export_request(request, runtime).await {
+    let r_path = {
+        let config = state.config.lock().await;
+        config.r_path.clone()
+    };
+
+    match process_export_request(request, runtime, &r_path).await {
         Ok(response) => {
             eprintln!("[handlers] Export successful: {}", response.output_path());
             single_response(WSResponse::ExportRMarkdownResponse { response })
@@ -34,16 +46,17 @@ pub(super) async fn handle_export_request(
 async fn process_export_request(
     request: ExportRMarkdownRequest,
     runtime: &Arc<ProjectRuntime>,
+    r_path: &str,
 ) -> Result<ExportRMarkdownResponse, String> {
     let document_path = request.document_path();
 
-    let (mode, options, output_path) = request
+    let (mode, format, options, pdf_options, output_path) = request
         .into_options()
         .map_err(|e| format!("Invalid export options: {}", e))?;
 
-    let generator = RMarkdownGenerator::new(options);
+    let generator = RMarkdownGenerator::new(options.clone());
 
-    let content = match mode {
+    let (mut content, bundle_opt) = match mode {
         ExportMode::Timeline => {
             let query = TimelineQuery {
                 filters: None,
@@ -58,7 +71,7 @@ async fn process_export_request(
                 .map_err(|e| format!("Failed to query timeline: {}", e))?;
 
             let bundle = ReproductionBundle::from_events(response.events);
-            generator.from_timeline(&bundle)
+            (generator.from_timeline(&bundle), Some(bundle))
         }
         ExportMode::Document => {
             let doc_path = document_path.ok_or("Document path is required for document mode")?;
@@ -73,13 +86,85 @@ async fn process_export_request(
                 .as_secs();
             let metadata = BundleMetadata::new(format!("export-{}", timestamp));
 
-            generator.from_document(&doc_path, &doc_content, &metadata)
+            (
+                generator.from_document(&doc_path, &doc_content, &metadata),
+                None,
+            )
         }
     };
 
-    tokio::fs::write(&output_path, content)
-        .await
-        .map_err(|e| format!("Failed to write RMarkdown file: {}", e))?;
+    match format {
+        ExportFormat::RMarkdown => {
+            tokio::fs::write(&output_path, content)
+                .await
+                .map_err(|e| format!("Failed to write RMarkdown file: {}", e))?;
 
-    Ok(ExportRMarkdownResponse::success(output_path))
+            Ok(ExportRMarkdownResponse::success(output_path))
+        }
+        ExportFormat::Pdf => {
+            let working_dir = runtime.descriptor.root_path.clone();
+            let pdf_options = pdf_options.unwrap_or_else(PdfRenderOptions::default);
+            let output_path = PathBuf::from(output_path);
+
+            if options.embed_plots {
+                if let Some(bundle) = bundle_opt.as_ref() {
+                    materialize_plots(bundle, &working_dir)
+                        .await
+                        .map_err(|e| format!("Failed to prepare plot images: {}", e))?;
+
+                    // Rewrite plot paths to absolute paths to avoid LaTeX lookup issues.
+                    for event in &bundle.events {
+                        for plot in &event.result.plots {
+                            let filename = plot.filename.trim();
+                            let abs_path = working_dir.join(filename);
+                            let abs_str = abs_path.to_string_lossy();
+                            content = content.replace(filename, &abs_str);
+                        }
+                    }
+                }
+            }
+
+            render_pdf_document(r_path, &working_dir, &content, &output_path, &pdf_options)
+                .await
+                .map_err(|e| format!("Failed to render PDF: {}", e))?;
+
+            Ok(ExportRMarkdownResponse::success(
+                output_path.to_string_lossy().to_string(),
+            ))
+        }
+    }
+}
+
+async fn materialize_plots(bundle: &ReproductionBundle, working_dir: &Path) -> Result<(), String> {
+    for event in &bundle.events {
+        for plot in &event.result.plots {
+            let filename = plot.filename.trim();
+            let mut targets = Vec::new();
+
+            let primary = working_dir.join(filename);
+            targets.push(primary.clone());
+
+            if primary.parent().is_none() {
+                targets.push(working_dir.join("plots").join(filename));
+            }
+
+            let bytes = BASE64_STANDARD
+                .decode(plot.base64_data.trim())
+                .map_err(|e| format!("Failed to decode plot {}: {}", plot.filename, e))?;
+
+            for target_path in targets {
+                if let Some(parent) = target_path.parent() {
+                    tokio::fs::create_dir_all(parent)
+                        .await
+                        .map_err(|e| format!("Failed to create plot directory {}: {}", parent.display(), e))?;
+                }
+
+                tokio::fs::write(&target_path, &bytes)
+                    .await
+                    .map_err(|e| format!("Failed to write plot {}: {}", plot.filename, e))?;
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/shared/src/ws.ts
+++ b/shared/src/ws.ts
@@ -27,6 +27,13 @@ type ToolExecutionResponse = {
 
 export type ExportMode = 'timeline' | 'document';
 export type ExportFormat = 'rmarkdown' | 'pdf';
+export type CodeFolding = 'show' | 'hide';
+
+export interface OutputTruncationOptions {
+  headLines: number;
+  tailLines: number;
+  maxLines: number;
+}
 
 export interface PdfExportOptions {
   toc: boolean;
@@ -42,12 +49,14 @@ export interface ExportRMarkdownRequestPayload {
   format?: ExportFormat;
   outputPath: string;
   documentPath?: string;
+  codeFolding?: CodeFolding;
   includeTimestamps: boolean;
   showActor: boolean;
   embedPlots: boolean;
   includeOutputs: boolean;
   includeErrors: boolean;
   includeSummary: boolean;
+  outputTruncation?: OutputTruncationOptions;
   pdfOptions?: PdfExportOptions;
 }
 

--- a/shared/src/ws.ts
+++ b/shared/src/ws.ts
@@ -26,9 +26,20 @@ type ToolExecutionResponse = {
 };
 
 export type ExportMode = 'timeline' | 'document';
+export type ExportFormat = 'rmarkdown' | 'pdf';
+
+export interface PdfExportOptions {
+  toc: boolean;
+  includeSource: boolean;
+  highlightTheme?: string;
+  figWidth?: number;
+  figHeight?: number;
+  latexPreamble?: string | null;
+}
 
 export interface ExportRMarkdownRequestPayload {
   mode: ExportMode;
+  format?: ExportFormat;
   outputPath: string;
   documentPath?: string;
   includeTimestamps: boolean;
@@ -37,6 +48,7 @@ export interface ExportRMarkdownRequestPayload {
   includeOutputs: boolean;
   includeErrors: boolean;
   includeSummary: boolean;
+  pdfOptions?: PdfExportOptions;
 }
 
 export interface ExportRMarkdownResponsePayload {


### PR DESCRIPTION
## Description

- Add PDF export polish: plot materialization to project root/plots, absolute paths before render, setwd to project root.
- Add export UX options: code folding (show/hide), output truncation with styled blocks, PDF figure/preamble options.
- Style Rmd/PDF outputs with background for output/error blocks and truncation markers.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes (updated export dialog test)
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- cargo check -p reprod-core
- cargo check -p reprod-server
- pnpm --filter client test -- run src/components/export/__tests__/ExportDialog.test.tsx

## Screenshots (if applicable)

- N/A

## Related Issues

Closes #147
