### PR TITLE
feat: create reusable LoadingSpinner component (#89)

### DIFF
--- a/client/src/components/export/ExportDialog.tsx
+++ b/client/src/components/export/ExportDialog.tsx
@@ -1,4 +1,5 @@
 import { useExportDialog } from "@/hooks/useExportDialog";
+import { LoadingSpinner } from "@/components/shared";
 
 interface ExportDialogProps {
 	open: boolean;
@@ -63,6 +64,11 @@ export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element 
 				</div>
 
 				<div className={`export-dialog-content ${exporting ? "loading" : ""}`}>
+					{exporting && (
+						<div className="export-loading-overlay">
+							<LoadingSpinner size="large" message="Exporting..." />
+						</div>
+					)}
 					{/* TODO: Reproduction Bundle export will be available in File > Export > Reproduction Bundle */}
 					<div className="export-section">
 						<label className="export-label" id="format-label">

--- a/client/src/components/shared/LoadingSpinner.tsx
+++ b/client/src/components/shared/LoadingSpinner.tsx
@@ -1,0 +1,25 @@
+export interface LoadingSpinnerProps {
+	/** Size variant of the spinner */
+	size?: "small" | "medium" | "large";
+	/** Optional message to display next to the spinner */
+	message?: string;
+	/** Additional CSS class name */
+	className?: string;
+}
+
+export function LoadingSpinner({
+	size = "medium",
+	message,
+	className = "",
+}: LoadingSpinnerProps): JSX.Element {
+	const sizeClass = `loading-spinner-${size}`;
+	const containerClass = `loading-spinner-container ${className}`.trim();
+
+	return (
+		<div className={containerClass} role="status" aria-live="polite">
+			<div className={`loading-spinner ${sizeClass}`} aria-hidden="true" />
+			{message && <span className="loading-spinner-message">{message}</span>}
+			<span className="sr-only">Loading...</span>
+		</div>
+	);
+}

--- a/client/src/components/shared/index.ts
+++ b/client/src/components/shared/index.ts
@@ -1,3 +1,4 @@
 export { ConfirmDialog } from "./dialog";
 export * from "./icons";
+export { LoadingSpinner, type LoadingSpinnerProps } from "./LoadingSpinner";
 export { type PanelTabItem, PanelTabs } from "./PanelTabs";

--- a/client/src/components/timeline/Timeline.tsx
+++ b/client/src/components/timeline/Timeline.tsx
@@ -1,4 +1,5 @@
 import type { TimelineListProps } from "@/types/timeline";
+import { LoadingSpinner } from "@/components/shared";
 import { TimelineEvent } from "./TimelineEvent";
 
 export function Timeline({
@@ -28,8 +29,7 @@ export function Timeline({
 
 			{loading && (
 				<div className="timeline-loading">
-					<div className="timeline-spinner" />
-					<span>Loading events...</span>
+					<LoadingSpinner size="small" message="Loading events..." />
 				</div>
 			)}
 

--- a/client/src/components/timeline/TimelineStats.tsx
+++ b/client/src/components/timeline/TimelineStats.tsx
@@ -1,10 +1,11 @@
 import type { TimelineStatsProps } from "@/types/timeline";
+import { LoadingSpinner } from "@/components/shared";
 
 export function TimelineStats({ stats, loading }: TimelineStatsProps): JSX.Element {
 	if (loading || !stats) {
 		return (
 			<div className="timeline-stats">
-				<div className="timeline-stats-loading">Loading stats...</div>
+				<LoadingSpinner size="small" message="Loading stats..." />
 			</div>
 		);
 	}

--- a/client/src/css/components/export-dialog.css
+++ b/client/src/css/components/export-dialog.css
@@ -300,7 +300,6 @@
 /* Loading State Overlay */
 .export-dialog-content.loading {
 	pointer-events: none;
-	opacity: 0.6;
 	position: relative;
 }
 
@@ -316,16 +315,6 @@
 	background: rgba(255, 255, 255, 0.9);
 	z-index: 10;
 	pointer-events: all;
-}
-
-.export-dialog-content.loading::after {
-	content: "";
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	background: rgba(255, 255, 255, 0.5);
 	cursor: wait;
 }
 

--- a/client/src/css/components/export-dialog.css
+++ b/client/src/css/components/export-dialog.css
@@ -304,6 +304,20 @@
 	position: relative;
 }
 
+.export-loading-overlay {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: rgba(255, 255, 255, 0.9);
+	z-index: 10;
+	pointer-events: all;
+}
+
 .export-dialog-content.loading::after {
 	content: "";
 	position: absolute;

--- a/client/src/css/components/loading-spinner.css
+++ b/client/src/css/components/loading-spinner.css
@@ -1,0 +1,63 @@
+/* Loading Spinner Component */
+
+.loading-spinner-container {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+}
+
+.loading-spinner {
+	border-radius: 50%;
+	border: 2px solid var(--border-color);
+	border-top-color: var(--accent-blue);
+	animation: spin 0.8s linear infinite;
+}
+
+/* Size variants */
+.loading-spinner-small {
+	width: 12px;
+	height: 12px;
+	border-width: 2px;
+}
+
+.loading-spinner-medium {
+	width: 16px;
+	height: 16px;
+	border-width: 2px;
+}
+
+.loading-spinner-large {
+	width: 24px;
+	height: 24px;
+	border-width: 3px;
+}
+
+/* Message styling */
+.loading-spinner-message {
+	color: var(--text-muted);
+	font-size: 12px;
+}
+
+/* Screen reader only text */
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
+
+/* Spin animation */
+@keyframes spin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}

--- a/client/src/css/components/timeline.css
+++ b/client/src/css/components/timeline.css
@@ -68,13 +68,6 @@
 	letter-spacing: 0.03em;
 }
 
-.timeline-stats-loading {
-	text-align: center;
-	color: var(--text-muted);
-	font-size: 12px;
-	padding: 12px;
-}
-
 /* Timeline Filters */
 .timeline-filters {
 	display: flex;
@@ -226,25 +219,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	gap: 12px;
 	padding: 24px;
-	color: var(--text-muted);
-	font-size: 12px;
-}
-
-.timeline-spinner {
-	width: 16px;
-	height: 16px;
-	border: 2px solid var(--border-color);
-	border-top-color: var(--accent-blue);
-	border-radius: 50%;
-	animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-	to {
-		transform: rotate(360deg);
-	}
 }
 
 .timeline-load-more {

--- a/client/src/css/index.css
+++ b/client/src/css/index.css
@@ -17,6 +17,7 @@
 @import "./components/export-dialog.css";
 @import "./components/confirm-dialog.css";
 @import "./components/modal-dialog.css";
+@import "./components/loading-spinner.css";
 
 /* Design themes */
 @import "./design-phylo-rstudio.css";


### PR DESCRIPTION
## Summary
Creates a reusable `LoadingSpinner` component to replace inline loading indicators scattered across multiple components, providing consistent loading UI and reducing code duplication.

## Changes

### New Components
- **`LoadingSpinner.tsx`**: Reusable loading spinner component
  - Supports 3 size variants: `small` (12px), `medium` (16px), `large` (24px)
  - Optional loading message prop
  - Accessible with ARIA attributes and screen reader text
  
- **`loading-spinner.css`**: Component styles
  - Smooth rotation animation
  - Size variant classes
  - Screen reader utility class

### Refactored Components
- **`TimelineStats.tsx`**: Replaced inline "Loading stats..." text with `LoadingSpinner`
- **`Timeline.tsx`**: Replaced inline spinner div with `LoadingSpinner` component  
- **`ExportDialog.tsx`**: Added `LoadingSpinner` overlay during export operations

### Style Updates
- Added `.export-loading-overlay` for centered loading display in export dialog
- Exported `LoadingSpinner` from `@/components/shared`
- Imported `loading-spinner.css` in main CSS file

## Test Plan
- [x] TypeScript compilation passes
- [x] Biome formatting passes
- [x] No console errors
- [ ] Manually verify loading states in:
  - [ ] Timeline stats loading
  - [ ] Timeline events loading
  - [ ] Export dialog during export

## Screenshots
_Loading states use consistent spinner component across all instances_

Fixes #89