### PR TITLE
Extract timeout magic numbers to named constants

### DIFF
--- a/client/src/components/ai-panel/CodeBlockWithApply.tsx
+++ b/client/src/components/ai-panel/CodeBlockWithApply.tsx
@@ -2,6 +2,7 @@ import type { CodeBlock } from "@shared/types";
 import { useEffect, useState } from "react";
 import { IconCheck, IconClipboard, IconLightbulb } from "@/components/shared";
 import { CodeActionFactory } from "@/core/ai/actions";
+import { COPY_FEEDBACK_DURATION } from "@/constants/timeouts";
 import { CodeBlockDiffPreview } from "./CodeBlockDiffPreview";
 
 interface Props {
@@ -44,7 +45,7 @@ export function CodeBlockWithApply({ codeBlock, onApply, showDiffPreview }: Prop
 			.writeText(currentBlock.code)
 			.then(() => {
 				setCopied(true);
-				setTimeout(() => setCopied(false), 1200);
+				setTimeout(() => setCopied(false), COPY_FEEDBACK_DURATION);
 			})
 			.catch(() => {});
 	};

--- a/client/src/components/settings/LLMProviderConfig.tsx
+++ b/client/src/components/settings/LLMProviderConfig.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useState } from "react";
 import { useSettingsStore } from "../../core/state/slices/settingsStore";
+import { TEST_STATUS_RESET_DELAY } from "../../constants/timeouts";
 import "./LLMProviderConfig.css";
 
 interface Props {
@@ -38,7 +39,7 @@ export const LLMProviderConfig: React.FC<Props> = ({
 		setTestStatus("testing");
 		const success = await testConnection(providerName);
 		setTestStatus(success ? "success" : "failed");
-		setTimeout(() => setTestStatus("idle"), 3000);
+		setTimeout(() => setTestStatus("idle"), TEST_STATUS_RESET_DELAY);
 	};
 
 	return (

--- a/client/src/constants/timeouts.ts
+++ b/client/src/constants/timeouts.ts
@@ -1,0 +1,26 @@
+/**
+ * Timeout Constants
+ *
+ * Centralized timeout values used throughout the application.
+ * All values are in milliseconds unless otherwise noted.
+ */
+
+/**
+ * UI Feedback Timeouts
+ */
+
+/** Duration to show test status (success/failed) before resetting to idle (3 seconds) */
+export const TEST_STATUS_RESET_DELAY = 3000;
+
+/** Duration to show "Copied" feedback after copying code to clipboard (1.2 seconds) */
+export const COPY_FEEDBACK_DURATION = 1200;
+
+/**
+ * Network & WebSocket Timeouts
+ */
+
+/** Default timeout for WebSocket request/response operations (10 seconds) */
+export const WEBSOCKET_REQUEST_TIMEOUT = 10000;
+
+/** Delay before attempting to reconnect WebSocket after connection loss (2 seconds) */
+export const WEBSOCKET_RECONNECT_DELAY = 2000;

--- a/client/src/services/socket.ts
+++ b/client/src/services/socket.ts
@@ -1,4 +1,5 @@
 import type { ClientMessage, ExtractServerMessage, ServerMessage, ServerMessageType } from "shared";
+import { WEBSOCKET_RECONNECT_DELAY, WEBSOCKET_REQUEST_TIMEOUT } from "@/constants/timeouts";
 
 export type WSRequest = ClientMessage;
 export type WSResponse = ServerMessage;
@@ -150,7 +151,7 @@ class SocketService {
 		payload: WSRequest,
 		responseType: TType,
 		matcher?: (message: ExtractServerMessage<TType>) => boolean,
-		timeoutMs = 10000,
+		timeoutMs = WEBSOCKET_REQUEST_TIMEOUT,
 	): Promise<ExtractServerMessage<TType>> {
 		return new Promise((resolve, reject) => {
 			if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
@@ -249,7 +250,7 @@ class SocketService {
 		this.reconnectTimer = setTimeout(() => {
 			this.reconnectTimer = null;
 			this.connect(this.url);
-		}, 2000);
+		}, WEBSOCKET_RECONNECT_DELAY);
 
 		if (
 			this.reconnectTimer &&


### PR DESCRIPTION
## Description

Extracted hardcoded timeout magic numbers to named constants in a centralized file. This improves code maintainability by providing a single source of truth for all timeout values used throughout the application.

Created `client/src/constants/timeouts.ts` with 4 descriptive constants:
- TEST_STATUS_RESET_DELAY (3 seconds) - Duration to show test status before resetting
- COPY_FEEDBACK_DURATION (1.2 seconds) - Duration for "Copied" feedback display
- WEBSOCKET_REQUEST_TIMEOUT (10 seconds) - Default WebSocket request timeout
- WEBSOCKET_RECONNECT_DELAY (2 seconds) - Delay before WebSocket reconnection

Updated all files using these timeouts to import the constants instead of using magic numbers.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

### For ALL PRs to \`develop\`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (\`pnpm test\`)
- [ ] New tests added for new features/bug fixes
- [x] Documentation updated (if needed)

### For PRs from \`develop\` → \`main\` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  \`\`\`bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  \`\`\`
- [x] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

All unit tests pass (135 tests):
\`\`\`bash
pnpm test -- --run
\`\`\`

Build succeeds with no errors:
\`\`\`bash
pnpm build
\`\`\`

Manual verification:
- Tested LLM provider test connection - status resets after 3 seconds as expected
- Tested code block copy - "Copied" feedback displays for 1.2 seconds as expected
- No functional changes - all timeouts maintain their exact original values

## Screenshots (if applicable)

N/A - This is a refactoring PR with no visual changes

## Related Issues

Closes #175