### PR TITLE
Remove numbered keyboard shortcuts (Command+1/2/3/4) for pane toggles

### DIFF
--- a/client/src/constants/shortcuts.ts
+++ b/client/src/constants/shortcuts.ts
@@ -72,16 +72,6 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
 				description: "Start new session",
 			},
 			{
-				id: "toggle-editor",
-				keys: ["⌘1", "Ctrl+1"],
-				description: "Show or hide editor",
-			},
-			{
-				id: "toggle-console",
-				keys: ["⌘2", "Ctrl+2"],
-				description: "Show or hide console",
-			},
-			{
 				id: "toggle-plots",
 				keys: ["⌘3", "Ctrl+3"],
 				description: "Show or hide plots",

--- a/client/src/constants/shortcuts.ts
+++ b/client/src/constants/shortcuts.ts
@@ -71,16 +71,6 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
 				keys: ["⌘⇧N", "Ctrl+Shift+N"],
 				description: "Start new session",
 			},
-			{
-				id: "toggle-plots",
-				keys: ["⌘3", "Ctrl+3"],
-				description: "Show or hide plots",
-			},
-			{
-				id: "toggle-timeline",
-				keys: ["⌘4", "Ctrl+4"],
-				description: "Toggle timeline tab",
-			},
 		],
 	},
 	{

--- a/client/src/core/ai/actions/BaseCodeAction.ts
+++ b/client/src/core/ai/actions/BaseCodeAction.ts
@@ -1,9 +1,5 @@
 import type { CodeBlock } from "@shared/types";
-import type {
-	CodeActionContext,
-	CodeActionValidation,
-	ICodeAction,
-} from "./ICodeAction";
+import type { CodeActionContext, CodeActionValidation, ICodeAction } from "./ICodeAction";
 
 /**
  * Abstract base class for code actions.

--- a/client/src/core/ai/actions/actions/CreateFileAction.ts
+++ b/client/src/core/ai/actions/actions/CreateFileAction.ts
@@ -1,9 +1,5 @@
 import type { CodeBlock } from "@shared/types";
-import type {
-	CodeActionContext,
-	CodeActionValidation,
-	ICodeAction,
-} from "../ICodeAction";
+import type { CodeActionContext, CodeActionValidation, ICodeAction } from "../ICodeAction";
 
 /**
  * Action for creating a new file with content

--- a/client/src/core/ai/actions/actions/DeleteRangeAction.ts
+++ b/client/src/core/ai/actions/actions/DeleteRangeAction.ts
@@ -1,9 +1,5 @@
 import type { CodeBlock } from "@shared/types";
-import type {
-	CodeActionContext,
-	CodeActionValidation,
-	ICodeAction,
-} from "../ICodeAction";
+import type { CodeActionContext, CodeActionValidation, ICodeAction } from "../ICodeAction";
 
 /**
  * Action for deleting a specific range of code

--- a/client/src/core/ai/actions/actions/ReplaceAllAction.ts
+++ b/client/src/core/ai/actions/actions/ReplaceAllAction.ts
@@ -1,9 +1,5 @@
 import type { CodeBlock } from "@shared/types";
-import type {
-	CodeActionContext,
-	CodeActionValidation,
-	ICodeAction,
-} from "../ICodeAction";
+import type { CodeActionContext, CodeActionValidation, ICodeAction } from "../ICodeAction";
 
 /**
  * Action for replacing entire file contents
@@ -45,7 +41,10 @@ export class ReplaceAllAction implements ICodeAction {
 		}
 	}
 
-	private isCurrentEditor(targetFile: string | undefined, editorFilepath: string | null | undefined): boolean {
+	private isCurrentEditor(
+		targetFile: string | undefined,
+		editorFilepath: string | null | undefined,
+	): boolean {
 		if (!targetFile) return true;
 
 		const placeholderPatterns = [

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -81,8 +81,6 @@ export function useKeyboardShortcuts() {
 
 			// View menu
 			"Mod+Shift+E": () => menuActions.view.togglePane("files"),
-			"Mod+1": () => menuActions.view.togglePane("editor"),
-			"Mod+2": () => menuActions.view.togglePane("assistant"),
 			"Mod++": () => menuActions.view.zoomIn(),
 			"Mod+=": () => menuActions.view.zoomIn(), // Also handle = key (no shift)
 			"Mod+-": () => menuActions.view.zoomOut(),


### PR DESCRIPTION
## Summary
Remove all numbered keyboard shortcuts (Command+1, Command+2, Command+3, Command+4) used for pane toggles to avoid conflicts with browser/OS tab navigation.

## Changes
- ✅ Removed Command+1 (Toggle Editor) from shortcuts
- ✅ Removed Command+2 (Toggle Assistant) from shortcuts  
- ✅ Removed Command+3 (Toggle Plots) from shortcuts
- ✅ Removed Command+4 (Toggle Timeline) from shortcuts
- ✅ Applied Biome formatting to code action files

## Technical Details
**Modified files:**
- `client/src/constants/shortcuts.ts` - Removed numbered shortcut entries
- `client/src/hooks/useKeyboardShortcuts.ts` - Removed Command+1/2 bindings
- Code action files - Formatting cleanup

## Rationale
These numbered shortcuts conflict with standard browser/OS shortcuts for tab navigation. Users can still access all pane toggles through the View menu and other shortcuts like Command+Shift+E for file browser.

## Testing
- ✅ TypeScript type checking passed
- ✅ Production build succeeded
- ✅ Pre-commit/pre-push hooks passed

## Related
Closes #88