### PR TITLE
Replace manual confirm dialog state with useConfirmDialog hook

### DIFF
--- a/client/src/components/file-browser/FileBrowserPane.tsx
+++ b/client/src/components/file-browser/FileBrowserPane.tsx
@@ -11,6 +11,7 @@ import {
 import { useFileSystemStore, useStore } from "@/core";
 import { normalizeRelativePath, normalizeSeparators, ROOT_PATH } from "@/core/pathUtils";
 import { useFileSystemData } from "@/hooks/useFileSystemData";
+import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { type FileEntry, fileSystem } from "@/services/fileSystem";
 import {
 	alertWorkspaceNotReady,
@@ -174,8 +175,7 @@ export function FileBrowserPane(): JSX.Element {
 	const [focusedPath, setFocusedPath] = useState<string | null>(null);
 	const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
 	const [dragOverPath, setDragOverPath] = useState<string | null>(null);
-	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-	const [filesToDelete, setFilesToDelete] = useState<Set<string>>(new Set());
+	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
 
 	const nodes = useMemo(
 		() => buildTree(files, expandedFolders, pendingFolders),
@@ -392,14 +392,21 @@ export function FileBrowserPane(): JSX.Element {
 		[closeContextMenu, refreshPath, toast],
 	);
 
-	const handleDeleteClick = useCallback(() => {
+	const handleDeleteClick = useCallback(async () => {
 		if (!selectedFiles.size) return;
-		setFilesToDelete(selectedFiles);
-		setShowDeleteConfirm(true);
-	}, [selectedFiles]);
 
-	const handleDeleteConfirm = useCallback(async () => {
-		const targets = Array.from(filesToDelete);
+		const targets = Array.from(selectedFiles);
+
+		const confirmed = await showConfirm(
+			"Delete Files",
+			`Are you sure you want to delete ${targets.length} item${targets.length > 1 ? "s" : ""}? This action cannot be undone.`,
+		);
+
+		if (!confirmed) {
+			return;
+		}
+
+		// Deletion logic
 		for (const path of targets) {
 			try {
 				await fileSystem.deletePath(path);
@@ -407,17 +414,11 @@ export function FileBrowserPane(): JSX.Element {
 				alertFileOperationError(toast, `Failed to delete ${path}: ${(error as Error).message}`);
 			}
 		}
+
 		await refreshParents(targets);
 		clearSelection();
 		closeContextMenu();
-		setShowDeleteConfirm(false);
-		setFilesToDelete(new Set());
-	}, [filesToDelete, refreshParents, clearSelection, closeContextMenu, toast]);
-
-	const handleDeleteCancel = useCallback(() => {
-		setShowDeleteConfirm(false);
-		setFilesToDelete(new Set());
-	}, []);
+	}, [selectedFiles, showConfirm, refreshParents, clearSelection, closeContextMenu, toast]);
 
 	const handleCopyCut = useCallback(
 		(mode: "copy" | "cut") => {
@@ -878,13 +879,13 @@ export function FileBrowserPane(): JSX.Element {
 			</div>
 			{renderContextMenu()}
 			<ConfirmDialog
-				open={showDeleteConfirm}
-				title="Delete Files"
-				message={`Are you sure you want to delete ${filesToDelete.size} item${filesToDelete.size > 1 ? "s" : ""}? This action cannot be undone.`}
+				open={dialogState.open}
+				title={dialogState.title}
+				message={dialogState.message}
 				confirmLabel="Delete"
 				cancelLabel="Cancel"
-				onConfirm={handleDeleteConfirm}
-				onCancel={handleDeleteCancel}
+				onConfirm={handleConfirm}
+				onCancel={handleCancel}
 			/>
 		</div>
 	);

--- a/client/src/components/plot-history/PlotHistoryPanel.tsx
+++ b/client/src/components/plot-history/PlotHistoryPanel.tsx
@@ -1,13 +1,13 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { IconBarChart, IconTrash, ConfirmDialog } from "@/components/shared";
 import { useStore } from "@/core";
+import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { deletePlot, exportPlot } from "@/services/plotHistoryService";
 import { formatClockTime } from "@/utils/time";
 
 export function PlotHistoryPanel(): JSX.Element {
 	const plotHistory = useStore((state) => state.plotHistory);
-	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-	const [plotToDelete, setPlotToDelete] = useState<string | null>(null);
+	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
 
 	const activePlot = useMemo(() => {
 		const byId = plotHistory.items.find((plot) => plot.id === plotHistory.activePlotId);
@@ -15,22 +15,18 @@ export function PlotHistoryPanel(): JSX.Element {
 		return plotHistory.items.length > 0 ? plotHistory.items[plotHistory.items.length - 1] : null;
 	}, [plotHistory.activePlotId, plotHistory.items]);
 
-	const handleDeleteClick = (plotId: string) => {
-		setPlotToDelete(plotId);
-		setShowDeleteConfirm(true);
-	};
+	const handleDeleteClick = async (plotId: string) => {
+		const confirmed = await showConfirm(
+			"Delete Plot",
+			"Are you sure you want to delete this plot? This action cannot be undone.",
+		);
 
-	const handleDeleteConfirm = () => {
-		if (plotToDelete) {
-			void deletePlot(plotToDelete).catch(() => {});
+		if (!confirmed) {
+			return;
 		}
-		setShowDeleteConfirm(false);
-		setPlotToDelete(null);
-	};
 
-	const handleDeleteCancel = () => {
-		setShowDeleteConfirm(false);
-		setPlotToDelete(null);
+		// Delete the plot
+		void deletePlot(plotId).catch(() => {});
 	};
 
 	const handleExport = (plotId: string, format: "png" | "pdf", filename: string) => {
@@ -98,13 +94,13 @@ export function PlotHistoryPanel(): JSX.Element {
 				</div>
 			)}
 			<ConfirmDialog
-				open={showDeleteConfirm}
-				title="Delete Plot"
-				message="Are you sure you want to delete this plot? This action cannot be undone."
+				open={dialogState.open}
+				title={dialogState.title}
+				message={dialogState.message}
 				confirmLabel="Delete"
 				cancelLabel="Cancel"
-				onConfirm={handleDeleteConfirm}
-				onCancel={handleDeleteCancel}
+				onConfirm={handleConfirm}
+				onCancel={handleCancel}
 			/>
 		</div>
 	);


### PR DESCRIPTION
## Summary
Replace manual `useState`-based confirmation dialog state management in `FileBrowserPane` and `PlotHistoryPanel` with the existing `useConfirmDialog` hook to improve code consistency and reduce boilerplate.

## Changes
### FileBrowserPane.tsx
- Added `useConfirmDialog` import
- Removed manual `showDeleteConfirm` state variable
- Removed `filesToDelete` state variable (no longer needed)
- Merged `handleDeleteClick`, `handleDeleteConfirm`, and `handleDeleteCancel` into single async handler
- Updated `ConfirmDialog` component to use `dialogState` props
- Leverages promise-based `showConfirm()` API for cleaner async/await code

### PlotHistoryPanel.tsx
- Added `useConfirmDialog` import
- Removed manual `showDeleteConfirm` state variable
- Removed `plotToDelete` state variable (no longer needed)
- Removed `useState` import (no longer used)
- Simplified `handleDeleteClick` with async/await pattern
- Updated `ConfirmDialog` component to use `dialogState` props

## Benefits
- **Reduces ~35 lines of boilerplate code** across both files
- **Consistent pattern**: All components now use the same confirm dialog approach (matches EditorPanel.tsx)
- **Cleaner code**: Promise-based async/await is more readable than separate handlers
- **DRY principle**: Reuses existing `useConfirmDialog` hook instead of duplicating logic
- **Single source of truth**: Dialog state managed in one place

## Test Plan
- [x] TypeScript compilation passes (`pnpm tsc --noEmit`)
- [x] Biome formatting passes (`pnpm format`)
- [x] Build succeeds (`pnpm build:client`)
- [x] Pre-commit hooks pass
- [x] Pre-push checks pass

### Manual Testing Checklist
- [ ] File deletion dialog appears when deleting files in FileBrowserPane
- [ ] Clicking "Delete" successfully deletes files
- [ ] Clicking "Cancel" closes dialog without deleting
- [ ] Plot deletion dialog appears when deleting plots in PlotHistoryPanel
- [ ] Clicking "Delete" successfully deletes plot
- [ ] Clicking "Cancel" closes dialog without deleting

## Code Statistics
- 2 files changed, 39 insertions(+), 42 deletions(-)
- Net reduction: 3 lines
- Boilerplate removed: ~35 lines
- Handlers consolidated: 6 → 2

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)