### PR TITLE
refactor: server-owned runs consistency + streaming

### DIFF
--- a/client/src/components/console/ConsolePanel.tsx
+++ b/client/src/components/console/ConsolePanel.tsx
@@ -37,6 +37,11 @@ export function ConsolePanel({ view }: ConsolePanelProps): JSX.Element {
 			<div className="panel-content console-content">
 				{view === "console" && (
 					<div className="console-output">
+						{execution.lastError && (
+							<div className="console-error-banner" role="alert">
+								{execution.lastError}
+							</div>
+						)}
 						{execution.results.length === 0 ? (
 							<div className="console-welcome">
 								<p>Console ready. Run R code to see output here.</p>

--- a/client/src/core/init/socketListeners.ts
+++ b/client/src/core/init/socketListeners.ts
@@ -51,7 +51,8 @@ export function setupSocketListeners(): () => void {
 		},
 		run_started: (message) => {
 			store.applyRunStarted(message.run);
-			store.setIsRunning(true);
+			store.setExecutionError(null);
+			setIsRunningFromExecutionState();
 		},
 		run_output: (message) => {
 			store.applyRunOutput(message);

--- a/client/src/core/state/slices/executionSlice.ts
+++ b/client/src/core/state/slices/executionSlice.ts
@@ -7,8 +7,10 @@ export interface ExecutionState {
 		results: ExecutionLogEntry[];
 		history: ExecutionLogEntry[];
 		currentCell: number | undefined;
+		lastError: string | null;
 	};
 	setIsRunning: (isRunning: boolean) => void;
+	setExecutionError: (message: string | null) => void;
 	appendExecutionEntry: (entry: ExecutionLogEntry) => void;
 	applyRunState: (runs: RunSummary[]) => void;
 	applyRunStarted: (run: RunSummary) => void;
@@ -25,10 +27,15 @@ export const createExecutionSlice: StateCreator<ExecutionState> = (set) => ({
 		results: [],
 		history: [],
 		currentCell: undefined,
+		lastError: null,
 	},
 	setIsRunning: (isRunning) =>
 		set((state) => ({
 			execution: { ...state.execution, isRunning },
+		})),
+	setExecutionError: (message) =>
+		set((state) => ({
+			execution: { ...state.execution, lastError: message },
 		})),
 	appendExecutionEntry: (entry) =>
 		set((state) => {
@@ -113,6 +120,7 @@ export const createExecutionSlice: StateCreator<ExecutionState> = (set) => ({
 				results: [],
 				history: [],
 				currentCell: undefined,
+				lastError: null,
 			},
 		})),
 });

--- a/client/src/css/components/console.css
+++ b/client/src/css/components/console.css
@@ -11,6 +11,18 @@
 	background: var(--bg-primary);
 }
 
+.console-error-banner {
+	margin-bottom: 12px;
+	padding: 10px 12px;
+	border-radius: 10px;
+	border: 1px solid var(--border-medium);
+	background: rgba(220, 76, 63, 0.08);
+	color: var(--error-color);
+	font-size: 12px;
+	line-height: 1.4;
+	white-space: pre-wrap;
+}
+
 .console-welcome {
 	color: var(--text-secondary);
 	font-style: italic;

--- a/client/src/hooks/useEditorExecution.ts
+++ b/client/src/hooks/useEditorExecution.ts
@@ -1,4 +1,3 @@
-import type { ExecutionLogEntry } from "@shared/types";
 import type { editor as MonacoEditor } from "monaco-editor";
 import type { MutableRefObject } from "react";
 import { useCallback, useState } from "react";
@@ -18,28 +17,18 @@ interface UseEditorExecutionProps {
 	cells: Cell[];
 }
 
-const normalizeFailure = (message: string, code: string): ExecutionLogEntry => ({
-	runId: undefined,
-	code,
-	stdout: "",
-	stderr: message,
-	plots: [],
-	timestamp: Date.now(),
-	duration: 0,
-	success: false,
-});
-
 export function useEditorExecution({ editorRef, cells }: UseEditorExecutionProps) {
 	const editorContent = useStore((state) => state.editor.content);
 	const editorFilepath = useStore((state) => state.editor.filepath);
 	const cursorLine = useStore((state) => state.editor.cursorPosition.line);
 	const setIsRunning = useStore((state) => state.setIsRunning);
-	const appendExecutionEntry = useStore((state) => state.appendExecutionEntry);
+	const setExecutionError = useStore((state) => state.setExecutionError);
 
 	const [executingCellIndex, setExecutingCellIndex] = useState<number | null>(null);
 
 	const executeCode = useCallback(
 		async (target: ExecutionTarget, cellIndex?: number | null) => {
+			setExecutionError(null);
 			setIsRunning(true);
 			if (cellIndex !== undefined && cellIndex !== null) {
 				setExecutingCellIndex(cellIndex);
@@ -59,13 +48,13 @@ export function useEditorExecution({ editorRef, cells }: UseEditorExecutionProps
 					error instanceof ExecutionServiceError
 						? error.message
 						: "Execution failed due to an unexpected error.";
-				appendExecutionEntry(normalizeFailure(message, target.code));
+				setExecutionError(message);
 				setIsRunning(false);
 			} finally {
 				setExecutingCellIndex(null);
 			}
 		},
-		[appendExecutionEntry, cells, editorContent, editorFilepath, setIsRunning],
+		[cells, editorContent, editorFilepath, setExecutionError, setIsRunning],
 	);
 
 	const handleRunAll = useCallback(() => {

--- a/core/src/execution_repository.rs
+++ b/core/src/execution_repository.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 #[async_trait]
 pub trait ExecutionRepository: Send + Sync {
     async fn create_run(&self, event: ExecutionEvent) -> Result<ExecutionEvent>;
+    async fn update_run(&self, event: ExecutionEvent) -> Result<ExecutionEvent>;
     async fn finish_run(&self, event: ExecutionEvent) -> Result<ExecutionEvent>;
     async fn latest_runs(&self, limit: usize) -> Result<Vec<ExecutionEvent>>;
     async fn get_run(&self, event_id: &str) -> Result<Option<ExecutionEvent>>;
@@ -40,6 +41,11 @@ impl TimelineExecutionRepository {
 impl ExecutionRepository for TimelineExecutionRepository {
     async fn create_run(&self, event: ExecutionEvent) -> Result<ExecutionEvent> {
         self.timeline.record(event.clone()).await?;
+        Ok(event)
+    }
+
+    async fn update_run(&self, event: ExecutionEvent) -> Result<ExecutionEvent> {
+        self.timeline.update(event.clone())?;
         Ok(event)
     }
 

--- a/core/src/executor/command_runner.rs
+++ b/core/src/executor/command_runner.rs
@@ -14,7 +14,7 @@ use tokio::{
     fs,
     io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
     process::{Child, Command},
-    sync::Mutex as AsyncMutex,
+    sync::{mpsc, Mutex as AsyncMutex},
     task::JoinHandle,
     time::{timeout, Duration},
 };
@@ -253,6 +253,79 @@ impl PersistentProcessCommandRunner {
 
         Ok((stdout_buf, stderr_buf, !saw_error_marker))
     }
+
+    async fn read_until_delimiter_streaming(
+        child: &mut PersistentChild,
+        timeout_duration: Duration,
+        on_chunk: &mut (dyn FnMut(String, bool) + Send),
+    ) -> Result<(Vec<u8>, Vec<u8>, bool)> {
+        let mut stdout_buf = Vec::new();
+        let mut stderr_buf = Vec::new();
+        let mut saw_error_marker = false;
+        let mut stdout_line = String::new();
+        let mut stderr_line = String::new();
+
+        loop {
+            let read_result = timeout(timeout_duration, async {
+                tokio::select! {
+                    res = child.stdout.read_line(&mut stdout_line) => res.map(|n| ("stdout", n)),
+                    res = child.stderr.read_line(&mut stderr_line) => res.map(|n| ("stderr", n)),
+                }
+            })
+            .await??;
+
+            match read_result {
+                ("stdout", 0) => break,
+                ("stdout", _) => {
+                    if stdout_line.contains(PERSISTENT_DELIMITER) {
+                        stdout_line.clear();
+                        break;
+                    }
+                    stdout_buf.extend_from_slice(stdout_line.as_bytes());
+                    let trimmed = stdout_line.trim_end_matches(['\n', '\r']).to_string();
+                    if !trimmed.is_empty() {
+                        on_chunk(trimmed, true);
+                    }
+                    stdout_line.clear();
+                }
+                ("stderr", 0) => continue,
+                ("stderr", _) => {
+                    stderr_buf.extend_from_slice(stderr_line.as_bytes());
+                    if stderr_line.contains("REPROD_ERROR:") {
+                        saw_error_marker = true;
+                    }
+                    let trimmed = stderr_line.trim_end_matches(['\n', '\r']).to_string();
+                    if !trimmed.is_empty() {
+                        on_chunk(trimmed, false);
+                    }
+                    stderr_line.clear();
+                }
+                _ => {}
+            }
+        }
+
+        loop {
+            match timeout(
+                Duration::from_millis(50),
+                child.stderr.read_line(&mut stderr_line),
+            )
+            .await
+            {
+                Ok(Ok(0)) | Err(_) => break,
+                Ok(Ok(_)) => {
+                    stderr_buf.extend_from_slice(stderr_line.as_bytes());
+                    let trimmed = stderr_line.trim_end_matches(['\n', '\r']).to_string();
+                    if !trimmed.is_empty() {
+                        on_chunk(trimmed, false);
+                    }
+                    stderr_line.clear();
+                }
+                Ok(Err(e)) => return Err(anyhow!(e)),
+            }
+        }
+
+        Ok((stdout_buf, stderr_buf, !saw_error_marker))
+    }
 }
 
 #[async_trait]
@@ -306,6 +379,103 @@ impl CommandRunner for ProcessCommandRunner {
             .await
             .map_err(|e| anyhow!("Failed to join stderr task: {}", e))??;
 
+        Ok(CommandOutput {
+            success: status.success(),
+            stdout: stdout_bytes,
+            stderr: stderr_bytes,
+            interrupted: active.was_interrupted(),
+        })
+    }
+
+    async fn run_streaming(
+        &self,
+        r_path: &str,
+        script_path: &Path,
+        working_dir: &Path,
+        on_chunk: &mut (dyn FnMut(String, bool) + Send),
+    ) -> Result<CommandOutput> {
+        let script_str = script_path
+            .to_str()
+            .ok_or_else(|| anyhow!("Invalid path"))?;
+        let mut child = Command::new(r_path)
+            .args(["--vanilla", "--quiet", script_str])
+            .current_dir(working_dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("Missing stdout"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("Missing stderr"))?;
+
+        let active = ActiveChild::new(child);
+        {
+            let mut guard = self.active_child.lock().await;
+            *guard = Some(active.clone());
+        }
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<(bool, Vec<u8>)>();
+        let stdout_task = spawn_line_reader(BufReader::new(stdout), true, tx.clone());
+        let stderr_task = spawn_line_reader(BufReader::new(stderr), false, tx);
+
+        let mut stdout_bytes: Vec<u8> = Vec::new();
+        let mut stderr_bytes: Vec<u8> = Vec::new();
+
+        let status_fut = active.wait();
+        tokio::pin!(status_fut);
+        let mut status: Option<std::process::ExitStatus> = None;
+        let mut io_closed = false;
+
+        loop {
+            tokio::select! {
+                exit = &mut status_fut, if status.is_none() => {
+                    status = Some(exit.context("Failed to wait for R process")?);
+                    if io_closed {
+                        break;
+                    }
+                }
+                maybe_line = rx.recv() => {
+                    let Some((is_stdout, bytes)) = maybe_line else {
+                        io_closed = true;
+                        if status.is_some() {
+                            break;
+                        }
+                        continue;
+                    };
+
+                    if is_stdout {
+                        stdout_bytes.extend_from_slice(&bytes);
+                    } else {
+                        stderr_bytes.extend_from_slice(&bytes);
+                    }
+
+                    if let Ok(text) = std::str::from_utf8(&bytes) {
+                        for line in text.lines() {
+                            on_chunk(line.to_string(), is_stdout);
+                        }
+                    }
+                }
+            }
+        }
+
+        let _ = stdout_task.await;
+        let _ = stderr_task.await;
+
+        {
+            let mut guard = self.active_child.lock().await;
+            if let Some(current) = guard.as_ref() {
+                if current.matches(&active) {
+                    guard.take();
+                }
+            }
+        }
+
+        let status = status.ok_or_else(|| anyhow!("Missing process status"))?;
         Ok(CommandOutput {
             success: status.success(),
             stdout: stdout_bytes,
@@ -369,6 +539,46 @@ impl CommandRunner for PersistentProcessCommandRunner {
         })
     }
 
+    async fn run_streaming(
+        &self,
+        _r_path: &str,
+        script_path: &Path,
+        _working_dir: &Path,
+        on_chunk: &mut (dyn FnMut(String, bool) + Send),
+    ) -> Result<CommandOutput> {
+        let _guard = self.in_flight.lock().await;
+        self.ensure_child().await?;
+
+        let mut child_guard = self.child.lock().await;
+        let child = child_guard
+            .as_mut()
+            .ok_or_else(|| anyhow!("Persistent process missing"))?;
+
+        let script_str = fs::read_to_string(script_path).await?;
+        let mut block = String::with_capacity(script_str.len() + 4);
+        block.push_str("{\n");
+        block.push_str(&script_str);
+        if !block.ends_with('\n') {
+            block.push('\n');
+        }
+        block.push_str("}\n");
+
+        child.stdin.write_all(block.as_bytes()).await?;
+        child.stdin.flush().await?;
+
+        let (stdout_bytes, stderr_bytes, status_ok) =
+            Self::read_until_delimiter_streaming(child, PERSISTENT_EXECUTION_TIMEOUT, on_chunk)
+                .await?;
+        let was_interrupted = self.interrupted.swap(false, Ordering::SeqCst);
+
+        Ok(CommandOutput {
+            success: status_ok && !was_interrupted,
+            stdout: stdout_bytes,
+            stderr: stderr_bytes,
+            interrupted: was_interrupted,
+        })
+    }
+
     async fn interrupt(&self) -> Result<bool> {
         let mut guard = self.child.lock().await;
         if let Some(child) = guard.as_mut() {
@@ -405,6 +615,31 @@ where
             Ok(buffer)
         } else {
             Ok(Vec::new())
+        }
+    })
+}
+
+fn spawn_line_reader<R>(
+    reader: BufReader<R>,
+    is_stdout: bool,
+    tx: mpsc::UnboundedSender<(bool, Vec<u8>)>,
+) -> JoinHandle<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut reader = reader;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = match reader.read_line(&mut line).await {
+                Ok(n) => n,
+                Err(_) => break,
+            };
+            if n == 0 {
+                break;
+            }
+            let _ = tx.send((is_stdout, line.as_bytes().to_vec()));
         }
     })
 }

--- a/core/src/executor/r_executor.rs
+++ b/core/src/executor/r_executor.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use anyhow::Result;
 use tokio::fs;
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tracing::info;
 use uuid::Uuid;
 
@@ -79,6 +79,33 @@ impl RExecutor {
         Vec<PlotHistoryEntry>,
         Vec<RunOutputChunk>,
     )> {
+        self.execute_with_event_with_history_internal(request, None, None)
+            .await
+    }
+
+    pub async fn execute_with_event_with_history_streaming(
+        &self,
+        request: ExecutionRequest,
+        run_id: &str,
+        output_tx: mpsc::UnboundedSender<RunOutputChunk>,
+    ) -> Result<(ExecutionResult, ExecutionEvent, Vec<PlotHistoryEntry>)> {
+        let (result, event, history, _) = self
+            .execute_with_event_with_history_internal(request, Some(run_id), Some(output_tx))
+            .await?;
+        Ok((result, event, history))
+    }
+
+    async fn execute_with_event_with_history_internal(
+        &self,
+        request: ExecutionRequest,
+        run_id: Option<&str>,
+        output_tx: Option<mpsc::UnboundedSender<RunOutputChunk>>,
+    ) -> Result<(
+        ExecutionResult,
+        ExecutionEvent,
+        Vec<PlotHistoryEntry>,
+        Vec<RunOutputChunk>,
+    )> {
         let start = Instant::now();
 
         let mut blocks = ensure_blocks(&request);
@@ -116,6 +143,7 @@ impl RExecutor {
         let mut streamed_stderr: Vec<String> = Vec::new();
 
         let mut streamed_chunks: Vec<RunOutputChunk> = Vec::new();
+        let run_id = run_id.map(str::to_string);
 
         let command_output = self
             .command_runner
@@ -128,22 +156,25 @@ impl RExecutor {
                     if is_internal_line(&line) {
                         return;
                     }
+                    let chunk = RunOutputChunk {
+                        run_id: run_id.clone().unwrap_or_default(),
+                        stream: if is_stdout {
+                            RunStream::Stdout
+                        } else {
+                            RunStream::Stderr
+                        },
+                        chunk: line.clone(),
+                        at_ms,
+                    };
+                    if let Some(tx) = output_tx.as_ref() {
+                        let _ = tx.send(chunk.clone());
+                    }
                     if is_stdout {
                         streamed_stdout.push(line.clone());
-                        streamed_chunks.push(RunOutputChunk {
-                            run_id: String::new(), // filled by caller
-                            stream: RunStream::Stdout,
-                            chunk: line,
-                            at_ms,
-                        });
+                        streamed_chunks.push(chunk);
                     } else {
                         streamed_stderr.push(line.clone());
-                        streamed_chunks.push(RunOutputChunk {
-                            run_id: String::new(), // filled by caller
-                            stream: RunStream::Stderr,
-                            chunk: line,
-                            at_ms,
-                        });
+                        streamed_chunks.push(chunk);
                     }
                 },
             )

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -8,21 +8,15 @@ use axum::{
 };
 use project_requests::handle_project_request;
 use reprod_core::{
-    executor::ensure_blocks,
-    fs::FileSystemEvent,
-    project::ProjectRecord,
-    ExecutionEvent,
-    ExecutionRequest,
-    ExecutionResult,
-    RunOutputChunk,
-    RunStatus,
-    RunStream,
-    RunSummary,
+    executor::ensure_blocks, fs::FileSystemEvent, project::ProjectRecord, ExecutionEvent,
+    ExecutionRequest, ExecutionResult, RunOutputChunk, RunStatus, RunStream, RunSummary,
 };
 use runtime_fs::{handle_fs_event, spawn_fs_watcher, FsWatcherHandle};
 use serde_json::{self, json};
 use std::sync::Arc;
 use tokio::sync::mpsc as tokio_mpsc;
+use tokio::sync::{broadcast, mpsc};
+use tokio::time::{Duration, Instant};
 use uuid::Uuid;
 
 mod ai_handler;
@@ -38,6 +32,7 @@ mod tool_handler;
 
 pub use common::AppState;
 
+use crate::projects::RuntimeBroadcastEvent;
 use ai_handler::handle_ai_message;
 use common::{error_response, WSRequest, WSResponse};
 use export_handler::handle_export_request;
@@ -63,6 +58,8 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
             return;
         }
     };
+    let mut run_event_rx: broadcast::Receiver<RuntimeBroadcastEvent> =
+        current_runtime.run_events.subscribe();
     let (fs_event_tx, mut fs_event_rx) = tokio_mpsc::unbounded_channel::<FileSystemEvent>();
     let mut fs_watcher = Some(spawn_fs_watcher(
         current_runtime.descriptor.root_path.clone(),
@@ -86,11 +83,34 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                     fs_events_closed = true;
                 }
             }
+            run_event = run_event_rx.recv() => {
+                match run_event {
+                    Ok(event) => {
+                        let response = match event {
+                            RuntimeBroadcastEvent::RunStarted { run } => WSResponse::RunStarted { run },
+                            RuntimeBroadcastEvent::RunOutput { chunk } => WSResponse::RunOutput(chunk),
+                            RuntimeBroadcastEvent::RunFinished { run } => WSResponse::RunFinished { run },
+                            RuntimeBroadcastEvent::TimelineEventAdded { event } => WSResponse::TimelineEventAdded { event },
+                            RuntimeBroadcastEvent::PlotHistoryUpdated { active_plot_id, plots } => WSResponse::PlotHistoryUpdated { active_plot_id, plots },
+                        };
+                        if !send_responses(&mut socket, vec![response]).await {
+                            break 'ws_loop;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        // If the client falls behind, it can recover by issuing `run_query` and/or timeline queries.
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        // Runtime broadcast closed; ignore and keep the socket alive.
+                    }
+                }
+            }
             msg = socket.recv() => {
                 if !handle_ws_text(
                     msg,
                     &state,
                     &mut current_runtime,
+                    &mut run_event_rx,
                     &mut fs_watcher,
                     &fs_event_tx,
                     &mut fs_events_closed,
@@ -112,6 +132,7 @@ async fn handle_ws_text(
     msg: Option<Result<Message, axum::Error>>,
     state: &AppState,
     current_runtime: &mut Arc<ProjectRuntime>,
+    run_event_rx: &mut broadcast::Receiver<RuntimeBroadcastEvent>,
     fs_watcher: &mut Option<FsWatcherHandle>,
     fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
     fs_events_closed: &mut bool,
@@ -124,6 +145,7 @@ async fn handle_ws_text(
                     &request,
                     state,
                     current_runtime,
+                    run_event_rx,
                     fs_watcher,
                     fs_event_tx,
                     fs_events_closed,
@@ -265,7 +287,7 @@ async fn handle_execution_request_streaming(
         },
         environment,
         created_at_ms: started_at,
-        status: RunStatus::Running,
+        status: RunStatus::Queued,
         started_at_ms: started_at,
         finished_at_ms: None,
         duration_ms: None,
@@ -283,142 +305,188 @@ async fn handle_execution_request_streaming(
         .await;
     }
 
-    let started_summary = run_summary_from_event(&running_event);
-    let accepted_and_started = vec![
-        WSResponse::RunAccepted {
-            run_id: run_id.clone(),
-        },
-        WSResponse::RunStarted {
-            run: started_summary,
-        },
-    ];
-    if !send_responses(socket, accepted_and_started).await {
+    let created_summary = run_summary_from_event(&running_event);
+    let accepted = vec![WSResponse::RunAccepted {
+        run_id: run_id.clone(),
+    }];
+    if !send_responses(socket, accepted).await {
         return false;
     }
 
-    let responses =
-        handle_execution_request_body(runtime, request, run_id, running_event).await;
-    send_responses(socket, responses).await
+    // Broadcast a queued run entry so all connected clients render the same server-owned history.
+    let _ = runtime.run_events.send(RuntimeBroadcastEvent::RunStarted {
+        run: created_summary,
+    });
+
+    spawn_execution_task(runtime.clone(), request, run_id, running_event);
+    true
 }
 
-async fn handle_execution_request_body(
-    runtime: &Arc<ProjectRuntime>,
+fn spawn_execution_task(
+    runtime: Arc<ProjectRuntime>,
     request: ExecutionRequest,
     run_id: String,
-    running_event: ExecutionEvent,
-) -> Vec<WSResponse> {
-    let mut responses: Vec<WSResponse> = Vec::new();
+    queued_event: ExecutionEvent,
+) {
+    tokio::spawn(async move {
+        let mut running_event = queued_event.clone();
+        running_event.status = RunStatus::Running;
+        running_event.started_at_ms = queued_event.started_at_ms;
 
-    let executor = runtime.r_executor.lock().await;
-    match executor.execute_with_event_with_history(request).await {
-        Ok((result, mut event, history, streamed_chunks)) => {
-            let finished_at = common::now_millis() as u64;
+        let _ = runtime
+            .execution_repo
+            .update_run(running_event.clone())
+            .await;
+        let _ = runtime.run_events.send(RuntimeBroadcastEvent::RunStarted {
+            run: run_summary_from_event(&running_event),
+        });
 
-            {
-                let mut buffer = runtime.stream_buffer.lock().await;
-                for mut chunk in streamed_chunks {
-                    chunk.run_id = run_id.clone();
-                    buffer.append(chunk.clone());
-                    responses.push(WSResponse::RunOutput(chunk));
+        let (output_tx, mut output_rx) = mpsc::unbounded_channel::<RunOutputChunk>();
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        let mut last_persist = Instant::now();
+
+        let executor_fut = async {
+            let executor = runtime.r_executor.lock().await;
+            executor
+                .execute_with_event_with_history_streaming(request, &run_id, output_tx)
+                .await
+        };
+        tokio::pin!(executor_fut);
+
+        let mut execution_result = None;
+        loop {
+            tokio::select! {
+                result = &mut executor_fut, if execution_result.is_none() => {
+                    execution_result = Some(result);
+                    break;
+                }
+                maybe_chunk = output_rx.recv() => {
+                    let Some(chunk) = maybe_chunk else {
+                        continue;
+                    };
+                    {
+                        let mut buffer = runtime.stream_buffer.lock().await;
+                        buffer.append(chunk.clone());
+                    }
+                    match chunk.stream {
+                        RunStream::Stdout => append_line(&mut stdout, &chunk.chunk),
+                        RunStream::Stderr => append_line(&mut stderr, &chunk.chunk),
+                    }
+                    let _ = runtime.run_events.send(RuntimeBroadcastEvent::RunOutput { chunk: chunk.clone() });
+
+                    if last_persist.elapsed() >= Duration::from_millis(250) {
+                        running_event.result.output = stdout.clone();
+                        running_event.result.error = if stderr.is_empty() { None } else { Some(stderr.clone()) };
+                        let _ = runtime.execution_repo.update_run(running_event.clone()).await;
+                        last_persist = Instant::now();
+                    }
                 }
             }
+        }
 
-            let (stdout, stderr) = {
-                let mut buffer = runtime.stream_buffer.lock().await;
-                buffer.finalize(&run_id)
-            };
-
-            event.event_id = run_id.clone();
-            event.started_at_ms = running_event.started_at_ms;
-            event.finished_at_ms = Some(finished_at);
-            event.duration_ms = Some(finished_at.saturating_sub(running_event.started_at_ms));
-            event.created_at_ms = finished_at;
-            if !stdout.is_empty() {
-                event.result.output = stdout.clone();
-            }
-            if let Some(err) = stderr.clone() {
-                event.result.error = Some(err);
-            }
-            if event.result.output.is_empty() && !result.output.is_empty() {
-                event.result.output = result.output.clone();
-            }
-            if event.result.error.is_none() {
-                event.result.error = result.error.clone();
-            }
-            event.status = if result.success {
-                RunStatus::Succeeded
-            } else {
-                RunStatus::Failed
-            };
-
-            if responses
-                .iter()
-                .all(|r| !matches!(r, WSResponse::RunOutput(_)))
+        // Drain any remaining chunks queued before the executor finished.
+        while let Ok(chunk) = output_rx.try_recv() {
             {
-                responses.extend(
-                    run_output_chunks_from_event(&event)
-                        .into_iter()
-                        .map(WSResponse::RunOutput),
-                );
+                let mut buffer = runtime.stream_buffer.lock().await;
+                buffer.append(chunk.clone());
             }
-
-            if let Err(e) = runtime.execution_repo.finish_run(event.clone()).await {
-                responses.extend(error_response(format!("Failed to persist run: {}", e)));
-                return responses;
+            match chunk.stream {
+                RunStream::Stdout => append_line(&mut stdout, &chunk.chunk),
+                RunStream::Stderr => append_line(&mut stderr, &chunk.chunk),
             }
+            let _ = runtime
+                .run_events
+                .send(RuntimeBroadcastEvent::RunOutput { chunk });
+        }
 
-            let summary = run_summary_from_event(&event);
-            responses.push(WSResponse::TimelineEventAdded { event: event.clone() });
-            responses.push(WSResponse::RunFinished {
-                run: summary,
-            });
+        let finished_at = common::now_millis() as u64;
+        let Some(execution_result) = execution_result else {
+            return;
+        };
+        match execution_result {
+            Ok((result, mut event, history)) => {
+                event.event_id = run_id.clone();
+                event.started_at_ms = queued_event.started_at_ms;
+                event.finished_at_ms = Some(finished_at);
+                event.duration_ms = Some(finished_at.saturating_sub(queued_event.started_at_ms));
+                event.created_at_ms = finished_at;
+                event.result.output = stdout;
+                event.result.error = if stderr.is_empty() {
+                    None
+                } else {
+                    Some(stderr)
+                };
+                event.status = if result.success {
+                    RunStatus::Succeeded
+                } else {
+                    RunStatus::Failed
+                };
 
-            if !history.is_empty() {
-                let active_plot_id = history.last().map(|plot| plot.id.clone());
-                responses.push(WSResponse::PlotHistoryUpdated {
-                    active_plot_id,
-                    plots: history,
+                let _ = runtime.execution_repo.finish_run(event.clone()).await;
+                runtime.stream_buffer.lock().await.remove_run(&run_id);
+                let summary = run_summary_from_event(&event);
+                let _ = runtime
+                    .run_events
+                    .send(RuntimeBroadcastEvent::TimelineEventAdded {
+                        event: event.clone(),
+                    });
+                let _ = runtime
+                    .run_events
+                    .send(RuntimeBroadcastEvent::RunFinished { run: summary });
+
+                if !history.is_empty() {
+                    let active_plot_id = history.last().map(|plot| plot.id.clone());
+                    let _ = runtime
+                        .run_events
+                        .send(RuntimeBroadcastEvent::PlotHistoryUpdated {
+                            active_plot_id,
+                            plots: history,
+                        });
+                }
+            }
+            Err(e) => {
+                let error_message = e.to_string();
+                let mut failed_event = queued_event.clone();
+                failed_event.status = RunStatus::Failed;
+                failed_event.created_at_ms = finished_at;
+                failed_event.finished_at_ms = Some(finished_at);
+                failed_event.duration_ms =
+                    Some(finished_at.saturating_sub(queued_event.started_at_ms));
+                failed_event.result = ExecutionResult {
+                    success: false,
+                    output: stdout,
+                    error: if stderr.is_empty() {
+                        Some(error_message)
+                    } else {
+                        Some(format!("{}\n{}", stderr, error_message))
+                    },
+                    plots: Vec::new(),
+                    execution_time_ms: 0,
+                };
+                let _ = runtime
+                    .execution_repo
+                    .finish_run(failed_event.clone())
+                    .await;
+                runtime.stream_buffer.lock().await.remove_run(&run_id);
+                let _ = runtime.run_events.send(RuntimeBroadcastEvent::RunFinished {
+                    run: run_summary_from_event(&failed_event),
                 });
             }
         }
-        Err(e) => {
-            let finished_at = common::now_millis() as u64;
-            let (stdout, stderr) = {
-                let mut buffer = runtime.stream_buffer.lock().await;
-                buffer.finalize(&run_id)
-            };
-            let error_message = e.to_string();
-            let mut failed_event = running_event.clone();
-            failed_event.status = RunStatus::Failed;
-            failed_event.created_at_ms = finished_at;
-            failed_event.finished_at_ms = Some(finished_at);
-            failed_event.duration_ms = Some(finished_at.saturating_sub(running_event.started_at_ms));
-            failed_event.result = ExecutionResult {
-                success: false,
-                output: stdout,
-                error: Some(
-                    stderr
-                        .filter(|s| !s.is_empty())
-                        .map(|s| format!("{}\n{}", s, error_message))
-                        .unwrap_or_else(|| error_message.clone()),
-                ),
-                plots: Vec::new(),
-                execution_time_ms: 0,
-            };
-            let _ = runtime.execution_repo.finish_run(failed_event.clone()).await;
-            responses.extend(
-                run_output_chunks_from_event(&failed_event)
-                    .into_iter()
-                    .map(WSResponse::RunOutput),
-            );
-            responses.extend(error_response(e.to_string()));
-            responses.push(WSResponse::RunFinished {
-                run: run_summary_from_event(&failed_event),
-            });
-        }
-    }
+    });
+}
 
-    responses
+fn append_line(target: &mut String, line: &str) {
+    if line.is_empty() {
+        return;
+    }
+    if target.is_empty() {
+        target.push_str(line);
+    } else {
+        target.push('\n');
+        target.push_str(line);
+    }
 }
 
 fn handle_fs_action(
@@ -570,14 +638,11 @@ async fn build_run_state_responses(
     let mut responses = common::single_response(WSResponse::RunState { runs });
 
     for event in events {
-        if matches!(event.status, RunStatus::Running) {
-            let buffered = runtime
-                .stream_buffer
-                .lock()
-                .await
-                .get(&event.event_id);
+        if matches!(event.status, RunStatus::Running | RunStatus::Queued) {
+            let buffered = runtime.stream_buffer.lock().await.get(&event.event_id);
             responses.extend(buffered.into_iter().map(WSResponse::RunOutput));
         } else {
+            // Replay stdout/stderr from the persisted run record for finished runs.
             responses.extend(
                 run_output_chunks_from_event(&event)
                     .into_iter()

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -8,8 +8,9 @@ use axum::{
 };
 use project_requests::handle_project_request;
 use reprod_core::{
-    executor::ensure_blocks, fs::FileSystemEvent, project::ProjectRecord, ExecutionEvent,
-    ExecutionRequest, ExecutionResult, RunOutputChunk, RunStatus, RunStream, RunSummary,
+    executor::ensure_blocks, fs::FileSystemEvent, project::ProjectRecord, ArtifactInfo,
+    ExecutionEvent, ExecutionRequest, ExecutionResult, RunOutputChunk, RunStatus, RunStream,
+    RunSummary,
 };
 use runtime_fs::{handle_fs_event, spawn_fs_watcher, FsWatcherHandle};
 use serde_json::{self, json};
@@ -640,7 +641,16 @@ async fn build_run_state_responses(
     for event in events {
         if matches!(event.status, RunStatus::Running | RunStatus::Queued) {
             let buffered = runtime.stream_buffer.lock().await.get(&event.event_id);
-            responses.extend(buffered.into_iter().map(WSResponse::RunOutput));
+            if buffered.is_empty() {
+                // Fallback for cases like server restarts where the in-memory buffer is empty.
+                responses.extend(
+                    run_output_chunks_from_event(&event)
+                        .into_iter()
+                        .map(WSResponse::RunOutput),
+                );
+            } else {
+                responses.extend(buffered.into_iter().map(WSResponse::RunOutput));
+            }
         } else {
             // Replay stdout/stderr from the persisted run record for finished runs.
             responses.extend(
@@ -655,6 +665,21 @@ async fn build_run_state_responses(
 }
 
 fn run_summary_from_event(event: &ExecutionEvent) -> RunSummary {
+    let artifacts: Vec<ArtifactInfo> = event
+        .result
+        .plots
+        .iter()
+        .map(|plot| ArtifactInfo {
+            path: plot
+                .storage_path
+                .clone()
+                .unwrap_or_else(|| plot.filename.clone()),
+            artifact_type: "plot".to_string(),
+            label: Some(plot.filename.clone()),
+            record_as: format!("plot[{}]", plot.index),
+        })
+        .collect();
+
     RunSummary {
         run_id: event.event_id.clone(),
         status: event.status.clone(),
@@ -664,7 +689,11 @@ fn run_summary_from_event(event: &ExecutionEvent) -> RunSummary {
         code: event.blocks.first().map(|b| b.code.clone()),
         has_stdout: !event.result.output.is_empty(),
         has_stderr: event.result.error.is_some(),
-        artifacts: None,
+        artifacts: if artifacts.is_empty() {
+            None
+        } else {
+            Some(artifacts)
+        },
         plots: if event.result.plots.is_empty() {
             None
         } else {

--- a/server/src/handlers/project_requests.rs
+++ b/server/src/handlers/project_requests.rs
@@ -2,11 +2,12 @@ use std::path::Path;
 use std::sync::Arc;
 
 use axum::extract::ws::WebSocket;
+use tokio::sync::broadcast;
 
 use super::common::{error_response, WSRequest, WSResponse};
 use super::runtime_fs::restart_fs_watcher;
 use super::{build_project_opened_response, send_responses, AppState};
-use crate::projects::ProjectRuntime;
+use crate::projects::{ProjectRuntime, RuntimeBroadcastEvent};
 use reprod_core::fs::FileSystemEvent;
 use tokio::sync::mpsc as tokio_mpsc;
 
@@ -16,6 +17,7 @@ pub async fn handle_project_request(
     request: &WSRequest,
     state: &AppState,
     current_runtime: &mut Arc<ProjectRuntime>,
+    run_event_rx: &mut broadcast::Receiver<RuntimeBroadcastEvent>,
     fs_watcher: &mut Option<FsWatcherHandle>,
     fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
     fs_events_closed: &mut bool,
@@ -30,6 +32,7 @@ pub async fn handle_project_request(
             switch_runtime(
                 state,
                 current_runtime,
+                run_event_rx,
                 fs_watcher,
                 fs_event_tx,
                 fs_events_closed,
@@ -47,6 +50,7 @@ pub async fn handle_project_request(
                 switch_runtime(
                     state,
                     current_runtime,
+                    run_event_rx,
                     fs_watcher,
                     fs_event_tx,
                     fs_events_closed,
@@ -63,6 +67,7 @@ pub async fn handle_project_request(
                     switch_runtime(
                         state,
                         current_runtime,
+                        run_event_rx,
                         fs_watcher,
                         fs_event_tx,
                         fs_events_closed,
@@ -83,6 +88,7 @@ pub async fn handle_project_request(
                 switch_runtime(
                     state,
                     current_runtime,
+                    run_event_rx,
                     fs_watcher,
                     fs_event_tx,
                     fs_events_closed,
@@ -132,6 +138,7 @@ pub async fn handle_project_request(
 async fn switch_runtime(
     state: &AppState,
     current_runtime: &mut Arc<ProjectRuntime>,
+    run_event_rx: &mut broadcast::Receiver<RuntimeBroadcastEvent>,
     fs_watcher: &mut Option<FsWatcherHandle>,
     fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
     fs_events_closed: &mut bool,
@@ -141,6 +148,7 @@ async fn switch_runtime(
     match state.projects.runtime_for(project_id).await {
         Ok(runtime) => {
             *current_runtime = runtime;
+            *run_event_rx = current_runtime.run_events.subscribe();
             restart_fs_watcher(current_runtime, fs_watcher, fs_event_tx, fs_events_closed);
 
             let responses = vec![build_project_opened_response(state, current_runtime).await];

--- a/server/src/handlers/session_handler.rs
+++ b/server/src/handlers/session_handler.rs
@@ -21,11 +21,7 @@ pub(super) async fn handle_restart(runtime: &Arc<ProjectRuntime>) -> Vec<WSRespo
             .reset()
             .await
             .map_err(|e| e.to_string())?;
-        runtime
-            .stream_buffer
-            .lock()
-            .await
-            .clear();
+        runtime.stream_buffer.lock().await.clear();
         let cleared = runtime
             .execution_repo
             .reset()

--- a/server/src/handlers/stream_buffer.rs
+++ b/server/src/handlers/stream_buffer.rs
@@ -37,11 +37,19 @@ impl StreamBuffer {
             }
         }
 
-        let error = if stderr.is_empty() { None } else { Some(stderr) };
+        let error = if stderr.is_empty() {
+            None
+        } else {
+            Some(stderr)
+        };
         (stdout, error)
     }
 
     pub fn clear(&mut self) {
         self.chunks.clear();
+    }
+
+    pub fn remove_run(&mut self, run_id: &str) {
+        self.chunks.remove(run_id);
     }
 }

--- a/server/src/projects.rs
+++ b/server/src/projects.rs
@@ -1,9 +1,10 @@
-use anyhow::{anyhow, Context, Result};
 use crate::handlers::stream_buffer::StreamBuffer;
+use anyhow::{anyhow, Context, Result};
 use reprod_core::{
     ai::tools::{FileSystemTool, RContextTool},
     execution_repository::{ExecutionRepository, TimelineExecutionRepository},
     fs::FileSystem,
+    plot_history::PlotHistoryEntry,
     plot_history::PlotHistoryManager,
     timeline::JsonTimeline,
 };
@@ -12,7 +13,7 @@ use reprod_core::{
         default_config_path, default_registry_path, locate_config, ProjectConfig,
         ProjectDescriptor, ProjectRecord, ProjectRegistry,
     },
-    Config, RExecutor,
+    Config, ExecutionEvent, RExecutor, RunOutputChunk, RunSummary,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -21,7 +22,7 @@ use std::{
     process::Command,
     sync::Arc,
 };
-use tokio::sync::Mutex;
+use tokio::sync::{broadcast, Mutex};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -108,11 +109,32 @@ fn default_zoom() -> f32 {
     1.0
 }
 
+#[derive(Debug, Clone)]
+pub enum RuntimeBroadcastEvent {
+    RunStarted {
+        run: RunSummary,
+    },
+    RunOutput {
+        chunk: RunOutputChunk,
+    },
+    RunFinished {
+        run: RunSummary,
+    },
+    TimelineEventAdded {
+        event: ExecutionEvent,
+    },
+    PlotHistoryUpdated {
+        active_plot_id: Option<String>,
+        plots: Vec<PlotHistoryEntry>,
+    },
+}
+
 pub struct ProjectRuntime {
     pub descriptor: ProjectDescriptor,
     pub timeline: Arc<JsonTimeline>,
     pub execution_repo: Arc<dyn ExecutionRepository>,
     pub stream_buffer: Arc<Mutex<StreamBuffer>>,
+    pub run_events: broadcast::Sender<RuntimeBroadcastEvent>,
     pub file_system: Arc<FileSystem>,
     pub filesystem_tool: Arc<FileSystemTool>,
     pub r_context_tool: Arc<RContextTool>,
@@ -164,11 +186,13 @@ impl ProjectRuntime {
             .build();
 
         let filesystem_root = descriptor.root_path.clone();
+        let (run_events, _) = broadcast::channel(1024);
         Ok(Self {
             descriptor,
             timeline,
             execution_repo,
             stream_buffer: Arc::new(Mutex::new(StreamBuffer::new())),
+            run_events,
             file_system: Arc::new(FileSystem::new(&filesystem_root)),
             filesystem_tool: Arc::new(FileSystemTool::new(filesystem_root)),
             r_context_tool: Arc::new(RContextTool::new()),


### PR DESCRIPTION
Closes #242.

## Summary
- Broadcast run lifecycle/output events to all connected clients per project.
- Stream stdout/stderr in real time (Process + persistent runners) and persist incremental output for reconnect/restart.
- Remove client-generated phantom runs; show send-failure as a console banner instead.
- Broadcast timeline and plot history updates for multi-client consistency.

