### PR TITLE
feat: Simplify export UI to RMarkdown/PDF/Both (issue #81)

### DIFF
--- a/client/src/components/export/ExportDialog.tsx
+++ b/client/src/components/export/ExportDialog.tsx
@@ -48,7 +48,10 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
 				aria-describedby="export-dialog-description"
 			>
 				<div className="export-dialog-header">
-					<h2 id="export-dialog-title">Export Analysis</h2>
+					<h2 id="export-dialog-title">Export Document</h2>
+					<p id="export-dialog-description" className="export-dialog-subtitle">
+						Generate RMarkdown or PDF from your analysis
+					</p>
 					<button
 						className="btn btn-icon"
 						onClick={onClose}
@@ -60,23 +63,12 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
 				</div>
 
 				<div className={`export-dialog-content ${exporting ? "loading" : ""}`}>
+					{/* TODO: Reproduction Bundle export will be available in File > Export > Reproduction Bundle */}
 					<div className="export-section">
 						<label className="export-label" id="format-label">
-							Format
+							Output Format
 						</label>
 						<div className="export-radio-group" role="radiogroup" aria-labelledby="format-label">
-							<label className="export-radio">
-								<input
-									type="radio"
-									name="format"
-									value="bundle"
-									checked={format === "bundle"}
-									onChange={(e) => setFormat(e.target.value as typeof format)}
-									disabled={exporting}
-									aria-label="Reproduction Bundle"
-								/>
-								<span>Reproduction Bundle (.tar.gz)</span>
-							</label>
 							<label className="export-radio">
 								<input
 									type="radio"
@@ -87,7 +79,7 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
 									disabled={exporting}
 									aria-label="RMarkdown Document"
 								/>
-								<span>RMarkdown Document (.Rmd)</span>
+								<span>RMarkdown (.Rmd)</span>
 							</label>
 							<label className="export-radio">
 								<input
@@ -99,7 +91,7 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
 									disabled={exporting}
 									aria-label="PDF Document"
 								/>
-								<span>PDF Document (.pdf)</span>
+								<span>PDF (.pdf)</span>
 							</label>
 							<label className="export-radio">
 								<input
@@ -111,12 +103,12 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
 									disabled={exporting}
 									aria-label="Both formats"
 								/>
-								<span>Both</span>
+								<span>Both (RMarkdown + PDF)</span>
 							</label>
 						</div>
 					</div>
 
-					{format !== "bundle" && (
+					{
 						<>
 							<div className="export-section">
 								<label className="export-label" id="mode-label">
@@ -183,7 +175,7 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
 								</div>
 							)}
 
-							{format === "pdf" && (
+							{(format === "pdf" || format === "both") && (
 								<>
 									<div className="export-section">
 										<p className="export-hint">
@@ -340,7 +332,7 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
 								</p>
 							</div>
 						</>
-					)}
+					}
 
 					{error && (
 						<div className="export-error" role="alert" aria-live="polite">

--- a/client/src/css/components/export-dialog.css
+++ b/client/src/css/components/export-dialog.css
@@ -35,6 +35,7 @@
 	padding: 16px;
 	background: var(--bg-toolbar);
 	border-bottom: 1px solid var(--border-light);
+	gap: 12px;
 }
 
 .export-dialog-header h2 {
@@ -43,6 +44,13 @@
 	font-weight: 600;
 	color: var(--text-primary);
 	letter-spacing: var(--letter-spacing-base);
+}
+
+.export-dialog-subtitle {
+	margin: 4px 0 0 0;
+	font-size: 12px;
+	font-weight: 400;
+	color: var(--text-secondary);
 }
 
 /* Content */

--- a/client/src/hooks/useExportDialog.ts
+++ b/client/src/hooks/useExportDialog.ts
@@ -126,12 +126,6 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
 		dispatch({ type: "set-exporting", payload: true });
 		dispatch({ type: "set-error", payload: "" });
 
-		if (format === "bundle") {
-			dispatch({ type: "set-error", payload: "Bundle export is not supported yet." });
-			dispatch({ type: "set-exporting", payload: false });
-			return;
-		}
-
 		const trimmedDocumentPath = documentPath.trim();
 
 		if (mode === "document" && !trimmedDocumentPath) {
@@ -143,9 +137,8 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
 			return;
 		}
 
-		const payload: ExportRMarkdownRequestPayload = {
+		const basePayload = {
 			mode,
-			format: format === "pdf" ? "pdf" : "rmarkdown",
 			outputPath,
 			documentPath: mode === "document" ? trimmedDocumentPath : undefined,
 			codeFolding,
@@ -160,21 +153,37 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
 				tailLines: 8,
 				maxLines: 200,
 			},
-			pdfOptions:
-				format === "pdf"
-					? {
-							toc: pdfOptions.toc,
-							includeSource: pdfOptions.includeSource,
-							highlightTheme: pdfOptions.highlightTheme,
-							figWidth: pdfOptions.figWidth,
-							figHeight: pdfOptions.figHeight,
-							latexPreamble: pdfOptions.latexPreamble || undefined,
-						}
-					: undefined,
+		};
+
+		const pdfPayload = {
+			...basePayload,
+			format: "pdf" as const,
+			pdfOptions: {
+				toc: pdfOptions.toc,
+				includeSource: pdfOptions.includeSource,
+				highlightTheme: pdfOptions.highlightTheme,
+				figWidth: pdfOptions.figWidth,
+				figHeight: pdfOptions.figHeight,
+				latexPreamble: pdfOptions.latexPreamble || undefined,
+			},
+		};
+
+		const rmdPayload = {
+			...basePayload,
+			format: "rmarkdown" as const,
 		};
 
 		try {
-			await exportRMarkdown(payload);
+			if (format === "both") {
+				// Export RMarkdown first
+				await exportRMarkdown(rmdPayload);
+				// Then export PDF
+				await exportRMarkdown(pdfPayload);
+			} else if (format === "pdf") {
+				await exportRMarkdown(pdfPayload);
+			} else {
+				await exportRMarkdown(rmdPayload);
+			}
 			onClose();
 		} catch (err) {
 			if (err instanceof ExportServiceError || err instanceof Error) {

--- a/client/src/types/exportDialog.ts
+++ b/client/src/types/exportDialog.ts
@@ -23,7 +23,9 @@ export type ExportPdfOptions = Required<
 
 export type ExportPdfOptionKey = keyof ExportPdfOptions;
 
-export type ExportFormat = "bundle" | "rmarkdown" | "pdf" | "both";
+// TODO: Reproduction Bundle export will be implemented as a separate feature
+// Future: Add "bundle" format with dedicated UI in File > Export > Reproduction Bundle
+export type ExportFormat = "rmarkdown" | "pdf" | "both";
 
 export interface ExportDialogState {
 	format: ExportFormat;


### PR DESCRIPTION
## Description

This PR simplifies the export dialog UI by removing the Bundle format option and focusing on document export with 3 clear choices: **RMarkdown**, **PDF**, and **Both**.

### Changes Made

**UI Simplification**:
- ✅ Removed "Bundle (.tar.gz)" format option
- ✅ Simplified to 3 options: RMarkdown, PDF, Both (RMarkdown + PDF)
- ✅ Updated dialog title to "Export Document" with descriptive subtitle
- ✅ Changed "Format" label to "Output Format" for clarity
- ✅ Made "Both" option more explicit: "Both (RMarkdown + PDF)"

**Functionality**:
- ✅ Implemented "Both" format to export RMarkdown and PDF sequentially
- ✅ Removed bundle validation check from hook
- ✅ Added proper CSS styling for subtitle text

**Code Quality**:
- ✅ Added TODO comments documenting future Bundle feature as separate menu item
- ✅ Updated TypeScript type definition to exclude "bundle"
- ✅ Refactored export logic for clarity (basePayload, pdfPayload, rmdPayload)

### Before vs After

**Before** (4 options):
```
Format:
  ○ Reproduction Bundle (.tar.gz)  [not implemented]
  ○ RMarkdown Document (.Rmd)
  ○ PDF Document (.pdf)
  ○ Both  [unclear what "both" means]
```

**After** (3 options):
```
Output Format:
  ○ RMarkdown (.Rmd)
  ○ PDF (.pdf)
  ○ Both (RMarkdown + PDF)  [clearly labeled]
```

### UX Improvements

1. **Clearer Purpose**: Dialog now clearly focuses on document export
2. **Reduced Confusion**: No "not supported yet" error for Bundle
3. **Better Labeling**: "Both" explicitly states it exports both formats
4. **Consistent Terminology**: "Output Format" instead of just "Format"
5. **Future-Ready**: TODO comments document where Bundle will live

### Future Work

Bundle export will be implemented as a separate feature:
- Separate menu item: `File > Export > Reproduction Bundle`
- Or dedicated "Export Bundle" button in a different location
- This keeps document export and bundle export as distinct workflows

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to \`develop\`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (\`pnpm test\`)
- [ ] New tests added for new features/bug fixes
- [x] Documentation updated (if needed)

### For PRs from \`develop\` → \`main\` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- [x] TypeScript compilation successful
- [x] Biome linting passed
- [x] Pre-commit/pre-push hooks passed
- [ ] Manual testing of export dialog (requires running app)

### Manual Testing Checklist

- [ ] Export as RMarkdown works
- [ ] Export as PDF works
- [ ] Export as Both creates both files
- [ ] Dialog UI looks correct
- [ ] Subtitle text displays properly
- [ ] No console errors

## Screenshots (if applicable)

N/A - UI changes are minor (text labels and option removal)

## Related Issues

Closes #81

## Migration Notes

- Existing code continues to work
- Users will see cleaner UI with 3 options instead of 4
- No breaking changes to backend API
- "Both" format now properly exports both RMarkdown and PDF