### PR TITLE
Fix session persistence to keep UI layout only

### DIFF
--- a/client/src/core/state/slices/viewSlice.ts
+++ b/client/src/core/state/slices/viewSlice.ts
@@ -3,7 +3,7 @@ import type { StateCreator } from "zustand";
 export type ViewPane = "files" | "editor" | "assistant";
 export type ModalType = "export" | "shortcuts" | "about" | "sessionInfo" | "settings" | "projects";
 
-interface ViewData {
+export interface ViewData {
 	panes: Record<ViewPane, boolean>;
 	modals: Record<ModalType, boolean>;
 	zoom: number;

--- a/client/src/hooks/useProjectSession.ts
+++ b/client/src/hooks/useProjectSession.ts
@@ -38,6 +38,25 @@ export function useProjectSession(): void {
 	const resetPlotHistory = useStore((state) => state.resetPlotHistory);
 
 	useEffect(() => {
+		const restoreSnapshot = async (snapshot: SessionSnapshot | null | undefined) => {
+			if (!snapshot) {
+				resetWorkspace();
+				await refreshTimelineData();
+				setLastRestoredState(null);
+				return;
+			}
+
+			const applied = await applySessionSnapshot(snapshot);
+			if (!applied) {
+				resetWorkspace();
+				await refreshTimelineData();
+				setLastRestoredState(null);
+				return;
+			}
+
+			setLastRestoredState(snapshot as unknown as Record<string, unknown>);
+		};
+
 		const handleProjectOpened = async (message: { project: ProjectRecord; state?: unknown }) => {
 			const snapshot = message.state as unknown as SessionSnapshot | null | undefined;
 
@@ -49,20 +68,7 @@ export function useProjectSession(): void {
 			const resetAndLoadRoot = useFileSystemStore.getState().resetAndLoadRoot;
 			void resetAndLoadRoot();
 
-			if (snapshot) {
-				const applied = await applySessionSnapshot(snapshot);
-				if (applied) {
-					setLastRestoredState(snapshot as unknown as Record<string, unknown>);
-				} else {
-					resetWorkspace();
-					await refreshTimelineData();
-					setLastRestoredState(null);
-				}
-			} else {
-				resetWorkspace();
-				await refreshTimelineData();
-				setLastRestoredState(null);
-			}
+			await restoreSnapshot(snapshot);
 		};
 
 		const offOpened = socketService.on("project_opened", (message) => {
@@ -80,14 +86,7 @@ export function useProjectSession(): void {
 		const offState = socketService.on("project_state", (message) => {
 			if (message.type === "project_state" && message.state) {
 				void (async () => {
-					const applied = await applySessionSnapshot(message.state as unknown as SessionSnapshot);
-					if (applied) {
-						setLastRestoredState(message.state as unknown as Record<string, unknown>);
-					} else {
-						resetWorkspace();
-						await refreshTimelineData();
-						setLastRestoredState(null);
-					}
+					await restoreSnapshot(message.state as unknown as SessionSnapshot);
 				})();
 			}
 		});

--- a/client/src/hooks/useProjectSession.ts
+++ b/client/src/hooks/useProjectSession.ts
@@ -39,7 +39,7 @@ export function useProjectSession(): void {
 
 	useEffect(() => {
 		const handleProjectOpened = async (message: { project: ProjectRecord; state?: unknown }) => {
-			const snapshot = message.state as SessionSnapshot | null | undefined;
+			const snapshot = message.state as unknown as SessionSnapshot | null | undefined;
 
 			setProject(message.project);
 			resetPlotHistory();
@@ -80,7 +80,7 @@ export function useProjectSession(): void {
 		const offState = socketService.on("project_state", (message) => {
 			if (message.type === "project_state" && message.state) {
 				void (async () => {
-					const applied = await applySessionSnapshot(message.state as SessionSnapshot);
+					const applied = await applySessionSnapshot(message.state as unknown as SessionSnapshot);
 					if (applied) {
 						setLastRestoredState(message.state as unknown as Record<string, unknown>);
 					} else {

--- a/client/src/hooks/useProjectSession.ts
+++ b/client/src/hooks/useProjectSession.ts
@@ -1,11 +1,12 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import type { ProjectRecord } from "shared";
 
 import { useStore } from "@/core";
 import { useFileSystemStore } from "@/core/fileSystemStore";
-import { DEFAULT_R_SCRIPT } from "@/core/state/slices/editorSlice";
 import { projectService } from "@/services/projectService";
+import type { SessionSnapshot } from "@/services/sessionPersistence";
 import {
+	DEFAULT_VIEW_STATE,
 	applySessionSnapshot,
 	getSessionSnapshot,
 	refreshTimelineData,
@@ -13,15 +14,21 @@ import {
 import { requestPlotHistory } from "@/services/plotHistoryService";
 import { socketService } from "@/services/socket";
 
-function resetWorkspace(options: { useSample?: boolean } = {}): void {
-	const state = useStore.getState();
-	const useSample = options.useSample ?? false;
-	state.setEditorContent(useSample ? DEFAULT_R_SCRIPT : "# New R Script\n\n");
-	state.setEditorFilepath(useSample ? "analysis.R" : "");
-	state.setEditorIsDirty(false);
-	state.clearAIMessages();
-	state.resetExecutionState();
-	state.reset();
+function resetWorkspace(): void {
+	const store = useStore.getState();
+	useStore.setState((state) => ({
+		editor: { ...state.editor, content: "", filepath: "", isDirty: false },
+		view: {
+			panes: { ...DEFAULT_VIEW_STATE.panes },
+			modals: { ...DEFAULT_VIEW_STATE.modals },
+			zoom: DEFAULT_VIEW_STATE.zoom,
+		},
+	}));
+	store.setZoomLevel(DEFAULT_VIEW_STATE.zoom);
+	store.clearAIMessages();
+	store.resetExecutionState();
+	store.reset();
+	useFileSystemStore.getState().setActivePath(null);
 }
 
 export function useProjectSession(): void {
@@ -29,14 +36,10 @@ export function useProjectSession(): void {
 	const setProjects = useStore((state) => state.setProjects);
 	const setLastRestoredState = useStore((state) => state.setLastRestoredState);
 	const resetPlotHistory = useStore((state) => state.resetPlotHistory);
-	const previousProjectId = useRef<string | null>(null);
 
 	useEffect(() => {
-		const handleProjectOpened = (message: { project: ProjectRecord; state?: unknown }) => {
-			const nextProjectId = message.project.id;
-			const hasState = Boolean(message.state);
-			const isSameProject = previousProjectId.current === nextProjectId;
-			previousProjectId.current = nextProjectId;
+		const handleProjectOpened = async (message: { project: ProjectRecord; state?: unknown }) => {
+			const snapshot = message.state as SessionSnapshot | null | undefined;
 
 			setProject(message.project);
 			resetPlotHistory();
@@ -46,23 +49,25 @@ export function useProjectSession(): void {
 			const resetAndLoadRoot = useFileSystemStore.getState().resetAndLoadRoot;
 			void resetAndLoadRoot();
 
-			if (hasState) {
-				applySessionSnapshot(message.state as any);
-				setLastRestoredState(message.state as Record<string, unknown>);
-				const editorState = useStore.getState().editor;
-				if (!editorState.content?.trim()) {
-					resetWorkspace({ useSample: true });
+			if (snapshot) {
+				const applied = await applySessionSnapshot(snapshot);
+				if (applied) {
+					setLastRestoredState(snapshot as unknown as Record<string, unknown>);
+				} else {
+					resetWorkspace();
+					await refreshTimelineData();
+					setLastRestoredState(null);
 				}
-			} else if (!isSameProject) {
-				resetWorkspace({ useSample: true });
-				void refreshTimelineData();
+			} else {
+				resetWorkspace();
+				await refreshTimelineData();
 				setLastRestoredState(null);
 			}
 		};
 
 		const offOpened = socketService.on("project_opened", (message) => {
 			if (message.type === "project_opened") {
-				handleProjectOpened(message);
+				void handleProjectOpened(message);
 			}
 		});
 
@@ -74,8 +79,16 @@ export function useProjectSession(): void {
 
 		const offState = socketService.on("project_state", (message) => {
 			if (message.type === "project_state" && message.state) {
-				applySessionSnapshot(message.state as any);
-				setLastRestoredState(message.state as Record<string, unknown>);
+				void (async () => {
+					const applied = await applySessionSnapshot(message.state as SessionSnapshot);
+					if (applied) {
+						setLastRestoredState(message.state as unknown as Record<string, unknown>);
+					} else {
+						resetWorkspace();
+						await refreshTimelineData();
+						setLastRestoredState(null);
+					}
+				})();
 			}
 		});
 

--- a/client/src/services/sessionPersistence.ts
+++ b/client/src/services/sessionPersistence.ts
@@ -1,35 +1,92 @@
-import type { AIMessage, AppSettings, ExecutionLogEntry } from "@shared/types";
 import { useStore } from "@/core";
-import { extractCodeBlocks } from "@/core/ai/codeBlockUtils";
+import { useFileSystemStore } from "@/core/fileSystemStore";
+import type { ViewData } from "@/core/state/slices/viewSlice";
+import { fileSystem } from "@/services/fileSystem";
 import { queryTimeline } from "@/services/timelineService";
 
-const SNAPSHOT_VERSION = 1;
+const SNAPSHOT_VERSION = 2;
 const STORAGE_FILENAME = () =>
 	`reprod-session-${new Date().toISOString().replace(/[:]/g, "-")}.json`;
+
+export const DEFAULT_VIEW_STATE: ViewData = {
+	panes: {
+		files: true,
+		editor: true,
+		assistant: true,
+	},
+	modals: {
+		export: false,
+		shortcuts: false,
+		about: false,
+		sessionInfo: false,
+		settings: false,
+		projects: false,
+	},
+	zoom: 1,
+};
 
 export interface SessionSnapshot {
 	version: number;
 	savedAt: number;
-	editor: {
-		content: string;
-		filepath: string;
+	editor?: {
+		filepath: string | null;
 	};
-	executionHistory: ExecutionLogEntry[];
-	settings: AppSettings;
-	aiMessages: AIMessage[];
+	view?: ViewData;
 }
 
-const normalizeAIMessages = (messages: AIMessage[]): AIMessage[] =>
-	messages.map((message) => {
-		if (message.codeBlocks && message.codeBlocks.length > 0) {
-			return message;
-		}
+const mergeViewState = (view?: ViewData): ViewData => ({
+	panes: { ...DEFAULT_VIEW_STATE.panes, ...(view?.panes ?? {}) },
+	modals: { ...DEFAULT_VIEW_STATE.modals, ...(view?.modals ?? {}) },
+	zoom: view?.zoom ?? DEFAULT_VIEW_STATE.zoom,
+});
 
-		const fallbackText = message.content || message.code || "";
-		const codeBlocks = fallbackText ? extractCodeBlocks(fallbackText) : [];
+const applyViewState = (view?: ViewData): void => {
+	const merged = mergeViewState(view);
+	useStore.setState((state) => ({
+		...state,
+		view: {
+			panes: { ...state.view.panes, ...merged.panes },
+			modals: { ...state.view.modals, ...merged.modals },
+			zoom: merged.zoom,
+		},
+	}));
+	useStore.getState().setZoomLevel(merged.zoom);
+};
 
-		return codeBlocks.length ? { ...message, codeBlocks } : message;
-	});
+const resetDomainState = (): void => {
+	const state = useStore.getState();
+	state.clearAIMessages();
+	state.resetExecutionState();
+	state.reset();
+};
+
+const restoreEditorFromFilesystem = async (filepath: string | null): Promise<void> => {
+	const normalizedPath = filepath ?? "";
+	useFileSystemStore.getState().setActivePath(normalizedPath || null);
+
+	if (!normalizedPath) {
+		useStore.setState((state) => ({
+			editor: { ...state.editor, content: "", filepath: "", isDirty: false },
+		}));
+		return;
+	}
+
+	useStore.setState((state) => ({
+		editor: { ...state.editor, content: "", filepath: normalizedPath, isDirty: false },
+	}));
+
+	try {
+		const content = await fileSystem.readFile(normalizedPath);
+		useStore.setState((state) => ({
+			editor: { ...state.editor, content, filepath: normalizedPath, isDirty: false },
+		}));
+	} catch (error) {
+		console.error("Failed to load file from filesystem", error);
+		useStore.setState((state) => ({
+			editor: { ...state.editor, content: "", filepath: normalizedPath, isDirty: false },
+		}));
+	}
+};
 
 export function getSessionSnapshot(): SessionSnapshot {
 	const state = useStore.getState();
@@ -37,12 +94,9 @@ export function getSessionSnapshot(): SessionSnapshot {
 		version: SNAPSHOT_VERSION,
 		savedAt: Date.now(),
 		editor: {
-			content: state.editor.content,
-			filepath: state.editor.filepath,
+			filepath: state.editor.filepath || null,
 		},
-		executionHistory: state.execution.history,
-		settings: state.settings,
-		aiMessages: normalizeAIMessages(state.ai.messages),
+		view: mergeViewState(state.view),
 	};
 }
 
@@ -71,7 +125,7 @@ export function importSessionSnapshot(): void {
 		try {
 			const text = await file.text();
 			const data = JSON.parse(text) as SessionSnapshot;
-			applySessionSnapshot(data);
+			await applySessionSnapshot(data);
 		} catch (error) {
 			window.alert("Unable to load session snapshot. Ensure the file is valid JSON.");
 		}
@@ -80,20 +134,21 @@ export function importSessionSnapshot(): void {
 	input.click();
 }
 
-export function applySessionSnapshot(snapshot: SessionSnapshot): void {
+export async function applySessionSnapshot(snapshot: SessionSnapshot): Promise<boolean> {
 	if (snapshot.version !== SNAPSHOT_VERSION) {
 		window.alert("Session snapshot version is not compatible with this build.");
-		return;
+		resetDomainState();
+		applyViewState();
+		await restoreEditorFromFilesystem(snapshot.editor?.filepath ?? null);
+		void refreshTimelineData();
+		return false;
 	}
 
-	const state = useStore.getState();
-	state.setEditorContent(snapshot.editor.content);
-	state.setEditorFilepath(snapshot.editor.filepath);
-	state.setEditorIsDirty(false);
-	state.loadExecutionHistory(snapshot.executionHistory ?? []);
-	state.updateSettings(snapshot.settings);
-	state.setAIMessages(normalizeAIMessages(snapshot.aiMessages ?? []));
+	resetDomainState();
+	applyViewState(snapshot.view);
+	await restoreEditorFromFilesystem(snapshot.editor?.filepath ?? null);
 	void refreshTimelineData();
+	return true;
 }
 
 export async function refreshTimelineData(): Promise<void> {

--- a/server/src/projects.rs
+++ b/server/src/projects.rs
@@ -12,6 +12,7 @@ use reprod_core::{
     },
     Config, RExecutor,
 };
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -19,6 +20,91 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SessionSnapshot {
+    version: u32,
+    saved_at: u64,
+    #[serde(default)]
+    editor: SessionEditor,
+    #[serde(default)]
+    view: SessionView,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SessionEditor {
+    #[serde(default)]
+    filepath: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SessionView {
+    #[serde(default)]
+    panes: SessionPanes,
+    #[serde(default)]
+    modals: SessionModals,
+    #[serde(default = "default_zoom")]
+    zoom: f32,
+}
+
+impl Default for SessionView {
+    fn default() -> Self {
+        Self {
+            panes: SessionPanes::default(),
+            modals: SessionModals::default(),
+            zoom: default_zoom(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SessionPanes {
+    #[serde(default = "true_bool")]
+    files: bool,
+    #[serde(default = "true_bool")]
+    editor: bool,
+    #[serde(default = "true_bool")]
+    assistant: bool,
+}
+
+impl Default for SessionPanes {
+    fn default() -> Self {
+        Self {
+            files: true,
+            editor: true,
+            assistant: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SessionModals {
+    #[serde(default)]
+    export: bool,
+    #[serde(default)]
+    shortcuts: bool,
+    #[serde(default)]
+    about: bool,
+    #[serde(default)]
+    session_info: bool,
+    #[serde(default)]
+    settings: bool,
+    #[serde(default)]
+    projects: bool,
+}
+
+fn true_bool() -> bool {
+    true
+}
+
+fn default_zoom() -> f32 {
+    1.0
+}
 
 pub struct ProjectRuntime {
     pub descriptor: ProjectDescriptor,
@@ -259,9 +345,22 @@ impl ProjectController {
         }
         let content = std::fs::read_to_string(&state_path)
             .with_context(|| format!("Failed to read {}", state_path.display()))?;
-        let value =
+        let value: serde_json::Value =
             serde_json::from_str(&content).context("Failed to parse project state document")?;
-        Ok(Some(value))
+
+        match serde_json::from_value::<SessionSnapshot>(value) {
+            Ok(snapshot) => Ok(Some(
+                serde_json::to_value(snapshot).context("Failed to serialize project state")?,
+            )),
+            Err(error) => {
+                tracing::warn!(
+                    "Ignoring invalid project state for {}: {}",
+                    runtime.descriptor.config.id,
+                    error
+                );
+                Ok(None)
+            }
+        }
     }
 
     pub async fn save_state(&self, project_id: &str, payload: serde_json::Value) -> Result<()> {
@@ -279,8 +378,10 @@ impl ProjectController {
                 )
             })?;
         }
+        let snapshot: SessionSnapshot = serde_json::from_value(payload)
+            .context("Project state payload contains unsupported fields")?;
         let content =
-            serde_json::to_string_pretty(&payload).context("Failed to serialize project state")?;
+            serde_json::to_string_pretty(&snapshot).context("Failed to serialize project state")?;
         std::fs::write(&state_path, content)
             .with_context(|| format!("Failed to write {}", state_path.display()))
     }


### PR DESCRIPTION
## Description
- limit session snapshot to UI layout metadata and reload editor content from filesystem on project open
- clear domain state on restore, refresh timeline, and validate UI-only payload server-side to prevent stale overwrites

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to develop:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (pnpm test)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from develop → main (REQUIRED):
- [ ] ✅ E2E tests ran successfully locally
  bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing
- pnpm -r lint
- pnpm --filter client test

## Screenshots (if applicable)

## Related Issues
Closes #221