### PR TITLE
Refactor: Extend Factory Pattern to all WebSocket message builders (#193)

### DIFF
--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -2,6 +2,7 @@ import type { AIMessage, AIMode } from "@shared/types";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useStore } from "@/core";
 import { buildPromptWithContext, createRequestId } from "@/core/ai/promptUtils";
+import { aiMessages } from "@/services/messageBuilders";
 import { socketService } from "@/services/socket";
 import { useAICodeApplication } from "./useAICodeApplication";
 import { useAIStreaming } from "./useAIStreaming";
@@ -131,14 +132,14 @@ export function useAIConversation() {
 
 			const enableTools = mode === "agent";
 
-			const sent = socketService.send({
-				type: "ai_message",
-				request_id: requestId,
-				stream: true,
-				messages: requestMessages,
-				enable_tools: enableTools,
-				mode,
-			});
+			const sent = socketService.send(
+				aiMessages.send(requestMessages, {
+					requestId,
+					stream: true,
+					enableTools,
+					mode,
+				}),
+			);
 
 			if (!sent) {
 				cleanup();

--- a/client/src/services/executionService.ts
+++ b/client/src/services/executionService.ts
@@ -1,5 +1,6 @@
 import type { ExecutionRequestPayload, ExecutionResultPayload } from "@shared/types";
 import type { ServerMessage } from "shared";
+import { executionMessages } from "@/services/messageBuilders";
 import { socketService } from "./socket";
 
 type ExecutionSuccessMessage = Extract<ServerMessage, { type: "execution_result" }>;
@@ -27,7 +28,7 @@ export interface ExecuteResponse {
 export async function executeRequest(request: ExecutionRequestPayload): Promise<ExecuteResponse> {
 	return new Promise<ExecuteResponse>((resolve, reject) => {
 		const didSend = socketService.send(
-			{ type: "execute", request },
+			executionMessages.execute(request),
 			(message) => {
 				if (message.type === "execution_result") {
 					resolve({ raw: message, result: message.result });

--- a/client/src/services/exportService.ts
+++ b/client/src/services/exportService.ts
@@ -3,6 +3,7 @@ import type {
 	ExportRMarkdownResponsePayload,
 	ServerMessage,
 } from "shared";
+import { exportMessages } from "@/services/messageBuilders";
 import { socketService } from "@/services/socket";
 
 const exportMatcher = (message: ServerMessage) =>
@@ -34,7 +35,7 @@ export async function exportRMarkdown(
 		}, timeoutMs);
 
 		const didSend = socketService.send(
-			{ type: "export_rmarkdown", request: payload },
+			exportMessages.exportRMarkdown(payload),
 			(message) => {
 				cleanup();
 

--- a/client/src/services/fileSystem.ts
+++ b/client/src/services/fileSystem.ts
@@ -1,6 +1,7 @@
 import type { FileEntryPayload, FileSystemAction, FileSystemEventPayload } from "@shared/types";
 import type { ExtractServerMessage } from "shared";
 import { normalizePathInput, normalizeRelativePath, ROOT_PATH } from "@/core/pathUtils";
+import { fsMessages } from "@/services/messageBuilders";
 import { socketService } from "./socket";
 
 export type FileEntry = FileEntryPayload & {
@@ -41,13 +42,10 @@ const sendFsAction = async <TData>(
 	const normalizedPath = normalizePathInput(path);
 	const normalizedTo = options?.to ? normalizePathInput(options.to) : undefined;
 	const response = await socketService.request(
-		{
-			type: "fs_action",
-			action,
-			path: normalizedPath,
+		fsMessages.action(action, normalizedPath, {
 			content: options?.content,
 			to: normalizedTo,
-		},
+		}),
 		"fs_result",
 		(message) => {
 			if (message.action !== action) {

--- a/client/src/services/messageBuilders.ts
+++ b/client/src/services/messageBuilders.ts
@@ -1,0 +1,190 @@
+/**
+ * Type-safe message builders for WebSocket communication.
+ *
+ * These functions ensure that all message payloads conform to the server's
+ * expected schema, preventing runtime errors from field name mismatches.
+ */
+
+import type {
+	AIMode,
+	ChatMessagePayload,
+	ExecutionRequestPayload,
+	FileSystemAction,
+	ToolExecutionRequestPayload,
+} from "@shared/types";
+import type { ClientMessage, ExportRMarkdownRequestPayload, TimelineQuery } from "shared";
+
+// Project messages
+export const projectMessages = {
+	list: (): Extract<ClientMessage, { type: "project_list" }> => ({
+		type: "project_list",
+	}),
+
+	open: (projectId: string): Extract<ClientMessage, { type: "project_open" }> => ({
+		type: "project_open",
+		project_id: projectId,
+	}),
+
+	create: (name: string, path: string): Extract<ClientMessage, { type: "project_create" }> => ({
+		type: "project_create",
+		name,
+		path,
+	}),
+
+	addExisting: (path: string): Extract<ClientMessage, { type: "project_add_existing" }> => ({
+		type: "project_add_existing",
+		path,
+	}),
+
+	clone: (
+		remote: string,
+		path: string,
+		name?: string,
+	): Extract<ClientMessage, { type: "project_clone" }> => ({
+		type: "project_clone",
+		remote,
+		path,
+		name,
+	}),
+
+	loadState: (projectId: string): Extract<ClientMessage, { type: "project_state_load" }> => ({
+		type: "project_state_load",
+		project_id: projectId,
+	}),
+
+	saveState: (
+		projectId: string,
+		state: Record<string, unknown>,
+	): Extract<ClientMessage, { type: "project_state_save" }> => ({
+		type: "project_state_save",
+		project_id: projectId,
+		state,
+	}),
+} as const;
+
+// Plot history messages
+export const plotHistoryMessages = {
+	get: (): Extract<ClientMessage, { type: "plot_history_get" }> => ({
+		type: "plot_history_get",
+	}),
+
+	setActive: (plotId: string): Extract<ClientMessage, { type: "plot_history_set_active" }> => ({
+		type: "plot_history_set_active",
+		plot_id: plotId,
+	}),
+
+	export: (
+		plotId: string,
+		path: string,
+		format?: "png" | "pdf",
+	): Extract<ClientMessage, { type: "plot_history_export" }> => ({
+		type: "plot_history_export",
+		plot_id: plotId,
+		path,
+		format,
+	}),
+
+	delete: (plotId: string): Extract<ClientMessage, { type: "plot_history_delete" }> => ({
+		type: "plot_history_delete",
+		plot_id: plotId,
+	}),
+
+	save: (): Extract<ClientMessage, { type: "plot_history_save" }> => ({
+		type: "plot_history_save",
+	}),
+
+	restore: (): Extract<ClientMessage, { type: "plot_history_restore" }> => ({
+		type: "plot_history_restore",
+	}),
+
+	clear: (): Extract<ClientMessage, { type: "plot_history_clear" }> => ({
+		type: "plot_history_clear",
+	}),
+} as const;
+
+// AI messages
+export const aiMessages = {
+	send: (
+		messages: ChatMessagePayload[],
+		options?: {
+			enableTools?: boolean;
+			requestId?: string;
+			stream?: boolean;
+			mode?: AIMode;
+		},
+	): Extract<ClientMessage, { type: "ai_message" }> => ({
+		type: "ai_message",
+		messages,
+		enable_tools: options?.enableTools,
+		request_id: options?.requestId,
+		stream: options?.stream,
+		mode: options?.mode,
+	}),
+} as const;
+
+// Tool messages
+export const toolMessages = {
+	list: (): Extract<ClientMessage, { type: "list_tools" }> => ({
+		type: "list_tools",
+	}),
+
+	execute: (
+		request: ToolExecutionRequestPayload,
+	): Extract<ClientMessage, { type: "execute_tool" }> => ({
+		type: "execute_tool",
+		...request,
+	}),
+} as const;
+
+// Timeline messages
+export const timelineMessages = {
+	query: (query: TimelineQuery): Extract<ClientMessage, { type: "timeline_query" }> => ({
+		type: "timeline_query",
+		query,
+	}),
+
+	statsQuery: (): Extract<ClientMessage, { type: "timeline_stats_query" }> => ({
+		type: "timeline_stats_query",
+	}),
+} as const;
+
+// Execution messages
+export const executionMessages = {
+	execute: (request: ExecutionRequestPayload): Extract<ClientMessage, { type: "execute" }> => ({
+		type: "execute",
+		request,
+	}),
+
+	interrupt: (): Extract<ClientMessage, { type: "interrupt_execution" }> => ({
+		type: "interrupt_execution",
+	}),
+
+	restart: (): Extract<ClientMessage, { type: "restart_session" }> => ({
+		type: "restart_session",
+	}),
+} as const;
+
+// File System messages
+export const fsMessages = {
+	action: (
+		action: FileSystemAction,
+		path: string,
+		options?: { content?: string; to?: string },
+	): Extract<ClientMessage, { type: "fs_action" }> => ({
+		type: "fs_action",
+		action,
+		path,
+		content: options?.content,
+		to: options?.to,
+	}),
+} as const;
+
+// Export messages
+export const exportMessages = {
+	exportRMarkdown: (
+		request: ExportRMarkdownRequestPayload,
+	): Extract<ClientMessage, { type: "export_rmarkdown" }> => ({
+		type: "export_rmarkdown",
+		request,
+	}),
+} as const;

--- a/client/src/services/plotHistoryService.ts
+++ b/client/src/services/plotHistoryService.ts
@@ -1,5 +1,6 @@
 import type { PlotHistoryStatePayload } from "shared";
 import type { ServerMessage } from "shared";
+import { plotHistoryMessages } from "@/services/messageBuilders";
 import { socketService } from "./socket";
 
 const historyMatcher = (message: ServerMessage): boolean =>
@@ -8,7 +9,7 @@ const historyMatcher = (message: ServerMessage): boolean =>
 export async function requestPlotHistory(): Promise<PlotHistoryStatePayload> {
 	return new Promise((resolve, reject) => {
 		const didSend = socketService.send(
-			{ type: "plot_history_get" },
+			plotHistoryMessages.get(),
 			(message) => {
 				if (message.type === "plot_history_state") {
 					resolve({
@@ -37,7 +38,7 @@ export async function requestPlotHistory(): Promise<PlotHistoryStatePayload> {
 export async function setActivePlot(plotId: string): Promise<PlotHistoryStatePayload> {
 	return new Promise((resolve, reject) => {
 		const didSend = socketService.send(
-			{ type: "plot_history_set_active", plotId },
+			plotHistoryMessages.setActive(plotId),
 			(message) => {
 				if (message.type === "plot_history_state") {
 					resolve({
@@ -70,7 +71,7 @@ export async function exportPlot(
 ): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const didSend = socketService.send(
-			{ type: "plot_history_export", plotId, path, format },
+			plotHistoryMessages.export(plotId, path, format),
 			(message) => {
 				if (message.type === "plot_history_exported") {
 					if (message.success) {
@@ -100,7 +101,7 @@ export async function exportPlot(
 export async function deletePlot(plotId: string): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const didSend = socketService.send(
-			{ type: "plot_history_delete", plotId },
+			plotHistoryMessages.delete(plotId),
 			(message) => {
 				if (message.type === "plot_history_deleted") {
 					if (message.error) {
@@ -130,7 +131,7 @@ export async function deletePlot(plotId: string): Promise<void> {
 export async function clearPlotHistory(): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const didSend = socketService.send(
-			{ type: "plot_history_clear" },
+			plotHistoryMessages.clear(),
 			(message) => {
 				if (message.type === "plot_history_cleared") {
 					if (message.error) {

--- a/client/src/services/projectService.ts
+++ b/client/src/services/projectService.ts
@@ -1,5 +1,6 @@
 import type { SessionSnapshot } from "@/services/sessionPersistence";
 import { getSessionSnapshot } from "@/services/sessionPersistence";
+import { projectMessages } from "@/services/messageBuilders";
 import { socketService } from "@/services/socket";
 
 interface CreateProjectPayload {
@@ -15,35 +16,33 @@ interface CloneProjectPayload {
 
 export const projectService = {
 	requestList(): void {
-		socketService.send({ type: "project_list" });
+		socketService.send(projectMessages.list());
 	},
 
 	open(projectId: string): void {
-		socketService.send({ type: "project_open", projectId });
+		socketService.send(projectMessages.open(projectId));
 	},
 
 	create(payload: CreateProjectPayload): void {
-		socketService.send({ type: "project_create", ...payload });
+		socketService.send(projectMessages.create(payload.name, payload.path));
 	},
 
 	addExisting(path: string): void {
-		socketService.send({ type: "project_add_existing", path });
+		socketService.send(projectMessages.addExisting(path));
 	},
 
 	clone(payload: CloneProjectPayload): void {
-		socketService.send({ type: "project_clone", ...payload });
+		socketService.send(projectMessages.clone(payload.remote, payload.path, payload.name));
 	},
 
 	loadState(projectId: string): void {
-		socketService.send({ type: "project_state_load", projectId });
+		socketService.send(projectMessages.loadState(projectId));
 	},
 
 	saveState(projectId: string, snapshot?: SessionSnapshot): void {
 		const state = snapshot ?? getSessionSnapshot();
-		socketService.send({
-			type: "project_state_save",
-			projectId,
-			state: state as unknown as Record<string, unknown>,
-		});
+		socketService.send(
+			projectMessages.saveState(projectId, state as unknown as Record<string, unknown>),
+		);
 	},
 };

--- a/client/src/services/sessionControl.ts
+++ b/client/src/services/sessionControl.ts
@@ -1,4 +1,5 @@
 import type { ServerMessage } from "shared";
+import { executionMessages } from "@/services/messageBuilders";
 import { socketService } from "./socket";
 
 const interruptMatcher = (message: ServerMessage): boolean =>
@@ -10,7 +11,7 @@ const restartMatcher = (message: ServerMessage): boolean =>
 export async function interruptExecution(): Promise<boolean> {
 	return new Promise((resolve, reject) => {
 		const didSend = socketService.send(
-			{ type: "interrupt_execution" },
+			executionMessages.interrupt(),
 			(message) => {
 				if (message.type === "execution_interrupted") {
 					resolve(message.success);
@@ -33,7 +34,7 @@ export async function interruptExecution(): Promise<boolean> {
 export async function restartSession(): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const didSend = socketService.send(
-			{ type: "restart_session" },
+			executionMessages.restart(),
 			(message) => {
 				if (message.type === "session_restarted") {
 					resolve();

--- a/client/src/services/timelineService.ts
+++ b/client/src/services/timelineService.ts
@@ -5,6 +5,7 @@ import type {
 	TimelineResponse,
 	TimelineStats,
 } from "shared";
+import { timelineMessages } from "@/services/messageBuilders";
 import { socketService } from "./socket";
 
 const timelineMatcher = (message: ServerMessage): boolean =>
@@ -13,7 +14,7 @@ const timelineMatcher = (message: ServerMessage): boolean =>
 export async function queryTimeline(query: TimelineQuery): Promise<TimelineResponse> {
 	return new Promise((resolve, reject) => {
 		const didSend = socketService.send(
-			{ type: "timeline_query", query },
+			timelineMessages.query(query),
 			(message) => {
 				if (message.type === "timeline_response") {
 					resolve(message.data);
@@ -39,7 +40,7 @@ export async function queryTimeline(query: TimelineQuery): Promise<TimelineRespo
 export async function getTimelineStats(): Promise<TimelineStats> {
 	return new Promise((resolve, reject) => {
 		const didSend = socketService.send(
-			{ type: "timeline_stats_query" },
+			timelineMessages.statsQuery(),
 			(message) => {
 				if (message.type === "timeline_stats_response") {
 					resolve(message.stats);

--- a/shared/src/ws.ts
+++ b/shared/src/ws.ts
@@ -114,20 +114,20 @@ export type ClientMessage =
 			to?: string;
 	  }
 	| { type: "project_list" }
-	| { type: "project_open"; projectId: string }
+	| { type: "project_open"; project_id: string }
 	| { type: "project_create"; name: string; path: string }
 	| { type: "project_add_existing"; path: string }
 	| { type: "project_clone"; remote: string; path: string; name?: string }
-	| { type: "project_state_load"; projectId: string }
+	| { type: "project_state_load"; project_id: string }
 	| {
 			type: "project_state_save";
-			projectId: string;
+			project_id: string;
 			state: Record<string, unknown>;
 	  }
 	| { type: "plot_history_get" }
-	| { type: "plot_history_set_active"; plotId: string }
-	| { type: "plot_history_export"; plotId: string; path: string; format?: PlotHistoryExportFormat }
-	| { type: "plot_history_delete"; plotId: string }
+	| { type: "plot_history_set_active"; plot_id: string }
+	| { type: "plot_history_export"; plot_id: string; path: string; format?: PlotHistoryExportFormat }
+	| { type: "plot_history_delete"; plot_id: string }
 	| { type: "plot_history_save" }
 	| { type: "plot_history_restore" }
 	| { type: "plot_history_clear" };


### PR DESCRIPTION
## Problem
Only `projectMessages` and `plotHistoryMessages` used the type-safe Factory Pattern. Other messages were unsafe object literals.

## Solution
Implemented `messageBuilders.ts` with factory functions for:
- AI messages
- Execution messages
- File System messages
- Timeline messages
- Session Control messages
- Export messages

Refactored all call sites to use these builders.
Standardized `projectId` -> `project_id` and `plotId` -> `plot_id` in `shared/src/ws.ts` to match server expectations (snake_case).

## Verification
- Ran `pnpm type-check` (passed)
- Ran `pnpm format` (passed)

Closes #193