### PR TITLE
Add aria-label to icon-only buttons in FileBrowserPane (Issue #219)

### DIFF
--- a/client/src/components/file-browser/FileBrowserPane.tsx
+++ b/client/src/components/file-browser/FileBrowserPane.tsx
@@ -815,6 +815,7 @@ export function FileBrowserPane(): JSX.Element {
 						type="button"
 						className="btn btn-icon"
 						title="New File"
+						aria-label="Create new file"
 						onClick={() => handleCreateEntry(ROOT_PATH, false, true)}
 					>
 						<IconPlus width={14} height={14} />
@@ -823,6 +824,7 @@ export function FileBrowserPane(): JSX.Element {
 						type="button"
 						className="btn btn-icon"
 						title="New Folder"
+						aria-label="Create new folder"
 						onClick={() => handleCreateEntry(ROOT_PATH, true, true)}
 					>
 						<IconFolder width={14} height={14} />


### PR DESCRIPTION
## Summary
Improves screen reader accessibility by adding descriptive `aria-label` attributes to icon-only buttons in the file browser component.

## Changes
Added `aria-label` attributes to the following icon-only buttons in `FileBrowserPane.tsx`:
- **New File button**: `aria-label="Create new file"`
- **New Folder button**: `aria-label="Create new folder"`

## Why This Matters
- Icon-only buttons without text labels are **completely inaccessible** to screen reader users
- Screen readers previously announced these buttons as just "Button" without any context
- With `aria-label`, screen readers now announce:
  - "Create new file, button" ✅
  - "Create new folder, button" ✅

## Accessibility Compliance
This change helps comply with:
- WCAG 2.1 Success Criterion 4.1.2 (Name, Role, Value)
- Section 508 accessibility standards

## Testing
- ✅ TypeScript compilation passes
- ✅ Build succeeds
- ✅ Biome formatting checks pass
- ✅ Pre-commit and pre-push hooks pass

## Investigation Summary
I investigated all components mentioned in issue #219:
- **BottomPane.tsx**: Already has `aria-label` on all icon-only buttons ✓
- **TerminalPane.tsx**: Already has `aria-label` on all icon-only buttons ✓
- **PlotHistoryPanel.tsx**: No icon-only buttons (all have text labels)
- **SettingsModal.tsx**: No icon-only buttons (all have text labels)
- **EditorPanel.tsx**: No icon-only buttons (all have text labels)
- **FileBrowserPane.tsx**: Missing `aria-label` on 2 buttons ❌ (fixed in this PR)

Most components already had proper accessibility labels. This PR addresses the remaining gaps in `FileBrowserPane.tsx`.

Fixes #219