### PR TITLE
feat: embed backend sidecar for desktop (#179)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ logs/
 /target/
 **/target/
 Cargo.lock
+desktop/binaries/
 
 # Cargo local config (environment-specific)
 .cargo/

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ logs/
 /target/
 **/target/
 Cargo.lock
+# Tauri sidecar outputs (placeholders generated at build time)
 desktop/binaries/
 
 # Cargo local config (environment-specific)

--- a/client/src/constants/urls.ts
+++ b/client/src/constants/urls.ts
@@ -22,33 +22,16 @@ export const GITHUB_ISSUE_URL = "https://github.com/reprod/issues/new";
 
 // ===== API URLs =====
 
-/**
- * Base URL for the backend API server
- */
-export const API_BASE_URL = "http://localhost:3001/api";
+let apiBaseUrl = "http://localhost:3001/api";
 
-/**
- * API endpoint for provider configuration
- */
-export const API_CONFIG_PROVIDER_URL = `${API_BASE_URL}/config/provider`;
+export const setApiBaseUrl = (url: string): void => {
+	apiBaseUrl = url;
+};
 
-/**
- * Get API endpoint for provider-specific API key
- * @param provider - The provider name (e.g., 'openai', 'anthropic')
- * @returns Full API endpoint URL
- */
-export const getApiKeyUrl = (provider: string) => `${API_BASE_URL}/config/key/${provider}`;
+export const getApiBaseUrl = (): string => apiBaseUrl;
 
-/**
- * Get API endpoint for provider connection test
- * @param provider - The provider name (e.g., 'openai', 'anthropic')
- * @returns Full API endpoint URL
- */
-export const getTestConnectionUrl = (provider: string) => `${API_BASE_URL}/config/test/${provider}`;
-
-/**
- * Get API endpoint for provider model selection
- * @param provider - The provider name (e.g., 'openai', 'anthropic')
- * @returns Full API endpoint URL
- */
-export const getModelUrl = (provider: string) => `${API_BASE_URL}/config/model/${provider}`;
+export const getApiConfigProviderUrl = (): string => `${apiBaseUrl}/config/provider`;
+export const getApiKeyUrl = (provider: string): string => `${apiBaseUrl}/config/key/${provider}`;
+export const getTestConnectionUrl = (provider: string): string =>
+	`${apiBaseUrl}/config/test/${provider}`;
+export const getModelUrl = (provider: string): string => `${apiBaseUrl}/config/model/${provider}`;

--- a/client/src/core/state/slices/settingsStore.ts
+++ b/client/src/core/state/slices/settingsStore.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
 import {
-	API_CONFIG_PROVIDER_URL,
 	getApiKeyUrl,
 	getModelUrl,
+	getApiConfigProviderUrl,
 	getTestConnectionUrl,
 } from "@/constants/urls";
 import { DEFAULT_MODEL_BY_PROVIDER, LLM_MODELS } from "@/constants/llmModels";
@@ -59,7 +59,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
 		set({ isLoading: true, error: null });
 		try {
 			// Fetch active provider
-			const providerRes = await fetch(API_CONFIG_PROVIDER_URL);
+			const providerRes = await fetch(getApiConfigProviderUrl());
 			if (!providerRes.ok) throw new Error("Failed to fetch active provider");
 			const { provider } = await providerRes.json();
 
@@ -114,7 +114,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
 	setActiveProvider: async (provider: string) => {
 		set({ isLoading: true, error: null });
 		try {
-			const res = await fetch(API_CONFIG_PROVIDER_URL, {
+			const res = await fetch(getApiConfigProviderUrl(), {
 				method: "PUT",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ provider }),

--- a/client/src/hooks/useSocketConnection.ts
+++ b/client/src/hooks/useSocketConnection.ts
@@ -1,6 +1,36 @@
 import { useEffect } from "react";
+import { setApiBaseUrl } from "@/constants/urls";
 import { useStore } from "@/core";
 import { socketService } from "@/services/socket";
+
+const isTauriAvailable =
+	typeof window !== "undefined" &&
+	Boolean(
+		(
+			window as typeof window & {
+				__TAURI__?: unknown;
+				__TAURI_IPC__?: unknown;
+				__TAURI_INTERNALS__?: unknown;
+			}
+		).__TAURI__ ||
+			(window as typeof window & { __TAURI_IPC__?: unknown }).__TAURI_IPC__ ||
+			(window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__,
+	);
+
+async function resolveServerPort(): Promise<number> {
+	if (!isTauriAvailable) {
+		return 3001;
+	}
+
+	try {
+		const { invoke } = await import("@tauri-apps/api/core");
+		const port = await invoke<number>("get_server_port");
+		return port;
+	} catch (error) {
+		console.error("Failed to resolve server port from Tauri, falling back to default", error);
+		return 3001;
+	}
+}
 
 /**
  * Establishes and tracks the lifecycle of the shared WebSocket connection.
@@ -13,18 +43,34 @@ export function useSocketConnection(): void {
 	const setConnected = useStore((state) => state.setConnected);
 
 	useEffect(() => {
-		socketService.connect();
+		let unsub: (() => void) | null = null;
+		let disposed = false;
 
-		if (socketService.isConnected()) {
-			setConnected(true);
-		}
+		const bootstrap = async () => {
+			const port = await resolveServerPort();
+			if (disposed) return;
 
-		const unsubscribe = socketService.onConnectionChange((status) => {
-			setConnected(status === "connected");
-		});
+			socketService.setPort(port);
+			setApiBaseUrl(`http://127.0.0.1:${port}/api`);
+			socketService.connect();
+
+			if (socketService.isConnected()) {
+				setConnected(true);
+			}
+
+			unsub = socketService.onConnectionChange((status) => {
+				setConnected(status === "connected");
+			});
+		};
+
+		void bootstrap();
 
 		return () => {
-			unsubscribe();
+			disposed = true;
+			if (unsub) {
+				unsub();
+				unsub = null;
+			}
 			socketService.disconnect();
 		};
 	}, [setConnected]);

--- a/client/src/services/socket.ts
+++ b/client/src/services/socket.ts
@@ -21,9 +21,14 @@ class SocketService {
 	private autoReconnectEnabled = true;
 	private intentionalDisconnect = false;
 	private url: string = "";
+	private port = 3001;
 	private connectionListeners: Set<(status: ConnectionStatus) => void> = new Set();
 
-	connect(url: string = "ws://localhost:3001/ws"): void {
+	setPort(port: number): void {
+		this.port = port;
+	}
+
+	connect(url?: string): void {
 		// Prevent duplicate connections
 		if (this.ws) {
 			if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
@@ -32,8 +37,9 @@ class SocketService {
 		}
 
 		this.intentionalDisconnect = false;
-		this.url = url;
-		this.ws = new WebSocket(url);
+		const target = url ?? `ws://127.0.0.1:${this.port}/ws`;
+		this.url = target;
+		this.ws = new WebSocket(target);
 
 		this.ws.onopen = () => {
 			this.clearReconnectTimer();

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -17,6 +17,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
+reqwest = { workspace = true }
 tauri-plugin-pty = "0.1.1"
 
 [features]

--- a/desktop/build-server-runner.js
+++ b/desktop/build-server-runner.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const path = require("node:path");
+
+// Resolve script relative to this file so it works regardless of CWD.
+const target = path.join(__dirname, "scripts", "build-server.js");
+require(target);

--- a/desktop/build.rs
+++ b/desktop/build.rs
@@ -1,3 +1,32 @@
+use std::{env, fs, path::PathBuf};
+
+fn ensure_sidecar_placeholder() {
+    let triple = env::var("TAURI_ENV_TARGET_TRIPLE")
+        .ok()
+        .or_else(|| env::var("TARGET").ok());
+
+    #[cfg(target_os = "windows")]
+    let ext = ".exe";
+    #[cfg(not(target_os = "windows"))]
+    let ext = "";
+
+    let base = "reprod-server";
+    let filename = match triple {
+        Some(t) if !t.is_empty() => format!("{base}-{t}{ext}"),
+        _ => format!("{base}{ext}"),
+    };
+
+    let path: PathBuf = ["binaries", &filename].iter().collect();
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        // Placeholder will be replaced by build-server script during bundling.
+        let _ = fs::write(&path, b"");
+    }
+}
+
 fn main() {
+    ensure_sidecar_placeholder();
     tauri_build::build()
 }

--- a/desktop/e2e/build-server-runner.js
+++ b/desktop/e2e/build-server-runner.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// Delegate to the root desktop runner so beforeBuildCommand works regardless of CWD.
+require("../build-server-runner");

--- a/desktop/scripts/build-server.js
+++ b/desktop/scripts/build-server.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+const { copyFileSync, existsSync, mkdirSync } = require("node:fs");
+const { execSync } = require("node:child_process");
+const path = require("node:path");
+
+function detectTargetTriple() {
+	const fromEnv =
+		process.env.TAURI_ENV_TARGET_TRIPLE ||
+		process.env.TAURI_TARGET_TRIPLE ||
+		process.env.TAURI_TARGET ||
+		process.env.CARGO_BUILD_TARGET;
+	if (fromEnv) return fromEnv;
+
+	const platform = process.env.TAURI_PLATFORM || process.platform;
+	const arch = process.env.TAURI_ARCH || process.arch;
+
+	if (platform === "darwin") {
+		return arch === "arm64" ? "aarch64-apple-darwin" : "x86_64-apple-darwin";
+	}
+	if (platform === "linux") {
+		return "x86_64-unknown-linux-gnu";
+	}
+	if (platform === "win32" || platform === "windows") {
+		return "x86_64-pc-windows-msvc";
+	}
+
+	return null;
+}
+
+function main() {
+	const triple = detectTargetTriple();
+	const targetArg = triple ? `--target ${triple}` : "";
+	const binaryName =
+		process.platform === "win32" || process.platform === "windows"
+			? "reprod-server.exe"
+			: "reprod-server";
+
+	const workspaceRoot = path.join(__dirname, "..", "..");
+	const buildCmd = `cargo build --release -p reprod-server ${targetArg}`.trim();
+	console.log(`[build-server] running: ${buildCmd}`);
+	execSync(buildCmd, { stdio: "inherit", cwd: workspaceRoot });
+
+	const builtPath = triple
+		? path.join(workspaceRoot, "target", triple, "release", binaryName)
+		: path.join(workspaceRoot, "target", "release", binaryName);
+
+	if (!existsSync(builtPath)) {
+		throw new Error(`[build-server] built binary not found at ${builtPath}`);
+	}
+
+	const destDir = path.join(__dirname, "..", "binaries");
+	mkdirSync(destDir, { recursive: true });
+	const destPath = path.join(destDir, binaryName);
+	copyFileSync(builtPath, destPath);
+
+	// Also write a target-suffixed name so Tauri can resolve per-target binaries.
+	if (triple) {
+		const ext = binaryName.endsWith(".exe") ? ".exe" : "";
+		const base = ext ? binaryName.replace(/\.exe$/, "") : binaryName;
+		const suffixed = path.join(destDir, `${base}-${triple}${ext}`);
+		copyFileSync(builtPath, suffixed);
+		console.log(`[build-server] copied ${builtPath} -> ${destPath} and ${suffixed}`);
+	} else {
+		console.log(`[build-server] copied ${builtPath} -> ${destPath}`);
+	}
+}
+
+main();

--- a/desktop/src/commands/mod.rs
+++ b/desktop/src/commands/mod.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 use tokio::sync::{mpsc, Mutex};
 
-use crate::terminal::{TerminalEvent, TerminalManager};
+use crate::{
+    server_launcher::SharedServerHandle,
+    terminal::{TerminalEvent, TerminalManager},
+};
 
 #[derive(Serialize, Clone)]
 struct TerminalOutputPayload {
@@ -208,4 +211,12 @@ pub async fn close_terminal_session(
         .close(&session_id)
         .await
         .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn get_server_port(
+    server: State<'_, SharedServerHandle>,
+) -> Result<u16, String> {
+    let server = server.lock().await;
+    Ok(server.port())
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -3,9 +3,10 @@
 #![allow(clippy::expect_used)]
 
 mod commands;
+mod server_launcher;
 mod terminal;
 
-use crate::terminal::TerminalManager;
+use crate::{server_launcher::launch_server, terminal::TerminalManager};
 use reprod_core::{Config, RExecutor};
 use std::sync::Arc;
 use tauri_plugin_pty;
@@ -27,13 +28,19 @@ async fn main() {
 
     let r_executor = Arc::new(Mutex::new(RExecutor::new(temp_dir, config.r_path.clone())));
     let terminal_manager = Arc::new(TerminalManager::new());
-
     let config_state = Arc::new(Mutex::new(config));
 
-    tauri::Builder::default()
+    // Start the bundled Axum server as a sidecar so the frontend can connect.
+    let server_handle = launch_server()
+        .await
+        .unwrap_or_else(|err| panic!("Failed to launch bundled server: {}", err));
+    let server_state = Arc::new(Mutex::new(server_handle));
+
+    let app = tauri::Builder::default()
         .manage(r_executor)
         .manage(terminal_manager)
         .manage(config_state)
+        .manage(server_state.clone())
         .plugin(tauri_plugin_pty::init())
         .invoke_handler(tauri::generate_handler![
             commands::execute_r_code,
@@ -44,7 +51,20 @@ async fn main() {
             commands::write_to_terminal,
             commands::resize_terminal,
             commands::close_terminal_session,
+            commands::get_server_port,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    let server_for_shutdown = server_state.clone();
+
+    app.run(move |_app_handle, event| {
+        if matches!(event, tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit) {
+            let server_for_shutdown = server_for_shutdown.clone();
+            tauri::async_runtime::spawn(async move {
+                let mut guard = server_for_shutdown.lock().await;
+                guard.shutdown().await;
+            });
+        }
+    });
 }

--- a/desktop/src/server_launcher.rs
+++ b/desktop/src/server_launcher.rs
@@ -1,0 +1,149 @@
+use std::{
+    env,
+    net::TcpListener,
+    path::{Path, PathBuf},
+    process::{Child, Command},
+    time::{Duration, Instant},
+};
+
+use reqwest::StatusCode;
+use thiserror::Error;
+use tokio::time::sleep;
+
+pub type SharedServerHandle = std::sync::Arc<tokio::sync::Mutex<ServerHandle>>;
+
+#[derive(Debug, Error)]
+pub enum ServerLaunchError {
+    #[error("failed to locate server binary at {0}")]
+    MissingBinary(String),
+    #[error("failed to spawn server process: {0}")]
+    SpawnFailed(String),
+    #[error("server failed to start within timeout")]
+    StartupTimeout,
+}
+
+pub struct ServerHandle {
+    child: Child,
+    port: u16,
+}
+
+impl ServerHandle {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub async fn shutdown(&mut self) {
+        // Try a graceful kill and give the process time to exit.
+        let _ = self.child.kill();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            if let Ok(Some(_)) = self.child.try_wait() {
+                return;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for ServerHandle {
+    fn drop(&mut self) {
+        // Best-effort synchronous shutdown for when async drop is unavailable.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn find_available_port() -> u16 {
+    // Prefer stable ports first for easier debugging, then fall back to OS-assigned.
+    for port in [3001_u16, 3002_u16, 3003_u16] {
+        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return port;
+        }
+    }
+
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+        .unwrap_or(3001)
+}
+
+fn server_binary_path() -> Option<PathBuf> {
+    if let Ok(custom) = env::var("REPROD_SERVER_PATH") {
+        let path = PathBuf::from(custom);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|parent| parent.to_path_buf()))
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    #[cfg(target_os = "windows")]
+    let binary_name = "reprod-server.exe";
+    #[cfg(not(target_os = "windows"))]
+    let binary_name = "reprod-server";
+
+    // When bundled, the sidecar is placed alongside the main binary.
+    let sidecar = exe_dir.join(binary_name);
+    if sidecar.exists() {
+        return Some(sidecar);
+    }
+
+    // Fallback: use workspace target for dev builds (`cargo tauri dev`).
+    let workspace_target = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("target")
+        .join("release")
+        .join(binary_name);
+    if workspace_target.exists() {
+        return Some(workspace_target);
+    }
+
+    None
+}
+
+async fn wait_for_server_health(port: u16, timeout: Duration) -> Result<(), ServerLaunchError> {
+    let url = format!("http://127.0.0.1:{}/health", port);
+    let start = Instant::now();
+    let client = reqwest::Client::new();
+
+    while start.elapsed() < timeout {
+        match client.get(&url).send().await {
+            Ok(resp) if resp.status() == StatusCode::OK => return Ok(()),
+            _ => sleep(Duration::from_millis(150)).await,
+        }
+    }
+
+    Err(ServerLaunchError::StartupTimeout)
+}
+
+pub async fn launch_server() -> Result<ServerHandle, ServerLaunchError> {
+    let port = find_available_port();
+    let binary = server_binary_path().ok_or_else(|| ServerLaunchError::MissingBinary(
+        "reprod-server (sidecar) not found next to app or in target/release; set REPROD_SERVER_PATH to override".to_string(),
+    ))?;
+    if !Path::new(&binary).exists() {
+        return Err(ServerLaunchError::MissingBinary(
+            binary.display().to_string(),
+        ));
+    }
+
+    let mut child = Command::new(&binary)
+        .env("REPROD_PORT", port.to_string())
+        .spawn()
+        .map_err(|err| ServerLaunchError::SpawnFailed(err.to_string()))?;
+
+    if let Err(err) = wait_for_server_health(port, Duration::from_secs(10)).await {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(err);
+    }
+
+    Ok(ServerHandle { child, port })
+}

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -6,12 +6,13 @@
 	"build": {
 		"beforeDevCommand": "pnpm --dir .. --filter client dev",
 		"devUrl": "http://localhost:5173",
-		"beforeBuildCommand": "pnpm --dir .. --filter client build",
+		"beforeBuildCommand": "pnpm --dir .. --filter client build && node build-server-runner.js",
 		"frontendDist": "../client/dist"
 	},
 	"bundle": {
 		"active": true,
 		"targets": ["deb", "appimage", "rpm", "nsis", "dmg"],
+		"externalBin": ["binaries/reprod-server"],
 		"icon": [
 			"icons/icon-16x16.png",
 			"icons/icon-32x32.png",

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -97,8 +97,12 @@ async fn main() {
             projects: projects.clone(),
         });
 
-    let addr = "127.0.0.1:3001";
-    let listener = tokio::net::TcpListener::bind(addr)
+    let port = std::env::var("REPROD_PORT")
+        .ok()
+        .and_then(|val| val.parse::<u16>().ok())
+        .unwrap_or(3001);
+    let addr = format!("127.0.0.1:{}", port);
+    let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .unwrap_or_else(|e| panic!("Failed to bind to {}: {}", addr, e));
 


### PR DESCRIPTION
## Description
Bundle and launch the Axum backend as a Tauri sidecar with dynamic port selection, expose the port to the webview via IPC, and make the client derive API/WS URLs from that port. Include server binaries in desktop builds and add a build helper.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test`)  <!-- ran pre-push: biome format, cargo fmt/clippy, pnpm lint -->
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing
- `.husky/pre-push` (biome format check, cargo fmt --check, cargo clippy --lib --all-features, pnpm lint)
- `cargo tauri build --target aarch64-apple-darwin --bundles dmg` (reaches bundling; fails in bundle_dmg.sh)

## Screenshots (if applicable)
N/A

## Related Issues
Closes #179
