### PR TITLE
feat: add release workflow for automated builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Get version from tag
+        id: get_version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            echo "version=v0.0.0-manual" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        id: create_release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          release_name: Release ${{ steps.get_version.outputs.version }}
+          draft: false
+          prerelease: false
+
+  build-tauri:
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            name: macOS (Apple Silicon)
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            name: macOS (Intel)
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            name: Linux (x86_64)
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            name: Windows (x86_64)
+
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Enable pnpm
+        run: corepack enable pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform.target }}
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: "4.3.0"
+
+      - name: Install Tauri dependencies (Ubuntu)
+        if: matrix.platform.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev
+
+      - name: Build frontend
+        run: pnpm --filter client build
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ needs.create-release.outputs.version }}
+          releaseName: 'Re-prod ${{ needs.create-release.outputs.version }}'
+          releaseBody: |
+            Release ${{ needs.create-release.outputs.version }} for ${{ matrix.platform.name }}
+
+            See the assets below for downloads.
+          releaseDraft: false
+          prerelease: false
+          args: --target ${{ matrix.platform.target }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: reprod-${{ matrix.platform.target }}
+          path: |
+            desktop/target/${{ matrix.platform.target }}/release/bundle/**/*
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically build and publish Tauri app binaries
- Trigger on tag push (`v*` pattern) or release publication
- Support manual workflow dispatch

## Features
### Multi-platform builds
- macOS (Apple Silicon - ARM64)
- macOS (Intel - x86_64)
- Linux (x86_64)
- Windows (x86_64)

### Automation
- Automatically create GitHub release from git tags
- Build release artifacts for all platforms
- Upload binaries to GitHub releases
- Archive build artifacts with 7-day retention

## Workflow Triggers
1. **Tag push**: When pushing tags matching `v*` pattern (e.g., `v1.0.0`)
2. **Release published**: When a release is published manually
3. **Manual dispatch**: Can be triggered manually from GitHub Actions UI

## Usage
To create a new release:
```bash
git tag v1.0.0
git push origin v1.0.0
```

The workflow will automatically:
1. Create a GitHub release
2. Build binaries for all platforms
3. Upload artifacts to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)