### PR TITLE
feat(ui): Replace colorful extension badges with monochrome icons

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -88,10 +88,7 @@ function App(): JSX.Element {
 					{panes.assistant && (
 						<Allotment.Pane minSize={260} preferredSize="25%">
 							<div className="ai-pane-wrapper">
-								<AIPanel
-									ref={setAIPanelRef}
-									hasConfiguredProvider={isActiveProviderConfigured}
-								/>
+								<AIPanel ref={setAIPanelRef} hasConfiguredProvider={isActiveProviderConfigured} />
 							</div>
 						</Allotment.Pane>
 					)}

--- a/client/src/components/ai-panel/AIPanel.tsx
+++ b/client/src/components/ai-panel/AIPanel.tsx
@@ -14,163 +14,161 @@ interface AIPanelProps {
 	hasConfiguredProvider: boolean;
 }
 
-export const AIPanel = forwardRef<AIPanelRef, AIPanelProps>(
-	({ hasConfiguredProvider, activeProviderLabel }, ref) => {
-		const { input, setInput, messages, isLoading, handleAsk, handleStop, handleApplyCode } =
-			useAIConversation();
+export const AIPanel = forwardRef<AIPanelRef, AIPanelProps>(({ hasConfiguredProvider }, ref) => {
+	const { input, setInput, messages, isLoading, handleAsk, handleStop, handleApplyCode } =
+		useAIConversation();
 
-		const messagesEndRef = useRef<HTMLDivElement>(null);
-		const textareaRef = useRef<HTMLTextAreaElement>(null);
-		const [showApiKeyError, setShowApiKeyError] = useState(false);
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const [showApiKeyError, setShowApiKeyError] = useState(false);
 
-		useImperativeHandle(ref, () => ({
-			focusInput: () => {
-				textareaRef.current?.focus();
-			},
-		}));
+	useImperativeHandle(ref, () => ({
+		focusInput: () => {
+			textareaRef.current?.focus();
+		},
+	}));
 
-		useEffect(() => {
-			messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-		}, [messages]);
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [messages]);
 
-		// Auto-resize textarea
-		useEffect(() => {
-			const textarea = textareaRef.current;
-			if (!textarea) return;
+	// Auto-resize textarea
+	useEffect(() => {
+		const textarea = textareaRef.current;
+		if (!textarea) return;
 
-			const adjustHeight = () => {
-				textarea.style.height = "auto";
-				textarea.style.height = `${Math.min(textarea.scrollHeight, 300)}px`;
-			};
-
-			adjustHeight();
-			textarea.addEventListener("input", adjustHeight);
-			return () => textarea.removeEventListener("input", adjustHeight);
-		}, [input]);
-
-		const [mode, setMode] = useState<AIMode>("agent");
-		const placeholder = mode === "agent" ? "Describe a task..." : "Ask a question...";
-
-		useEffect(() => {
-			if (hasConfiguredProvider && showApiKeyError) {
-				setShowApiKeyError(false);
-			}
-		}, [hasConfiguredProvider, showApiKeyError]);
-
-		const handleOpenSettings = () => {
-			commandRegistry.execute("session.settings");
+		const adjustHeight = () => {
+			textarea.style.height = "auto";
+			textarea.style.height = `${Math.min(textarea.scrollHeight, 300)}px`;
 		};
 
-		const handleSend = (selectedMode: AIMode) => {
-			if (!hasConfiguredProvider) {
-				setShowApiKeyError(true);
-				handleOpenSettings();
-				return;
-			}
+		adjustHeight();
+		textarea.addEventListener("input", adjustHeight);
+		return () => textarea.removeEventListener("input", adjustHeight);
+	}, [input]);
 
+	const [mode, setMode] = useState<AIMode>("agent");
+	const placeholder = mode === "agent" ? "Describe a task..." : "Ask a question...";
+
+	useEffect(() => {
+		if (hasConfiguredProvider && showApiKeyError) {
 			setShowApiKeyError(false);
-			handleAsk(selectedMode);
-		};
+		}
+	}, [hasConfiguredProvider, showApiKeyError]);
 
-		const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
-			if (e.key === "Enter" && !e.shiftKey && !e.altKey && !e.metaKey) {
-				e.preventDefault();
-				handleSend(mode);
-			}
-		};
+	const handleOpenSettings = () => {
+		commandRegistry.execute("session.settings");
+	};
 
-		return (
-			<div className="panel ai-panel">
-				<div className="panel-header">
-					<div className="panel-title">AI Assistant</div>
-					<ProviderSwitcher />
-				</div>
-				<div className="panel-content">
-					<div className="ai-messages">
-						{messages.length === 0 ? (
-							<div className="ai-welcome">
-								<h3>AI Assistant</h3>
-								<p>Ask me anything about R programming, data analysis, or visualization.</p>
-							</div>
-						) : (
-							<>
-								{messages.map((message) =>
-									message.role === "assistant" ? (
-										<StreamingMessage
-											key={message.id}
-											message={message}
-											onApplyCode={handleApplyCode}
-										/>
-									) : (
-										<div key={message.id} className="message message-user">
-											<div className="message-header">
-												<span className="message-role">You</span>
-											</div>
-											<div className="message-content">{message.content}</div>
+	const handleSend = (selectedMode: AIMode) => {
+		if (!hasConfiguredProvider) {
+			setShowApiKeyError(true);
+			handleOpenSettings();
+			return;
+		}
+
+		setShowApiKeyError(false);
+		handleAsk(selectedMode);
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
+		if (e.key === "Enter" && !e.shiftKey && !e.altKey && !e.metaKey) {
+			e.preventDefault();
+			handleSend(mode);
+		}
+	};
+
+	return (
+		<div className="panel ai-panel">
+			<div className="panel-header">
+				<div className="panel-title">AI Assistant</div>
+				<ProviderSwitcher />
+			</div>
+			<div className="panel-content">
+				<div className="ai-messages">
+					{messages.length === 0 ? (
+						<div className="ai-welcome">
+							<h3>AI Assistant</h3>
+							<p>Ask me anything about R programming, data analysis, or visualization.</p>
+						</div>
+					) : (
+						<>
+							{messages.map((message) =>
+								message.role === "assistant" ? (
+									<StreamingMessage
+										key={message.id}
+										message={message}
+										onApplyCode={handleApplyCode}
+									/>
+								) : (
+									<div key={message.id} className="message message-user">
+										<div className="message-header">
+											<span className="message-role">You</span>
 										</div>
-									),
-								)}
-								<div ref={messagesEndRef} />
-							</>
-						)}
-					</div>
-					<div className="ai-input-container-wrapper">
-						<div className="ai-input-container vscode-style">
-							<textarea
-								ref={textareaRef}
-								className="ai-input"
-								placeholder={placeholder}
-								aria-label={placeholder}
-								value={input}
-								onChange={(e) => setInput(e.target.value)}
-								onKeyDown={handleKeyDown}
-								disabled={isLoading}
-								rows={5}
-							/>
-							<div className="input-controls-bar">
-								<div className="input-controls-left">
-									<select
-										className="mode-dropdown"
-										value={mode}
-										onChange={(e) => setMode(e.target.value as AIMode)}
-										disabled={isLoading}
-										aria-label="AI interaction mode"
+										<div className="message-content">{message.content}</div>
+									</div>
+								),
+							)}
+							<div ref={messagesEndRef} />
+						</>
+					)}
+				</div>
+				<div className="ai-input-container-wrapper">
+					<div className="ai-input-container vscode-style">
+						<textarea
+							ref={textareaRef}
+							className="ai-input"
+							placeholder={placeholder}
+							aria-label={placeholder}
+							value={input}
+							onChange={(e) => setInput(e.target.value)}
+							onKeyDown={handleKeyDown}
+							disabled={isLoading}
+							rows={5}
+						/>
+						<div className="input-controls-bar">
+							<div className="input-controls-left">
+								<select
+									className="mode-dropdown"
+									value={mode}
+									onChange={(e) => setMode(e.target.value as AIMode)}
+									disabled={isLoading}
+									aria-label="AI interaction mode"
+								>
+									<option value="agent">Agent</option>
+									<option value="chat">Chat</option>
+								</select>
+							</div>
+							<div className="input-controls-right">
+								{isLoading ? (
+									<button
+										type="button"
+										className="icon-btn stop-btn"
+										onClick={handleStop}
+										title="Stop generation (Esc)"
+										aria-label="Stop generation"
 									>
-										<option value="agent">Agent</option>
-										<option value="chat">Chat</option>
-									</select>
-								</div>
-								<div className="input-controls-right">
-									{isLoading ? (
-										<button
-											type="button"
-											className="icon-btn stop-btn"
-											onClick={handleStop}
-											title="Stop generation (Esc)"
-											aria-label="Stop generation"
-										>
-											<IconSquare width={16} height={16} aria-hidden />
-										</button>
-									) : (
-										<button
-											type="button"
-											className="send-btn"
-											onClick={() => handleSend(mode)}
-											disabled={!input.trim()}
-											title="Send message (Enter)"
-											aria-label="Send message"
-										>
-											<IconSend width={16} height={16} aria-hidden />
-											<span>Send</span>
-										</button>
-									)}
-								</div>
+										<IconSquare width={16} height={16} aria-hidden />
+									</button>
+								) : (
+									<button
+										type="button"
+										className="send-btn"
+										onClick={() => handleSend(mode)}
+										disabled={!input.trim()}
+										title="Send message (Enter)"
+										aria-label="Send message"
+									>
+										<IconSend width={16} height={16} aria-hidden />
+										<span>Send</span>
+									</button>
+								)}
 							</div>
 						</div>
 					</div>
 				</div>
 			</div>
-		);
-	},
-);
+		</div>
+	);
+});
 AIPanel.displayName = "AIPanel";

--- a/client/src/components/file-browser/FileBrowserPane.tsx
+++ b/client/src/components/file-browser/FileBrowserPane.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { IconFile } from "@/components/icons/IconFile";
 import { IconChevronDown, IconChevronRight, IconFolder, IconPlus } from "@/components/shared";
 import { useFileSystemStore, useStore } from "@/core";
 import { normalizeRelativePath, normalizeSeparators, ROOT_PATH } from "@/core/pathUtils";
@@ -31,25 +32,6 @@ type TauriWindow = typeof window & {
 			open: (target: string) => Promise<void>;
 		};
 	};
-};
-
-const extensionColors: Record<string, string> = {
-	r: "#F38BA3",
-	rmd: "#9D8CE0",
-	rs: "#E37933",
-	rproj: "#5B8DEF",
-	md: "#4FD1C5",
-	json: "#56C4C4",
-	ts: "#2F6FED",
-	tsx: "#5A67D8",
-	js: "#F6C343",
-	jsx: "#EC7063",
-	py: "#2D9CDB",
-	rsx: "#E85858",
-	txt: "#94A3B8",
-	toml: "#FFA94D",
-	yaml: "#FFB347",
-	yml: "#FFB347",
 };
 
 const joinPath = (parent: string, name: string): string => {
@@ -325,7 +307,7 @@ export function FileBrowserPane(): JSX.Element {
 				console.error("Failed to open file", error);
 			}
 		},
-		[openInSystemViewer, setEditorContent, setEditorFilepath, setEditorIsDirty, toggleFolder],
+		[openInSystemViewer, setEditorContent, setEditorFilepath, setEditorIsDirty],
 	);
 
 	const handleContextMenu = useCallback(
@@ -739,9 +721,6 @@ export function FileBrowserPane(): JSX.Element {
 	const renderNode = (node: TreeNode) => {
 		const isSelected = selectedFiles.has(node.path);
 		const isFocused = focusedPath === node.path;
-		const ext = getExtension(node.name);
-		const color =
-			ext && extensionColors[ext] ? extensionColors[ext] : node.is_dir ? "#60A5FA" : "#CBD5F5";
 
 		return (
 			<div
@@ -789,14 +768,11 @@ export function FileBrowserPane(): JSX.Element {
 						<span className="file-tree-placeholder" />
 					)}
 				</button>
-				<span
-					className="file-type-icon"
-					style={{ backgroundColor: node.is_dir ? "transparent" : color }}
-				>
+				<span className="file-type-icon">
 					{node.is_dir ? (
-						<IconFolder width={14} height={14} />
+						<IconFolder width={14} height={14} style={{ color: "#6B7280" }} />
 					) : (
-						(ext ?? "file").slice(0, 3).toUpperCase()
+						<IconFile width={14} height={14} color="#9CA3AF" />
 					)}
 				</span>
 				<span className="file-tree-label">{node.name}</span>

--- a/client/src/components/icons/IconFile.tsx
+++ b/client/src/components/icons/IconFile.tsx
@@ -1,0 +1,41 @@
+interface Props {
+	width?: number;
+	height?: number;
+	color?: string;
+	className?: string;
+}
+
+export function IconFile({
+	width = 16,
+	height = 16,
+	color = "#9CA3AF",
+	className,
+}: Props): JSX.Element {
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox="0 0 16 16"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			className={className}
+			role="img"
+			aria-label="File icon"
+		>
+			<path
+				d="M9 1H3C2.44772 1 2 1.44772 2 2V14C2 14.5523 2.44772 15 3 15H13C13.5523 15 14 14.5523 14 14V6L9 1Z"
+				stroke={color}
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<path
+				d="M9 1V6H14"
+				stroke={color}
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+}


### PR DESCRIPTION
## Summary

Removes the colorful extension-based file icons and replaces them with a clean, professional monochrome design using simple grey file/folder icons.

## Problem

The current colorful badge system had several issues:
- **Visual distortion**: 3-4 character extensions (TOML, YAML, JSON, RPROJ) looked cramped in small badges
- **Inconsistent aesthetic**: 16 different colors clashed with Re-prod's minimalist white/grey/black design
- **Visual noise**: Too many colors created distraction in the file tree
- **Maintenance burden**: Required maintaining color mappings for every file type

## Solution

Replaced with a **monochrome icon system**:
- 📁 **Folders**: Grey folder icon (#6B7280)
- 📄 **Files**: Light grey document icon (#9CA3AF)
- No text badges, no extension colors—just clean, scannable icons

## Changes

### Added
- `client/src/components/icons/IconFile.tsx` - New generic file icon component
  - SVG document icon with customizable color
  - Accessibility attributes (role="img", aria-label)

### Modified
- `client/src/components/file-browser/FileBrowserPane.tsx`
  - Removed `extensionColors` dictionary (16 color mappings)
  - Simplified `renderNode` logic to use IconFile/IconFolder with grey tones
  - Kept `getExtension()` function for PDF detection logic
  - Fixed useCallback dependency array (removed unused `toggleFolder`)
  - Updated imports to maintain alphabetical order

- `client/src/App.tsx`
  - Minor formatting changes (line wrapping)

## Visual Comparison

### Before
```
📂 src/
  📄 R    analysis.R          (pink badge)
  📄 MD   README.md           (turquoise badge)
  📄 PY   utils.py            (blue badge)
  📄 JSON config.json         (cyan badge, cramped)
  📄 TOML Cargo.toml          (orange badge, cramped)
```

### After
```
📂 src/
  📄 analysis.R
  📄 README.md
  📄 utils.py
  📄 config.json
  📄 Cargo.toml
```

## Benefits

✅ **Cleaner visual hierarchy** - Focus on file names, not decorative colors  
✅ **Better scalability** - No color mappings needed for new file types  
✅ **Improved legibility** - No competition with editor syntax highlighting  
✅ **Professional aesthetic** - Matches tools like VS Code, Sublime, RStudio  
✅ **No distortion** - Icons scale cleanly without cramped text  
✅ **Reduced maintenance** - No color dictionary to update  

## Testing

- [x] File tree renders correctly for all file types
- [x] Folder expand/collapse works
- [x] Selected/focused states visible
- [x] PDF double-click still opens externally (getExtension preserved)
- [x] Biome formatting passes
- [x] Pre-commit hooks pass

## Related

- Closes #207