### PR TITLE
[WIP] Add welcome startup flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,16 +15,20 @@ import {
 	SettingsModal,
 } from "@/components/modals";
 import { TimelineDialog, type TimelineDialogRef } from "@/components/timeline";
+import { WelcomeScreen } from "@/components/welcome";
 import { useStore } from "@/core";
 import { useSettingsStore } from "@/core/state/slices/settingsStore";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useProjectSession } from "@/hooks/useProjectSession";
+import { useStartup } from "@/hooks/useStartup";
 import { usePlotHistoryEvents } from "@/hooks/usePlotHistoryEvents";
 import { useSessionControlEvents } from "@/hooks/useSessionControlEvents";
 import { useSettingsPersistence } from "@/hooks/useSettingsPersistence";
 import { useSocketConnection } from "@/hooks/useSocketConnection";
+import type { ProjectManagerSection } from "@/components/modals/ProjectManagerModal";
 
 function App(): JSX.Element {
+	const project = useStore((state) => state.project);
 	const panes = useStore((state) => state.view.panes);
 	const theme = useStore((state) => state.settings.theme);
 	const setAIPanelRef = useStore((state) => state.setAIPanelRef);
@@ -36,13 +40,21 @@ function App(): JSX.Element {
 	const [sessionInfoOpen, setSessionInfoOpen] = useState(false);
 	const [settingsOpen, setSettingsOpen] = useState(false);
 	const [projectManagerOpen, setProjectManagerOpen] = useState(false);
+	const [projectManagerSection, setProjectManagerSection] = useState<ProjectManagerSection | null>(
+		null,
+	);
 	const { fetchSettings, providers, activeProvider } = useSettingsStore();
+	const { showWelcome, setShowWelcome } = useStartup();
 
 	const activeProviderConfig = providers.find((provider) => provider.name === activeProvider);
 	const isActiveProviderConfigured = Boolean(activeProviderConfig?.isConfigured);
 	const activeProviderLabel = activeProviderConfig?.displayName || activeProvider || "AI provider";
 
 	const openSettings = () => setSettingsOpen(true);
+	const openProjectsDialog = (section?: ProjectManagerSection) => {
+		setProjectManagerSection(section ?? null);
+		setProjectManagerOpen(true);
+	};
 
 	// Enable global keyboard shortcuts
 	useKeyboardShortcuts();
@@ -75,7 +87,8 @@ function App(): JSX.Element {
 		globalScope.openAboutDialog = () => setAboutOpen(true);
 		globalScope.openSessionInfoDialog = () => setSessionInfoOpen(true);
 		globalScope.openSettingsDialog = () => openSettings();
-		globalScope.openProjectsDialog = () => setProjectManagerOpen(true);
+		globalScope.openProjectsDialog = () => openProjectsDialog();
+		globalScope.openWelcomeScreen = () => setShowWelcome(true);
 
 		return () => {
 			delete globalScope.openExportDialog;
@@ -84,56 +97,79 @@ function App(): JSX.Element {
 			delete globalScope.openSessionInfoDialog;
 			delete globalScope.openSettingsDialog;
 			delete globalScope.openProjectsDialog;
+			delete globalScope.openWelcomeScreen;
 		};
-	}, []);
+	}, [setShowWelcome]);
+
+	const shouldShowWelcome = showWelcome || !project;
+	const appClassName = shouldShowWelcome ? "app app--welcome" : "app";
 
 	return (
-		<div className="app">
-			<MenuBar />
-			<div className="workspace-shell">
-				<Allotment>
-					{panes.files && (
-						<Allotment.Pane minSize={220} preferredSize={240}>
-							<FileBrowserPane />
-						</Allotment.Pane>
-					)}
-					{/* Left side: Editor + Bottom Pane */}
-					<Allotment.Pane minSize={400} preferredSize="75%">
-						<Allotment vertical>
-							{panes.editor && (
-								<Allotment.Pane minSize={300} preferredSize="65%">
-									<EditorPanel />
+		<div className={appClassName}>
+			{shouldShowWelcome ? (
+				<WelcomeScreen
+					onOpenFolder={() => openProjectsDialog("add_existing")}
+					onCreateProject={() => openProjectsDialog("create")}
+					onCloneProject={() => openProjectsDialog("clone")}
+					onSetupApiKeys={openSettings}
+					onClose={project ? () => setShowWelcome(false) : undefined}
+				/>
+			) : (
+				<>
+					<MenuBar />
+					<div className="workspace-shell">
+						<Allotment>
+							{panes.files && (
+								<Allotment.Pane minSize={220} preferredSize={240}>
+									<FileBrowserPane />
 								</Allotment.Pane>
 							)}
-							<Allotment.Pane minSize={150} preferredSize={panes.editor ? "35%" : "100%"}>
-								<BottomPane />
+							{/* Left side: Editor + Bottom Pane */}
+							<Allotment.Pane minSize={400} preferredSize="75%">
+								<Allotment vertical>
+									{panes.editor && (
+										<Allotment.Pane minSize={300} preferredSize="65%">
+											<EditorPanel />
+										</Allotment.Pane>
+									)}
+									<Allotment.Pane minSize={150} preferredSize={panes.editor ? "35%" : "100%"}>
+										<BottomPane />
+									</Allotment.Pane>
+								</Allotment>
 							</Allotment.Pane>
+							{/* Right side: AI Assistant (full height) */}
+							{panes.assistant && (
+								<Allotment.Pane minSize={260} preferredSize="25%">
+									<div className="ai-pane-wrapper">
+										<AIPanel
+											ref={setAIPanelRef}
+											onOpenSettings={openSettings}
+											onRequireApiKeys={handleRequireApiKeys}
+											hasConfiguredProvider={isActiveProviderConfigured}
+											activeProviderLabel={activeProviderLabel}
+										/>
+									</div>
+								</Allotment.Pane>
+							)}
 						</Allotment>
-					</Allotment.Pane>
-					{/* Right side: AI Assistant (full height) */}
-					{panes.assistant && (
-						<Allotment.Pane minSize={260} preferredSize="25%">
-							<div className="ai-pane-wrapper">
-								<AIPanel
-									ref={setAIPanelRef}
-									onOpenSettings={openSettings}
-									onRequireApiKeys={handleRequireApiKeys}
-									hasConfiguredProvider={isActiveProviderConfigured}
-									activeProviderLabel={activeProviderLabel}
-								/>
-							</div>
-						</Allotment.Pane>
-					)}
-				</Allotment>
-			</div>
-			<StatusBar onOpenSettings={openSettings} />
+					</div>
+					<StatusBar onOpenSettings={openSettings} />
+				</>
+			)}
 			<ExportDialog open={exportDialogOpen} onClose={() => setExportDialogOpen(false)} />
 			<TimelineDialog ref={timelineDialogRef} />
 			<KeyboardShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
 			<AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
 			<SessionInfoModal open={sessionInfoOpen} onClose={() => setSessionInfoOpen(false)} />
 			<SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
-			<ProjectManagerModal open={projectManagerOpen} onClose={() => setProjectManagerOpen(false)} />
+			<ProjectManagerModal
+				open={projectManagerOpen}
+				onClose={() => {
+					setProjectManagerOpen(false);
+					setProjectManagerSection(null);
+				}}
+				initialSection={projectManagerSection ?? undefined}
+			/>
 		</div>
 	);
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,18 +14,18 @@ import {
 	SessionInfoModal,
 	SettingsModal,
 } from "@/components/modals";
+import type { ProjectManagerSection } from "@/components/modals/ProjectManagerModal";
 import { TimelineDialog, type TimelineDialogRef } from "@/components/timeline";
 import { WelcomeScreen } from "@/components/welcome";
 import { useStore } from "@/core";
 import { useSettingsStore } from "@/core/state/slices/settingsStore";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
-import { useProjectSession } from "@/hooks/useProjectSession";
-import { useStartup } from "@/hooks/useStartup";
 import { usePlotHistoryEvents } from "@/hooks/usePlotHistoryEvents";
+import { useProjectSession } from "@/hooks/useProjectSession";
 import { useSessionControlEvents } from "@/hooks/useSessionControlEvents";
 import { useSettingsPersistence } from "@/hooks/useSettingsPersistence";
 import { useSocketConnection } from "@/hooks/useSocketConnection";
-import type { ProjectManagerSection } from "@/components/modals/ProjectManagerModal";
+import { useStartup } from "@/hooks/useStartup";
 
 function App(): JSX.Element {
 	const project = useStore((state) => state.project);

--- a/client/src/components/bottom-pane/BottomPane.tsx
+++ b/client/src/components/bottom-pane/BottomPane.tsx
@@ -1,7 +1,7 @@
 import { ConsolePanel } from "@/components/console";
+import { PlotHistoryPanel } from "@/components/plot-history";
 import { IconChevronLeft, IconChevronRight, IconTrash, PanelTabs } from "@/components/shared";
 import { TerminalPane } from "@/components/Terminal";
-import { PlotHistoryPanel } from "@/components/plot-history";
 import { useBottomPaneState } from "@/hooks/useBottomPaneState";
 
 export function BottomPane(): JSX.Element {

--- a/client/src/components/console/ConsolePanel.tsx
+++ b/client/src/components/console/ConsolePanel.tsx
@@ -1,8 +1,8 @@
 import { IconBarChart, IconCheckCircle, IconXCircle } from "@/components/shared";
 import { useConsolePanelState } from "@/hooks/useConsolePanelState";
 import { clearPlotHistory } from "@/services/plotHistoryService";
-import { formatClockTime } from "@/utils/time";
 import type { ConsoleTabId } from "@/types/panels";
+import { formatClockTime } from "@/utils/time";
 
 interface ConsolePanelProps {
 	view: ConsoleTabId;

--- a/client/src/components/export/__tests__/ExportDialog.test.tsx
+++ b/client/src/components/export/__tests__/ExportDialog.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
-import { ExportDialog } from "../ExportDialog";
 import { socketService } from "@/services/socket";
+import { ExportDialog } from "../ExportDialog";
 
 describe("ExportDialog", () => {
 	afterEach(() => {

--- a/client/src/components/modals/ProjectManagerModal.tsx
+++ b/client/src/components/modals/ProjectManagerModal.tsx
@@ -1,18 +1,22 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useStore } from "@/core";
 import { persistCurrentProjectState } from "@/hooks/useProjectSession";
 import { projectService } from "@/services/projectService";
 import { ModalShell } from "./ModalShell";
 
+export type ProjectManagerSection = "create" | "clone" | "add_existing";
+
 interface ProjectManagerModalProps {
 	open: boolean;
 	onClose: () => void;
+	initialSection?: ProjectManagerSection;
 }
 
 export function ProjectManagerModal({
 	open,
 	onClose,
+	initialSection,
 }: ProjectManagerModalProps): JSX.Element | null {
 	const currentProject = useStore((state) => state.project);
 	const [newProjectName, setNewProjectName] = useState("New Project");
@@ -20,7 +24,14 @@ export function ProjectManagerModal({
 	const [cloneRemote, setCloneRemote] = useState("");
 	const [clonePath, setClonePath] = useState("");
 	const [cloneName, setCloneName] = useState("");
+	const [existingProjectPath, setExistingProjectPath] = useState("");
 	const [error, setError] = useState<string | null>(null);
+	const createSectionRef = useRef<HTMLDivElement | null>(null);
+	const cloneSectionRef = useRef<HTMLDivElement | null>(null);
+	const addExistingSectionRef = useRef<HTMLDivElement | null>(null);
+	const createPathRef = useRef<HTMLInputElement | null>(null);
+	const clonePathRef = useRef<HTMLInputElement | null>(null);
+	const addExistingInputRef = useRef<HTMLInputElement | null>(null);
 
 	if (!open) {
 		return null;
@@ -60,6 +71,38 @@ export function ProjectManagerModal({
 		});
 	};
 
+	const handleAddExisting = () => {
+		if (!existingProjectPath.trim()) {
+			setError("Folder path is required.");
+			return;
+		}
+		setError(null);
+		persistCurrentProjectState();
+		projectService.addExisting(existingProjectPath.trim());
+	};
+
+	useEffect(() => {
+		if (!open || !initialSection) return;
+
+		const targetRef =
+			initialSection === "create"
+				? createSectionRef
+				: initialSection === "clone"
+					? cloneSectionRef
+					: addExistingSectionRef;
+		targetRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+
+		if (initialSection === "create") {
+			createPathRef.current?.focus();
+		}
+		if (initialSection === "clone") {
+			clonePathRef.current?.focus();
+		}
+		if (initialSection === "add_existing") {
+			addExistingInputRef.current?.focus();
+		}
+	}, [initialSection, open]);
+
 	return (
 		<ModalShell
 			open={open}
@@ -91,7 +134,26 @@ export function ProjectManagerModal({
 					)}
 				</section>
 
-				<section className="project-manager-section">
+				<section ref={addExistingSectionRef} className="project-manager-section">
+					<h3>Open Existing Folder</h3>
+					<div className="form-grid">
+						<label>
+							Directory Path
+							<input
+								ref={addExistingInputRef}
+								type="text"
+								placeholder="/path/to/project"
+								value={existingProjectPath}
+								onChange={(event) => setExistingProjectPath(event.target.value)}
+							/>
+						</label>
+					</div>
+					<button type="button" className="btn btn-secondary" onClick={handleAddExisting}>
+						Open Folder
+					</button>
+				</section>
+
+				<section ref={createSectionRef} className="project-manager-section">
 					<h3>Create New Project</h3>
 					<div className="form-grid">
 						<label>
@@ -105,6 +167,7 @@ export function ProjectManagerModal({
 						<label>
 							Directory Path
 							<input
+								ref={createPathRef}
 								type="text"
 								placeholder="/path/to/project"
 								value={newProjectPath}
@@ -132,6 +195,7 @@ export function ProjectManagerModal({
 						<label>
 							Destination Path
 							<input
+								ref={clonePathRef}
 								type="text"
 								placeholder="/path/to/clone"
 								value={clonePath}

--- a/client/src/components/welcome/WelcomeScreen.tsx
+++ b/client/src/components/welcome/WelcomeScreen.tsx
@@ -1,0 +1,80 @@
+type WelcomeScreenProps = {
+	onOpenFolder: () => void;
+	onCreateProject: () => void;
+	onCloneProject: () => void;
+	onSetupApiKeys: () => void;
+	onClose?: () => void;
+};
+
+export function WelcomeScreen({
+	onOpenFolder,
+	onCreateProject,
+	onCloneProject,
+	onSetupApiKeys,
+	onClose,
+}: WelcomeScreenProps): JSX.Element {
+	return (
+		<div className="welcome-screen">
+			<div className="welcome-surface">
+				<header className="welcome-header">
+					<div className="welcome-header-top">
+						<div className="welcome-pill">Re-prod</div>
+						{onClose ? (
+							<button type="button" className="welcome-close" onClick={onClose}>
+								Return to workspace
+							</button>
+						) : null}
+					</div>
+					<h1>Reproducible research, zero guesswork.</h1>
+					<p>
+						Start from a project so timelines, plots, and AI context stay in sync. Choose how you
+						want to get going:
+					</p>
+				</header>
+
+				<div className="welcome-grid">
+					<section className="welcome-card">
+						<div className="welcome-card-header">
+							<div>
+								<h2>Get started</h2>
+								<p>Pick a workspace to unlock the timeline, plots, and AI tools.</p>
+							</div>
+						</div>
+						<div className="welcome-actions">
+							<button type="button" className="btn btn-primary" onClick={onOpenFolder}>
+								Open Existing Folder
+							</button>
+							<button type="button" className="btn btn-secondary" onClick={onCreateProject}>
+								Create New Project
+							</button>
+							<button type="button" className="btn btn-outline" onClick={onCloneProject}>
+								Clone from Git
+							</button>
+						</div>
+					</section>
+
+					<section className="welcome-card">
+						<div className="welcome-card-header">
+							<div>
+								<h2>Configure</h2>
+								<p>Connect AI providers before you start chatting or patching code.</p>
+							</div>
+						</div>
+						<div className="welcome-actions">
+							<button type="button" className="btn btn-outline" onClick={onSetupApiKeys}>
+								Setup API Keys
+							</button>
+						</div>
+						<ul className="welcome-list">
+							<li>
+								Timeline saves to <code>.reprod/timeline.ndjson</code>
+							</li>
+							<li>Plots and exports live inside your project folder</li>
+							<li>AI suggestions stay aware of your project files</li>
+						</ul>
+					</section>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/src/components/welcome/index.ts
+++ b/client/src/components/welcome/index.ts
@@ -1,0 +1,1 @@
+export { WelcomeScreen } from "./WelcomeScreen";

--- a/client/src/core/menu/menuConfig.ts
+++ b/client/src/core/menu/menuConfig.ts
@@ -256,6 +256,11 @@ export function buildMenuSections(snapshot: MenuStateSnapshot): MenuSection[] {
 					action: () => menuActions.help.docs(),
 				},
 				{
+					id: "help:welcome",
+					label: "Show Welcome",
+					action: () => menuActions.help.welcome(),
+				},
+				{
 					id: "help:shortcuts",
 					label: "Keyboard Shortcuts",
 					action: () => menuActions.help.shortcuts(),

--- a/client/src/core/state/slices/settingsStore.ts
+++ b/client/src/core/state/slices/settingsStore.ts
@@ -1,11 +1,11 @@
 import { create } from "zustand";
+import { DEFAULT_MODEL_BY_PROVIDER, LLM_MODELS } from "@/constants/llmModels";
 import {
+	getApiConfigProviderUrl,
 	getApiKeyUrl,
 	getModelUrl,
-	getApiConfigProviderUrl,
 	getTestConnectionUrl,
 } from "@/constants/urls";
-import { DEFAULT_MODEL_BY_PROVIDER, LLM_MODELS } from "@/constants/llmModels";
 
 interface Provider {
 	name: string;

--- a/client/src/css/components/layout.css
+++ b/client/src/css/components/layout.css
@@ -9,6 +9,10 @@
 	overflow: hidden;
 }
 
+.app.app--welcome {
+	padding: 0;
+}
+
 .workspace-shell {
 	flex: 1;
 	min-height: 0;

--- a/client/src/css/components/welcome.css
+++ b/client/src/css/components/welcome.css
@@ -1,0 +1,132 @@
+.welcome-screen {
+	min-height: 100vh;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 48px 28px;
+	background: linear-gradient(135deg, #0f1f3d, #0f2d2f);
+}
+
+.welcome-surface {
+	width: min(1100px, 100%);
+	background: var(--bg-primary);
+	border: 1px solid #d5dae1;
+	border-radius: 14px;
+	box-shadow: 0 18px 35px rgba(5, 15, 44, 0.16);
+	padding: 36px;
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+}
+
+.welcome-header {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.welcome-header-top {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.welcome-header h1 {
+	font-size: 28px;
+	font-weight: 700;
+	color: #0d1a33;
+}
+
+.welcome-header p {
+	color: var(--text-muted);
+	max-width: 720px;
+}
+
+.welcome-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 12px;
+	border-radius: 999px;
+	background: linear-gradient(120deg, #25a18e, #2f65d9);
+	color: #ffffff;
+	font-size: 12px;
+	font-weight: 600;
+	width: fit-content;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+
+.welcome-close {
+	border: 1px solid #c8d0de;
+	border-radius: 8px;
+	background: #f4f6fb;
+	color: #0d1a33;
+	padding: 8px 12px;
+	font-weight: 600;
+	transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.welcome-close:hover {
+	background: #e6ebf5;
+	border-color: #aeb8ca;
+}
+
+.welcome-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+	gap: 16px;
+}
+
+.welcome-card {
+	background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
+	border: 1px solid #d5dae1;
+	border-radius: 10px;
+	padding: 18px 18px 14px;
+	box-shadow: 0 8px 22px rgba(13, 26, 51, 0.06);
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.welcome-card-header {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+}
+
+.welcome-card h2 {
+	margin: 0;
+	font-size: 18px;
+	color: #0d1a33;
+}
+
+.welcome-card p {
+	margin: 0;
+	color: var(--text-muted);
+}
+
+.welcome-actions {
+	display: grid;
+	gap: 10px;
+}
+
+.welcome-actions .btn {
+	justify-content: flex-start;
+	width: 100%;
+}
+
+.welcome-list {
+	margin: 8px 0 0;
+	padding-left: 18px;
+	color: var(--text-muted);
+	display: grid;
+	gap: 6px;
+}
+
+.welcome-list code {
+	background: #f2f5f9;
+	padding: 2px 6px;
+	border-radius: 4px;
+}

--- a/client/src/css/components/welcome.css
+++ b/client/src/css/components/welcome.css
@@ -65,7 +65,9 @@
 	color: #0d1a33;
 	padding: 8px 12px;
 	font-weight: 600;
-	transition: background 0.2s ease, border-color 0.2s ease;
+	transition:
+		background 0.2s ease,
+		border-color 0.2s ease;
 }
 
 .welcome-close:hover {

--- a/client/src/css/index.css
+++ b/client/src/css/index.css
@@ -17,6 +17,7 @@
 @import "./components/export-dialog.css";
 @import "./components/confirm-dialog.css";
 @import "./components/modal-dialog.css";
+@import "./components/welcome.css";
 
 /* Design themes */
 @import "./design-phylo-rstudio.css";

--- a/client/src/hooks/useExportDialog.ts
+++ b/client/src/hooks/useExportDialog.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useReducer } from "react";
-import { exportRMarkdown, ExportServiceError } from "@/services/exportService";
-import { adjustOutputPathForFormat, exportDialogInitialState } from "@/types/exportDialog";
+import type { CodeFolding, ExportRMarkdownRequestPayload } from "shared";
+import { ExportServiceError, exportRMarkdown } from "@/services/exportService";
 import type {
 	ExportDialogAction,
 	ExportDialogOptions,
@@ -10,7 +10,7 @@ import type {
 	ExportPdfOptionKey,
 	ExportPdfOptions,
 } from "@/types/exportDialog";
-import type { CodeFolding, ExportRMarkdownRequestPayload } from "shared";
+import { adjustOutputPathForFormat, exportDialogInitialState } from "@/types/exportDialog";
 
 function reducer(state: ExportDialogState, action: ExportDialogAction): ExportDialogState {
 	switch (action.type) {

--- a/client/src/hooks/useProjectSession.ts
+++ b/client/src/hooks/useProjectSession.ts
@@ -3,13 +3,13 @@ import type { ProjectRecord } from "shared";
 
 import { useStore } from "@/core";
 import { DEFAULT_R_SCRIPT } from "@/core/state/slices/editorSlice";
+import { requestPlotHistory } from "@/services/plotHistoryService";
 import { projectService } from "@/services/projectService";
 import {
 	applySessionSnapshot,
 	getSessionSnapshot,
 	refreshTimelineData,
 } from "@/services/sessionPersistence";
-import { requestPlotHistory } from "@/services/plotHistoryService";
 import { socketService } from "@/services/socket";
 
 function resetWorkspace(options: { useSample?: boolean } = {}): void {

--- a/client/src/hooks/useStartup.ts
+++ b/client/src/hooks/useStartup.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
+import type { ServerMessage } from "shared";
 import { useStore } from "@/core";
 import { socketService } from "@/services/socket";
-import type { ServerMessage } from "shared";
 
 export function useStartup(): {
 	showWelcome: boolean;

--- a/client/src/hooks/useStartup.ts
+++ b/client/src/hooks/useStartup.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from "react";
+import { useStore } from "@/core";
+import { socketService } from "@/services/socket";
+import type { ServerMessage } from "shared";
+
+export function useStartup(): {
+	showWelcome: boolean;
+	setShowWelcome: (value: boolean) => void;
+	requestStartupAction: () => void;
+} {
+	const project = useStore((state) => state.project);
+	const [showWelcome, setShowWelcome] = useState(false);
+
+	const requestStartupAction = useCallback(() => {
+		socketService.send({ type: "get_startup_action" });
+	}, []);
+
+	useEffect(() => {
+		const handleStartup = (message: ServerMessage) => {
+			if (message.type !== "startup_action") {
+				return;
+			}
+			const payload = message as Extract<ServerMessage, { type: "startup_action" }>;
+			if (payload.action_type === "show_welcome") {
+				setShowWelcome(true);
+			}
+			if (payload.action_type === "open_project") {
+				setShowWelcome(false);
+			}
+		};
+
+		const offStartup = socketService.on("startup_action", handleStartup);
+		const unsubscribeConnection = socketService.onConnectionChange((status) => {
+			if (status === "connected") {
+				requestStartupAction();
+			}
+		});
+
+		if (socketService.isConnected()) {
+			requestStartupAction();
+		}
+
+		return () => {
+			offStartup();
+			unsubscribeConnection();
+		};
+	}, [requestStartupAction]);
+
+	useEffect(() => {
+		if (project) {
+			setShowWelcome(false);
+		}
+	}, [project]);
+
+	return { showWelcome, setShowWelcome, requestStartupAction };
+}

--- a/client/src/services/menuActions.ts
+++ b/client/src/services/menuActions.ts
@@ -11,8 +11,8 @@
  * with cell metadata, use EditorPanel's buttons or shortcuts.
  */
 
-import { DOCS_URL, GITHUB_ISSUE_URL } from "@/constants/urls";
 import { DEFAULT_FILENAMES, UI_TIMING, ZOOM } from "@/constants/ui";
+import { DOCS_URL, GITHUB_ISSUE_URL } from "@/constants/urls";
 import { DEFAULT_R_SCRIPT } from "@/core/state/slices/editorSlice";
 import type { ViewPane } from "@/core/state/slices/viewSlice";
 import { useStore } from "@/core/state/store";

--- a/client/src/services/menuActions.ts
+++ b/client/src/services/menuActions.ts
@@ -414,6 +414,10 @@ export const menuActions = {
 			window.open(DOCS_URL, "_blank");
 		},
 
+		welcome: () => {
+			callGlobalHandler("openWelcomeScreen");
+		},
+
 		/**
 		 * Show keyboard shortcuts modal
 		 * TODO: Implement shortcuts modal

--- a/client/src/services/plotHistoryService.ts
+++ b/client/src/services/plotHistoryService.ts
@@ -1,5 +1,4 @@
-import type { PlotHistoryStatePayload } from "shared";
-import type { ServerMessage } from "shared";
+import type { PlotHistoryStatePayload, ServerMessage } from "shared";
 import { socketService } from "./socket";
 
 const historyMatcher = (message: ServerMessage): boolean =>

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -64,7 +64,7 @@ impl Config {
 
         if let Some(legacy) = legacy_auth_path() {
             if legacy.exists() {
-                let config = Self::load_from_path(legacy.clone())?;
+                let config = Self::load_from_path(legacy)?;
                 // Migrate legacy → global path for future reads.
                 if let Some(parent) = global_path.parent() {
                     fs::create_dir_all(parent)?;

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -145,6 +145,8 @@ pub(super) enum WSRequest {
         #[serde(default)]
         to: Option<String>,
     },
+    #[serde(rename = "get_startup_action")]
+    StartupAction,
     #[serde(rename = "project_list")]
     ProjectList,
     #[serde(rename = "project_open")]
@@ -253,6 +255,12 @@ pub(super) enum WSResponse {
         data: Option<Value>,
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
+    },
+    #[serde(rename = "startup_action")]
+    StartupAction {
+        action_type: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        project_id: Option<String>,
     },
     #[serde(rename = "project_list")]
     ProjectList { projects: Vec<ProjectRecord> },

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -1,4 +1,4 @@
-use crate::projects::ProjectRuntime;
+use crate::projects::{ProjectRuntime, StartupAction};
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
@@ -8,9 +8,9 @@ use axum::{
 };
 use project_requests::handle_project_request;
 use reprod_core::{fs::FileSystemEvent, project::ProjectRecord, ExecutionRequest};
-use runtime_fs::{handle_fs_event, spawn_fs_watcher, FsWatcherHandle};
+use runtime_fs::{handle_fs_event, restart_fs_watcher, FsWatcherHandle};
 use serde_json::{self, json};
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 use tokio::sync::mpsc as tokio_mpsc;
 
 mod ai_handler;
@@ -36,31 +36,17 @@ use plot_history_handler::{
 use session_handler::{handle_interrupt, handle_restart};
 use timeline_handler::{handle_timeline_query, handle_timeline_stats_query};
 use tool_handler::{handle_execute_tool, handle_list_tools};
+use common::single_response;
 
 pub async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> Response {
     ws.on_upgrade(|socket| handle_socket(socket, state))
 }
 
 async fn handle_socket(mut socket: WebSocket, state: AppState) {
-    let mut current_runtime = match state.projects.default_runtime().await {
-        Ok(runtime) => runtime,
-        Err(error) => {
-            let _ = send_responses(&mut socket, error_response(error.to_string())).await;
-            return;
-        }
-    };
     let (fs_event_tx, mut fs_event_rx) = tokio_mpsc::unbounded_channel::<FileSystemEvent>();
-    let mut fs_watcher = Some(spawn_fs_watcher(
-        current_runtime.descriptor.root_path.clone(),
-        fs_event_tx.clone(),
-    ));
-    let mut fs_events_closed = false;
-
-    let _ = send_responses(
-        &mut socket,
-        vec![build_project_opened_response(&state, &current_runtime).await],
-    )
-    .await;
+    let mut current_runtime: Option<Arc<ProjectRuntime>> = None;
+    let mut fs_watcher: Option<FsWatcherHandle> = None;
+    let mut fs_events_closed = true;
 
     'ws_loop: loop {
         tokio::select! {
@@ -97,7 +83,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
 async fn handle_ws_text(
     msg: Option<Result<Message, axum::Error>>,
     state: &AppState,
-    current_runtime: &mut Arc<ProjectRuntime>,
+    current_runtime: &mut Option<Arc<ProjectRuntime>>,
     fs_watcher: &mut Option<FsWatcherHandle>,
     fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
     fs_events_closed: &mut bool,
@@ -120,7 +106,16 @@ async fn handle_ws_text(
                     return continue_loop;
                 }
 
-                let responses = handle_ws_request(request, state, current_runtime).await;
+                let responses = handle_ws_request(
+                    request,
+                    state,
+                    current_runtime.as_ref(),
+                    fs_watcher,
+                    fs_event_tx,
+                    fs_events_closed,
+                    current_runtime,
+                )
+                .await;
                 send_responses(socket, responses).await
             }
             Err(error) => {
@@ -140,10 +135,16 @@ async fn handle_ws_text(
 async fn handle_ws_request(
     request: WSRequest,
     state: &AppState,
-    runtime: &Arc<ProjectRuntime>,
+    runtime: Option<&Arc<ProjectRuntime>>,
+    fs_watcher: &mut Option<FsWatcherHandle>,
+    fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
+    fs_events_closed: &mut bool,
+    current_runtime: &mut Option<Arc<ProjectRuntime>>,
 ) -> Vec<WSResponse> {
     match request {
-        WSRequest::Execute { request } => handle_execution_request(runtime, request).await,
+        WSRequest::Execute { request } => {
+            with_runtime(runtime, |rt| handle_execution_request(rt, request)).await
+        }
         WSRequest::AIMessage {
             messages,
             enable_tools,
@@ -151,15 +152,9 @@ async fn handle_ws_request(
             stream,
             mode,
         } => {
-            handle_ai_message(
-                state,
-                runtime,
-                messages,
-                enable_tools,
-                request_id,
-                stream,
-                mode,
-            )
+            with_runtime(runtime, |rt| {
+                handle_ai_message(state, rt, messages, enable_tools, request_id, stream, mode)
+            })
             .await
         }
         WSRequest::ListTools => handle_list_tools(state),
@@ -167,36 +162,110 @@ async fn handle_ws_request(
             tool_id,
             capability_id,
             parameters,
-        } => handle_execute_tool(state, runtime, tool_id, capability_id, parameters).await,
-        WSRequest::TimelineQuery { query } => handle_timeline_query(runtime, query),
-        WSRequest::TimelineStatsQuery => handle_timeline_stats_query(runtime),
-        WSRequest::ExportRMarkdown { request } => {
-            handle_export_request(state, runtime, request).await
+        } => with_runtime(runtime, |rt| {
+            handle_execute_tool(state, rt, tool_id, capability_id, parameters)
+        })
+        .await,
+        WSRequest::TimelineQuery { query } => {
+            with_runtime(runtime, |rt| handle_timeline_query(rt, query)).await
         }
-        WSRequest::InterruptExecution => handle_interrupt(runtime).await,
-        WSRequest::RestartSession => handle_restart(runtime).await,
+        WSRequest::TimelineStatsQuery => {
+            with_runtime(runtime, |rt| handle_timeline_stats_query(rt)).await
+        }
+        WSRequest::ExportRMarkdown { request } => {
+            with_runtime(runtime, |rt| handle_export_request(state, rt, request)).await
+        }
+        WSRequest::InterruptExecution => with_runtime(runtime, handle_interrupt).await,
+        WSRequest::RestartSession => with_runtime(runtime, handle_restart).await,
         WSRequest::FileSystemAction {
             action,
             path,
             content,
             to,
-        } => handle_fs_action(runtime, action, path, content, to),
-        WSRequest::PlotHistoryGet => handle_plot_history_get(runtime).await,
+        } => {
+            with_runtime(runtime, |rt| async move {
+                handle_fs_action(rt, action, path, content, to)
+            })
+            .await
+        }
+        WSRequest::PlotHistoryGet => with_runtime(runtime, handle_plot_history_get).await,
         WSRequest::PlotHistorySetActive { plot_id } => {
-            handle_plot_history_set_active(runtime, plot_id).await
+            with_runtime(runtime, |rt| handle_plot_history_set_active(rt, plot_id)).await
         }
         WSRequest::PlotHistoryExport {
             plot_id,
             path,
             format,
-        } => handle_plot_history_export(runtime, plot_id, path, format).await,
+        } => with_runtime(runtime, |rt| {
+            handle_plot_history_export(rt, plot_id, path, format)
+        })
+        .await,
         WSRequest::PlotHistoryDelete { plot_id } => {
-            handle_plot_history_delete(runtime, plot_id).await
+            with_runtime(runtime, |rt| handle_plot_history_delete(rt, plot_id)).await
         }
-        WSRequest::PlotHistorySave => handle_plot_history_save(runtime).await,
-        WSRequest::PlotHistoryRestore => handle_plot_history_restore(runtime).await,
-        WSRequest::PlotHistoryClear => handle_plot_history_clear(runtime).await,
+        WSRequest::PlotHistorySave => with_runtime(runtime, handle_plot_history_save).await,
+        WSRequest::PlotHistoryRestore => {
+            with_runtime(runtime, handle_plot_history_restore).await
+        }
+        WSRequest::PlotHistoryClear => with_runtime(runtime, handle_plot_history_clear).await,
+        WSRequest::StartupAction => {
+            handle_startup_action(
+                state,
+                current_runtime,
+                fs_watcher,
+                fs_event_tx,
+                fs_events_closed,
+            )
+            .await
+        }
         _ => Vec::new(),
+    }
+}
+
+async fn handle_startup_action(
+    state: &AppState,
+    current_runtime: &mut Option<Arc<ProjectRuntime>>,
+    fs_watcher: &mut Option<FsWatcherHandle>,
+    fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
+    fs_events_closed: &mut bool,
+) -> Vec<WSResponse> {
+    match state.projects.startup_behavior().await {
+        StartupAction::ShowWelcome => single_response(WSResponse::StartupAction {
+            action_type: "show_welcome".to_string(),
+            project_id: None,
+        }),
+        StartupAction::OpenProject(project_id) => match state.projects.runtime_for(&project_id).await {
+            Ok(runtime) => {
+                *current_runtime = Some(runtime);
+                if let Some(active_runtime) = current_runtime.as_ref() {
+                    restart_fs_watcher(active_runtime, fs_watcher, fs_event_tx, fs_events_closed);
+                    vec![
+                        WSResponse::StartupAction {
+                            action_type: "open_project".to_string(),
+                            project_id: Some(project_id),
+                        },
+                        build_project_opened_response(state, active_runtime).await,
+                    ]
+                } else {
+                    error_response("Failed to initialize project runtime")
+                }
+            }
+            Err(error) => error_response(error.to_string()),
+        },
+    }
+}
+
+async fn with_runtime<F, Fut>(
+    runtime: Option<&Arc<ProjectRuntime>>,
+    action: F,
+) -> Vec<WSResponse>
+where
+    F: FnOnce(&Arc<ProjectRuntime>) -> Fut,
+    Fut: Future<Output = Vec<WSResponse>>,
+{
+    match runtime {
+        Some(rt) => action(rt).await,
+        None => error_response("No project is open"),
     }
 }
 

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -10,7 +10,7 @@ use project_requests::handle_project_request;
 use reprod_core::{fs::FileSystemEvent, project::ProjectRecord, ExecutionRequest};
 use runtime_fs::{handle_fs_event, restart_fs_watcher, FsWatcherHandle};
 use serde_json::{self, json};
-use std::{future::Future, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::mpsc as tokio_mpsc;
 
 mod ai_handler;
@@ -109,7 +109,7 @@ async fn handle_ws_text(
                 let responses = handle_ws_request(
                     request,
                     state,
-                    current_runtime.as_ref(),
+                    current_runtime.clone(),
                     fs_watcher,
                     fs_event_tx,
                     fs_events_closed,
@@ -135,79 +135,100 @@ async fn handle_ws_text(
 async fn handle_ws_request(
     request: WSRequest,
     state: &AppState,
-    runtime: Option<&Arc<ProjectRuntime>>,
+    runtime: Option<Arc<ProjectRuntime>>,
     fs_watcher: &mut Option<FsWatcherHandle>,
     fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
     fs_events_closed: &mut bool,
     current_runtime: &mut Option<Arc<ProjectRuntime>>,
 ) -> Vec<WSResponse> {
+    let runtime_ref = runtime.as_ref();
     match request {
-        WSRequest::Execute { request } => {
-            with_runtime(runtime, |rt| handle_execution_request(rt, request)).await
-        }
+        WSRequest::Execute { request } => match runtime_ref {
+            Some(rt) => handle_execution_request(rt, request).await,
+            None => error_response("No project is open"),
+        },
         WSRequest::AIMessage {
             messages,
             enable_tools,
             request_id,
             stream,
             mode,
-        } => {
-            with_runtime(runtime, |rt| {
-                handle_ai_message(state, rt, messages, enable_tools, request_id, stream, mode)
-            })
-            .await
-        }
+        } => match runtime_ref {
+            Some(rt) => {
+                handle_ai_message(state, rt, messages, enable_tools, request_id, stream, mode).await
+            }
+            None => error_response("No project is open"),
+        },
         WSRequest::ListTools => handle_list_tools(state),
         WSRequest::ExecuteTool {
             tool_id,
             capability_id,
             parameters,
-        } => with_runtime(runtime, |rt| {
-            handle_execute_tool(state, rt, tool_id, capability_id, parameters)
-        })
-        .await,
-        WSRequest::TimelineQuery { query } => {
-            with_runtime(runtime, |rt| handle_timeline_query(rt, query)).await
-        }
-        WSRequest::TimelineStatsQuery => {
-            with_runtime(runtime, |rt| handle_timeline_stats_query(rt)).await
-        }
-        WSRequest::ExportRMarkdown { request } => {
-            with_runtime(runtime, |rt| handle_export_request(state, rt, request)).await
-        }
-        WSRequest::InterruptExecution => with_runtime(runtime, handle_interrupt).await,
-        WSRequest::RestartSession => with_runtime(runtime, handle_restart).await,
+        } => match runtime_ref {
+            Some(rt) => handle_execute_tool(state, rt, tool_id, capability_id, parameters).await,
+            None => error_response("No project is open"),
+        },
+        WSRequest::TimelineQuery { query } => match runtime_ref {
+            Some(rt) => handle_timeline_query(rt, query),
+            None => error_response("No project is open"),
+        },
+        WSRequest::TimelineStatsQuery => match runtime_ref {
+            Some(rt) => handle_timeline_stats_query(rt),
+            None => error_response("No project is open"),
+        },
+        WSRequest::ExportRMarkdown { request } => match runtime_ref {
+            Some(rt) => handle_export_request(state, rt, request).await,
+            None => error_response("No project is open"),
+        },
+        WSRequest::InterruptExecution => match runtime_ref {
+            Some(rt) => handle_interrupt(rt).await,
+            None => error_response("No project is open"),
+        },
+        WSRequest::RestartSession => match runtime_ref {
+            Some(rt) => handle_restart(rt).await,
+            None => error_response("No project is open"),
+        },
         WSRequest::FileSystemAction {
             action,
             path,
             content,
             to,
-        } => {
-            with_runtime(runtime, |rt| async move {
-                handle_fs_action(rt, action, path, content, to)
-            })
-            .await
-        }
-        WSRequest::PlotHistoryGet => with_runtime(runtime, handle_plot_history_get).await,
-        WSRequest::PlotHistorySetActive { plot_id } => {
-            with_runtime(runtime, |rt| handle_plot_history_set_active(rt, plot_id)).await
-        }
+        } => match runtime_ref {
+            Some(rt) => handle_fs_action(rt, action, path, content, to),
+            None => error_response("No project is open"),
+        },
+        WSRequest::PlotHistoryGet => match runtime_ref {
+            Some(rt) => handle_plot_history_get(rt).await,
+            None => error_response("No project is open"),
+        },
+        WSRequest::PlotHistorySetActive { plot_id } => match runtime_ref {
+            Some(rt) => handle_plot_history_set_active(rt, plot_id).await,
+            None => error_response("No project is open"),
+        },
         WSRequest::PlotHistoryExport {
             plot_id,
             path,
             format,
-        } => with_runtime(runtime, |rt| {
-            handle_plot_history_export(rt, plot_id, path, format)
-        })
-        .await,
-        WSRequest::PlotHistoryDelete { plot_id } => {
-            with_runtime(runtime, |rt| handle_plot_history_delete(rt, plot_id)).await
-        }
-        WSRequest::PlotHistorySave => with_runtime(runtime, handle_plot_history_save).await,
-        WSRequest::PlotHistoryRestore => {
-            with_runtime(runtime, handle_plot_history_restore).await
-        }
-        WSRequest::PlotHistoryClear => with_runtime(runtime, handle_plot_history_clear).await,
+        } => match runtime_ref {
+            Some(rt) => handle_plot_history_export(rt, plot_id, path, format).await,
+            None => error_response("No project is open"),
+        },
+        WSRequest::PlotHistoryDelete { plot_id } => match runtime_ref {
+            Some(rt) => handle_plot_history_delete(rt, plot_id).await,
+            None => error_response("No project is open"),
+        },
+        WSRequest::PlotHistorySave => match runtime_ref {
+            Some(rt) => handle_plot_history_save(rt).await,
+            None => error_response("No project is open"),
+        },
+        WSRequest::PlotHistoryRestore => match runtime_ref {
+            Some(rt) => handle_plot_history_restore(rt).await,
+            None => error_response("No project is open"),
+        },
+        WSRequest::PlotHistoryClear => match runtime_ref {
+            Some(rt) => handle_plot_history_clear(rt).await,
+            None => error_response("No project is open"),
+        },
         WSRequest::StartupAction => {
             handle_startup_action(
                 state,
@@ -252,20 +273,6 @@ async fn handle_startup_action(
             }
             Err(error) => error_response(error.to_string()),
         },
-    }
-}
-
-async fn with_runtime<F, Fut>(
-    runtime: Option<&Arc<ProjectRuntime>>,
-    action: F,
-) -> Vec<WSResponse>
-where
-    F: FnOnce(&Arc<ProjectRuntime>) -> Fut,
-    Fut: Future<Output = Vec<WSResponse>>,
-{
-    match runtime {
-        Some(rt) => action(rt).await,
-        None => error_response("No project is open"),
     }
 }
 

--- a/server/src/handlers/project_requests.rs
+++ b/server/src/handlers/project_requests.rs
@@ -15,7 +15,7 @@ use super::runtime_fs::FsWatcherHandle;
 pub async fn handle_project_request(
     request: &WSRequest,
     state: &AppState,
-    current_runtime: &mut Arc<ProjectRuntime>,
+    current_runtime: &mut Option<Arc<ProjectRuntime>>,
     fs_watcher: &mut Option<FsWatcherHandle>,
     fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
     fs_events_closed: &mut bool,
@@ -131,7 +131,7 @@ pub async fn handle_project_request(
 
 async fn switch_runtime(
     state: &AppState,
-    current_runtime: &mut Arc<ProjectRuntime>,
+    current_runtime: &mut Option<Arc<ProjectRuntime>>,
     fs_watcher: &mut Option<FsWatcherHandle>,
     fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
     fs_events_closed: &mut bool,
@@ -140,11 +140,15 @@ async fn switch_runtime(
 ) -> bool {
     match state.projects.runtime_for(project_id).await {
         Ok(runtime) => {
-            *current_runtime = runtime;
-            restart_fs_watcher(current_runtime, fs_watcher, fs_event_tx, fs_events_closed);
+            *current_runtime = Some(runtime);
+            if let Some(active_runtime) = current_runtime.as_ref() {
+                restart_fs_watcher(active_runtime, fs_watcher, fs_event_tx, fs_events_closed);
 
-            let responses = vec![build_project_opened_response(state, current_runtime).await];
-            send_responses(socket, responses).await
+                let responses = vec![build_project_opened_response(state, active_runtime).await];
+                send_responses(socket, responses).await
+            } else {
+                send_responses(socket, error_response("Failed to activate project runtime")).await
+            }
         }
         Err(error) => send_responses(socket, error_response(error.to_string())).await,
     }

--- a/server/src/handlers/tool_handler.rs
+++ b/server/src/handlers/tool_handler.rs
@@ -18,7 +18,7 @@ pub(super) async fn handle_execute_tool(
     capability_id: String,
     parameters: HashMap<String, Value>,
 ) -> Vec<WSResponse> {
-    let mut r_executor = runtime.r_executor.lock().await;
+    let r_executor = runtime.r_executor.lock().await;
     match state
         .tool_executor
         .execute(&tool_id, &capability_id, parameters, &r_executor)

--- a/server/src/projects.rs
+++ b/server/src/projects.rs
@@ -78,6 +78,11 @@ impl ProjectRuntime {
     }
 }
 
+pub enum StartupAction {
+    OpenProject(String),
+    ShowWelcome,
+}
+
 pub struct ProjectController {
     registry: Mutex<ProjectRegistry>,
     runtimes: Mutex<HashMap<String, Arc<ProjectRuntime>>>,
@@ -99,13 +104,22 @@ impl ProjectController {
             base_temp_dir,
             config,
         };
-        controller.ensure_default_project().await?;
         Ok(controller)
     }
 
     pub async fn list_projects(&self) -> Vec<ProjectRecord> {
         let registry = self.registry.lock().await;
         registry.records().to_vec()
+    }
+
+    pub async fn startup_behavior(&self) -> StartupAction {
+        let registry = self.registry.lock().await;
+        registry
+            .records()
+            .iter()
+            .max_by_key(|record| record.last_opened_at.unwrap_or(0))
+            .map(|record| StartupAction::OpenProject(record.id.clone()))
+            .unwrap_or(StartupAction::ShowWelcome)
     }
 
     pub async fn default_runtime(&self) -> Result<Arc<ProjectRuntime>> {
@@ -276,29 +290,6 @@ impl ProjectController {
             serde_json::to_string_pretty(&payload).context("Failed to serialize project state")?;
         std::fs::write(&state_path, content)
             .with_context(|| format!("Failed to write {}", state_path.display()))
-    }
-
-    async fn ensure_default_project(&self) -> Result<()> {
-        let mut registry = self.registry.lock().await;
-        if registry.records().is_empty() {
-            let cwd =
-                std::env::current_dir().context("Failed to determine current working directory")?;
-            let mut descriptor = if locate_config(&cwd).is_ok() {
-                ProjectDescriptor::load(&cwd)?
-            } else {
-                let name = cwd
-                    .file_name()
-                    .and_then(|os| os.to_str())
-                    .unwrap_or("Re-prod Project");
-                ProjectDescriptor::create(&cwd, name, None)?
-            };
-            descriptor.config.touch_opened();
-            descriptor.update_config()?;
-            registry.upsert(ProjectRecord::from(&descriptor));
-            registry.save()?;
-        }
-        drop(registry);
-        Ok(())
     }
 
     async fn register_project(

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -180,7 +180,7 @@ pub async fn execute_tool(
     Json(request): Json<ToolExecutionRequest>,
 ) -> Resp<ToolExecutionResult> {
     let runtime = state.projects.default_runtime().await.map_err(err_500)?;
-    let mut r_executor = runtime.r_executor.lock().await;
+    let r_executor = runtime.r_executor.lock().await;
 
     state
         .tool_executor

--- a/shared/src/ws.ts
+++ b/shared/src/ws.ts
@@ -86,6 +86,13 @@ export interface ExportRMarkdownResponsePayload {
 	error?: string | null;
 }
 
+export type StartupActionType = "open_project" | "show_welcome";
+
+export interface StartupActionPayload {
+	action_type: StartupActionType;
+	project_id?: string | null;
+}
+
 export type ClientMessage =
 	| { type: "execute"; request: ExecutionRequestPayload }
 	| {
@@ -118,6 +125,7 @@ export type ClientMessage =
 	| { type: "project_create"; name: string; path: string }
 	| { type: "project_add_existing"; path: string }
 	| { type: "project_clone"; remote: string; path: string; name?: string }
+	| { type: "get_startup_action" }
 	| { type: "project_state_load"; projectId: string }
 	| {
 			type: "project_state_save";
@@ -171,6 +179,7 @@ export type ServerMessage =
 	| { type: "project_opened"; project: ProjectRecord; state?: Record<string, unknown> | null }
 	| { type: "project_state"; project_id: string; state?: Record<string, unknown> | null }
 	| { type: "project_state_saved"; project_id: string }
+	| { type: "startup_action"; action_type: StartupActionType; project_id?: string | null }
 	| {
 			type: "plot_history_state";
 			activePlotId?: string | null;


### PR DESCRIPTION
## Description
- add startup_action handshake to avoid default project creation and surface welcome screen when no recent project exists
- introduce client welcome screen + startup hook and wire menu shortcut; clean up clippy/formatting

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to develop:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from develop → main (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing
- pnpm format
- cargo fmt --manifest-path core/Cargo.toml
- cargo clippy --manifest-path core/Cargo.toml --lib --all-features
- pnpm run lint

## Screenshots (if applicable)


## Related Issues

Closes #181
