### PR TITLE
Refactor: Remove document.querySelector from menuActions (#71)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,8 +25,9 @@ import { useSocketConnection } from "@/hooks/useSocketConnection";
 function App(): JSX.Element {
 	const panes = useStore((state) => state.view.panes);
 	const theme = useStore((state) => state.settings.theme);
+	const setAIPanelRef = useStore((state) => state.setAIPanelRef);
+	const setTimelinePanelRef = useStore((state) => state.setTimelinePanelRef);
 	const [exportDialogOpen, setExportDialogOpen] = useState(false);
-	const [timelineDialogOpen, setTimelineDialogOpen] = useState(false);
 	const [shortcutsOpen, setShortcutsOpen] = useState(false);
 	const [aboutOpen, setAboutOpen] = useState(false);
 	const [sessionInfoOpen, setSessionInfoOpen] = useState(false);
@@ -47,7 +48,6 @@ function App(): JSX.Element {
 	useEffect(() => {
 		const globalScope = window as typeof window & Record<string, () => void>;
 		globalScope.openExportDialog = () => setExportDialogOpen(true);
-		globalScope.openTimelineDialog = () => setTimelineDialogOpen(true);
 		globalScope.openShortcutsDialog = () => setShortcutsOpen(true);
 		globalScope.openAboutDialog = () => setAboutOpen(true);
 		globalScope.openSessionInfoDialog = () => setSessionInfoOpen(true);
@@ -56,7 +56,6 @@ function App(): JSX.Element {
 
 		return () => {
 			delete globalScope.openExportDialog;
-			delete globalScope.openTimelineDialog;
 			delete globalScope.openShortcutsDialog;
 			delete globalScope.openAboutDialog;
 			delete globalScope.openSessionInfoDialog;
@@ -92,7 +91,7 @@ function App(): JSX.Element {
 					{panes.assistant && (
 						<Allotment.Pane minSize={260} preferredSize="25%">
 							<div className="ai-pane-wrapper">
-								<AIPanel />
+								<AIPanel ref={setAIPanelRef} />
 							</div>
 						</Allotment.Pane>
 					)}
@@ -100,7 +99,7 @@ function App(): JSX.Element {
 			</div>
 			<StatusBar />
 			<ExportDialog open={exportDialogOpen} onClose={() => setExportDialogOpen(false)} />
-			<TimelineDialog open={timelineDialogOpen} onClose={() => setTimelineDialogOpen(false)} />
+			<TimelineDialog ref={setTimelinePanelRef} />
 			<KeyboardShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
 			<AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
 			<SessionInfoModal open={sessionInfoOpen} onClose={() => setSessionInfoOpen(false)} />

--- a/client/src/components/ai-panel/AIPanel.tsx
+++ b/client/src/components/ai-panel/AIPanel.tsx
@@ -1,16 +1,26 @@
 import type { AIMode } from "@shared/types";
-import { useEffect, useRef, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { IconSend, IconSquare } from "@/components/shared";
 import { useAIConversation } from "@/hooks/useAIConversation";
 import { ProviderSwitcher } from "./ProviderSwitcher";
 import { StreamingMessage } from "./StreamingMessage";
 
-export function AIPanel(): JSX.Element {
+export interface AIPanelRef {
+	focusInput: () => void;
+}
+
+export const AIPanel = forwardRef<AIPanelRef>((_, ref) => {
 	const { input, setInput, messages, isLoading, handleAsk, handleStop, handleApplyCode } =
 		useAIConversation();
 
 	const messagesEndRef = useRef<HTMLDivElement>(null);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	useImperativeHandle(ref, () => ({
+		focusInput: () => {
+			textareaRef.current?.focus();
+		},
+	}));
 
 	useEffect(() => {
 		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -133,4 +143,5 @@ export function AIPanel(): JSX.Element {
 			</div>
 		</div>
 	);
-}
+});
+AIPanel.displayName = "AIPanel";

--- a/client/src/components/timeline/TimelineDialog.tsx
+++ b/client/src/components/timeline/TimelineDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from "react";
 import type { ExecutionEventPayload } from "shared";
 
 import { useStore } from "@/core";
@@ -9,112 +9,138 @@ import { TimelineSort } from "./TimelineSort";
 import { TimelineStats } from "./TimelineStats";
 
 interface TimelineDialogProps {
-	open: boolean;
-	onClose: () => void;
+	open?: boolean;
+	onClose?: () => void;
 }
 
-export function TimelineDialog({ open, onClose }: TimelineDialogProps): JSX.Element | null {
-	const {
-		events,
-		total,
-		hasMore,
-		loading,
-		error,
-		filters,
-		sort,
-		setFilters,
-		setSort,
-		loadMore,
-		stats,
-		statsLoading,
-	} = useTimelineData();
+export interface TimelineDialogRef {
+	scrollIntoView: () => void;
+}
 
-	const editorRef = useStore((state) => state.editorRef);
+export const TimelineDialog = forwardRef<TimelineDialogRef, TimelineDialogProps>(
+	({ open: initialOpen, onClose }, ref) => {
+		const [isOpen, setIsOpen] = useState(initialOpen || false);
 
-	const handleNavigate = useCallback(
-		(event: ExecutionEventPayload) => {
-			const targetEditor = editorRef?.current;
-			if (!targetEditor) {
-				return;
+		useEffect(() => {
+			if (initialOpen !== undefined) {
+				setIsOpen(initialOpen);
 			}
+		}, [initialOpen]);
 
-			const line = event.blocks?.[0]?.start_line;
-			if (line === undefined) {
-				return;
-			}
+		useImperativeHandle(ref, () => ({
+			scrollIntoView: () => {
+				setIsOpen(true);
+			},
+		}));
 
-			targetEditor.navigateToLine(line);
-			// Close dialog after navigation
-			onClose();
-		},
-		[editorRef, onClose],
-	);
+		const handleClose = useCallback(() => {
+			setIsOpen(false);
+			onClose?.();
+		}, [onClose]);
 
-	// Handle ESC key to close dialog
-	useEffect(() => {
-		if (!open) return;
+		const {
+			events,
+			total,
+			hasMore,
+			loading,
+			error,
+			filters,
+			sort,
+			setFilters,
+			setSort,
+			loadMore,
+			stats,
+			statsLoading,
+		} = useTimelineData();
 
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				onClose();
-			}
-		};
+		const editorRef = useStore((state) => state.editorRef);
 
-		document.addEventListener("keydown", handleKeyDown);
-		return () => {
-			document.removeEventListener("keydown", handleKeyDown);
-		};
-	}, [open, onClose]);
+		const handleNavigate = useCallback(
+			(event: ExecutionEventPayload) => {
+				const targetEditor = editorRef?.current;
+				if (!targetEditor) {
+					return;
+				}
 
-	if (!open) return null;
+				const line = event.blocks?.[0]?.start_line;
+				if (line === undefined) {
+					return;
+				}
 
-	return (
-		<div className="timeline-dialog-overlay" onClick={onClose} tabIndex={-1}>
-			<div
-				className="timeline-dialog"
-				onClick={(e) => e.stopPropagation()}
-				role="dialog"
-				aria-modal="true"
-				aria-labelledby="timeline-dialog-title"
-			>
-				<div className="timeline-dialog-header">
-					<h2 id="timeline-dialog-title">Timeline</h2>
-					<button className="btn btn-icon" onClick={onClose} aria-label="Close dialog">
-						×
-					</button>
-				</div>
+				targetEditor.navigateToLine(line);
+				// Close dialog after navigation
+				handleClose();
+			},
+			[editorRef, handleClose],
+		);
 
-				<div className="timeline-dialog-content">
-					{/* Filter section - 20-25% height */}
-					<div className="timeline-dialog-filters">
-						<TimelineStats stats={stats} loading={statsLoading} />
+		// Handle ESC key to close dialog
+		useEffect(() => {
+			if (!isOpen) return;
 
-						<div className="timeline-panel-controls">
-							<TimelineFilters filters={filters} onChange={setFilters} />
-							<TimelineSort sort={sort} onChange={setSort} />
-						</div>
+			const handleKeyDown = (e: KeyboardEvent) => {
+				if (e.key === "Escape") {
+					handleClose();
+				}
+			};
 
-						{error && (
-							<div className="timeline-error">
-								<span className="timeline-error-icon">⚠️</span>
-								<span className="timeline-error-message">{error}</span>
-							</div>
-						)}
+			document.addEventListener("keydown", handleKeyDown);
+			return () => {
+				document.removeEventListener("keydown", handleKeyDown);
+			};
+		}, [isOpen, handleClose]);
+
+		if (!isOpen) return null;
+
+		return (
+			<div className="timeline-dialog-overlay" onClick={handleClose} tabIndex={-1}>
+				<div
+					className="timeline-dialog"
+					onClick={(e) => e.stopPropagation()}
+					role="dialog"
+					aria-modal="true"
+					aria-labelledby="timeline-dialog-title"
+				>
+					<div className="timeline-dialog-header">
+						<h2 id="timeline-dialog-title">Timeline</h2>
+						<button className="btn btn-icon" onClick={handleClose} aria-label="Close dialog">
+							×
+						</button>
 					</div>
 
-					{/* History list - 75-80% height */}
-					<div className="timeline-dialog-history">
-						<Timeline
-							events={events}
-							total={total}
-							hasMore={hasMore}
-							loading={loading}
-							onLoadMore={loadMore}
-							onNavigate={handleNavigate}
-						/>
+					<div className="timeline-dialog-content">
+						{/* Filter section - 20-25% height */}
+						<div className="timeline-dialog-filters">
+							<TimelineStats stats={stats} loading={statsLoading} />
+
+							<div className="timeline-panel-controls">
+								<TimelineFilters filters={filters} onChange={setFilters} />
+								<TimelineSort sort={sort} onChange={setSort} />
+							</div>
+
+							{error && (
+								<div className="timeline-error">
+									<span className="timeline-error-icon">⚠️</span>
+									<span className="timeline-error-message">{error}</span>
+								</div>
+							)}
+						</div>
+
+						{/* History list - 75-80% height */}
+						<div className="timeline-dialog-history">
+							<Timeline
+								events={events}
+								total={total}
+								hasMore={hasMore}
+								loading={loading}
+								onLoadMore={loadMore}
+								onNavigate={handleNavigate}
+							/>
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
-	);
-}
+		);
+	},
+);
+TimelineDialog.displayName = "TimelineDialog";

--- a/client/src/core/state/slices/aiSlice.ts
+++ b/client/src/core/state/slices/aiSlice.ts
@@ -53,6 +53,8 @@ export interface AIState {
 		patchMatchFailures: number;
 		patchMatchStatus: PatchMatchStatus;
 	};
+	aiPanelRef: { focusInput: () => void } | null;
+	setAIPanelRef: (ref: { focusInput: () => void } | null) => void;
 	addAIMessage: (message: AIMessage) => void;
 	setAILoading: (isLoading: boolean) => void;
 	clearAIMessages: () => void;
@@ -79,6 +81,8 @@ export const createAISlice: StateCreator<AIState> = (set) => ({
 		patchMatchFailures: 0,
 		patchMatchStatus: { lastFailureId: null, lastFailureReason: null },
 	},
+	aiPanelRef: null,
+	setAIPanelRef: (ref) => set({ aiPanelRef: ref }),
 	addAIMessage: (message) =>
 		set((state) => ({
 			ai: { ...state.ai, messages: [...state.ai.messages, message] },

--- a/client/src/core/state/slices/timelineSlice.ts
+++ b/client/src/core/state/slices/timelineSlice.ts
@@ -15,6 +15,9 @@ export interface TimelineState {
 	limit: number;
 	offset: number;
 
+	timelinePanelRef: { scrollIntoView: () => void } | null;
+	setTimelinePanelRef: (ref: { scrollIntoView: () => void } | null) => void;
+
 	// Actions
 	setEvents: (events: ExecutionEventPayload[], total: number, hasMore: boolean) => void;
 	addEvent: (event: ExecutionEventPayload) => void;
@@ -36,10 +39,13 @@ const initialState = {
 	sort: "desc" as const,
 	limit: 50,
 	offset: 0,
+	timelinePanelRef: null,
 };
 
 export const createTimelineSlice: StateCreator<TimelineState> = (set) => ({
 	...initialState,
+
+	setTimelinePanelRef: (ref) => set({ timelinePanelRef: ref }),
 
 	setEvents: (events, total, hasMore) =>
 		set(() => ({

--- a/client/src/services/menuActions.ts
+++ b/client/src/services/menuActions.ts
@@ -16,6 +16,7 @@ import { DEFAULT_FILENAMES, UI_TIMING, ZOOM } from "@/constants/ui";
 import { DEFAULT_R_SCRIPT } from "@/core/state/slices/editorSlice";
 import type { ViewPane } from "@/core/state/slices/viewSlice";
 import { useStore } from "@/core/state/store";
+import { downloadFile, openFile } from "@/utils/fileOperations";
 import { interruptExecution, restartSession as restartSessionRequest } from "./sessionControl";
 import { exportSessionSnapshot, importSessionSnapshot } from "./sessionPersistence";
 
@@ -74,25 +75,19 @@ export const menuActions = {
 		 * Open file dialog
 		 * Browser file picker for .R and .Rmd files
 		 */
-		open: () => {
-			const input = document.createElement("input");
-			input.type = "file";
-			input.accept = ".R,.Rmd";
-			input.onchange = async (e) => {
-				const file = (e.target as HTMLInputElement).files?.[0];
+		open: async () => {
+			try {
+				const file = await openFile(".R,.Rmd");
 				if (!file) return;
 
-				try {
-					const content = await file.text();
-					const store = useStore.getState();
-					store.setEditorContent(content);
-					store.setEditorFilepath(file.name);
-					store.setEditorIsDirty(false);
-				} catch (error) {
-					console.error(`Failed to open file: ${error}`);
-				}
-			};
-			input.click();
+				const content = await file.text();
+				const store = useStore.getState();
+				store.setEditorContent(content);
+				store.setEditorFilepath(file.name);
+				store.setEditorIsDirty(false);
+			} catch (error) {
+				console.error(`Failed to open file: ${error}`);
+			}
 		},
 
 		/**
@@ -113,13 +108,7 @@ export const menuActions = {
 			}
 
 			// Save file (simplified - no socket event for now)
-			const blob = new Blob([content], { type: "text/plain" });
-			const url = URL.createObjectURL(blob);
-			const a = document.createElement("a");
-			a.href = url;
-			a.download = filepath;
-			a.click();
-			URL.revokeObjectURL(url);
+			downloadFile(filepath, content);
 
 			store.setEditorIsDirty(false);
 		},
@@ -137,13 +126,7 @@ export const menuActions = {
 				return;
 			}
 
-			const blob = new Blob([content], { type: "text/plain" });
-			const url = URL.createObjectURL(blob);
-			const a = document.createElement("a");
-			a.href = url;
-			a.download = DEFAULT_FILENAMES.UNTITLED_R_SCRIPT;
-			a.click();
-			URL.revokeObjectURL(url);
+			downloadFile(DEFAULT_FILENAMES.UNTITLED_R_SCRIPT, content);
 		},
 
 		/**
@@ -219,9 +202,9 @@ export const menuActions = {
 		aiAssist: () => {
 			// Focus AI panel input
 			setTimeout(() => {
-				const aiInput = document.querySelector(".ai-input") as HTMLTextAreaElement;
-				if (aiInput) {
-					aiInput.focus();
+				const { aiPanelRef } = useStore.getState();
+				if (aiPanelRef) {
+					aiPanelRef.focusInput();
 				}
 			}, UI_TIMING.AI_INPUT_FOCUS_DELAY_MS);
 		},
@@ -314,9 +297,9 @@ export const menuActions = {
 		 * Show timeline dialog
 		 */
 		showTimeline: () => {
-			// Call global timeline dialog handler
-			if (typeof (window as any).openTimelineDialog === "function") {
-				(window as any).openTimelineDialog();
+			const { timelinePanelRef } = useStore.getState();
+			if (timelinePanelRef) {
+				timelinePanelRef.scrollIntoView();
 			} else {
 				console.error("Timeline dialog not initialized");
 			}

--- a/client/src/utils/fileOperations.ts
+++ b/client/src/utils/fileOperations.ts
@@ -1,0 +1,38 @@
+/**
+ * File operation utilities
+ * Abstracts DOM-based file interactions (input[type=file], anchors for download)
+ */
+
+/**
+ * Opens a file picker dialog and returns the selected file
+ * @param accept - Comma-separated list of allowed file extensions (e.g. ".R,.Rmd")
+ * @returns Promise resolving to the selected File object or null if canceled/no file selected
+ */
+export const openFile = (accept: string): Promise<File | null> => {
+	return new Promise((resolve) => {
+		const input = document.createElement("input");
+		input.type = "file";
+		input.accept = accept;
+		input.onchange = (e) => {
+			const file = (e.target as HTMLInputElement).files?.[0];
+			resolve(file || null);
+		};
+		input.click();
+	});
+};
+
+/**
+ * Triggers a browser download for the given content
+ * @param filename - Name of the file to download
+ * @param content - Text content of the file
+ * @param type - MIME type (default: "text/plain")
+ */
+export const downloadFile = (filename: string, content: string, type = "text/plain"): void => {
+	const blob = new Blob([content], { type });
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement("a");
+	a.href = url;
+	a.download = filename;
+	a.click();
+	URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
Refactors `client/src/services/menuActions.ts` to remove direct DOM manipulation.

Changes:
- Extracted file operations to `client/src/utils/fileOperations.ts`.
- Implemented `AIPanelRef` and stored in Zustand to handle AI input focus.
- Implemented `TimelineDialogRef` and stored in Zustand to handle Timeline dialog visibility.
- Updated `menuActions.ts` to use the new refs and utilities.
- Cleaned up global window handlers in `App.tsx`.

Closes #71