### PR TITLE
Fix macOS release artifact paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          projectPath: desktop
           tagName: ${{ needs.create-release.outputs.version }}
           releaseName: 'Re-prod ${{ needs.create-release.outputs.version }}'
           releaseBody: |
@@ -117,5 +118,5 @@ jobs:
         with:
           name: reprod-${{ matrix.platform.target }}
           path: |
-            desktop/target/${{ matrix.platform.target }}/release/bundle/**/*
+            target/${{ matrix.platform.target }}/release/bundle/**/*
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,6 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             name: macOS (Intel)
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            name: Linux (x86_64)
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            name: Windows (x86_64)
 
     runs-on: ${{ matrix.platform.os }}
     steps:


### PR DESCRIPTION
## Summary
- point tauri-action at desktop project to run bundling with correct config
- upload release bundles from target/<target>/release/bundle so mac artifacts are found

## Testing
- not run (workflow change only)