### PR TITLE
Unify ACP runtime strategy (#261)

### DIFF
--- a/acp/src/lib.rs
+++ b/acp/src/lib.rs
@@ -4,8 +4,10 @@ pub mod connection;
 pub mod detection;
 pub mod gateway;
 pub mod process;
+pub mod runtime;
 pub mod session;
 pub mod types;
 
 pub use gateway::{build_process_config, AcpGateway};
 pub use process::{AcpChild, ProcessConfig, SpawnedPipes};
+pub use runtime::AcpRuntime;

--- a/acp/src/runtime.rs
+++ b/acp/src/runtime.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use tokio::sync::broadcast;
+
+use crate::types::{AcpPermissionDecision, AcpPermissionRequestPayload, AcpSessionUpdateEnvelope};
+
+#[async_trait::async_trait]
+pub trait AcpRuntime: Send + Sync {
+	async fn create_session(&self) -> Result<String>;
+	async fn send_prompt(&self, session_id: &str, messages: Vec<String>) -> Result<()>;
+	async fn cancel(&self, session_id: &str) -> Result<()>;
+	async fn respond_permission(&self, decision: AcpPermissionDecision) -> Result<()>;
+	async fn subscribe_session_updates(&self) -> broadcast::Receiver<AcpSessionUpdateEnvelope>;
+	async fn subscribe_permission_requests(
+		&self,
+	) -> broadcast::Receiver<AcpPermissionRequestPayload>;
+}

--- a/client/src/components/agent/PermissionRequestManager.tsx
+++ b/client/src/components/agent/PermissionRequestManager.tsx
@@ -1,8 +1,8 @@
 import type { CSSProperties } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { AcpPermissionOption, AcpPermissionRequestPayload } from "@/types/generated";
-import { ACP_FEATURE_ENABLED, IS_TAURI } from "@/constants/features";
-import { socketService } from "@/services/socket";
+import { ACP_FEATURE_ENABLED } from "@/constants/features";
+import { getExternalAgentClient } from "@/services/externalAgentClient";
 
 type DecisionOutcome = "AllowOnce" | "AllowAlways" | "RejectOnce" | "RejectAlways" | "Cancelled";
 
@@ -12,46 +12,20 @@ export function PermissionRequestManager(): JSX.Element | null {
 	const [remember, setRemember] = useState(false);
 	const allowButtonRef = useRef<HTMLButtonElement | null>(null);
 
-	const tauriEnabled = ACP_FEATURE_ENABLED && IS_TAURI;
-	const serverEnabled = ACP_FEATURE_ENABLED && !IS_TAURI;
 	const enabled = ACP_FEATURE_ENABLED;
+	const externalAgentClient = enabled ? getExternalAgentClient() : null;
 	const pending = queue[0] ?? null;
 
 	useEffect(() => {
-		if (!tauriEnabled) return;
-
-		let unsubscribe: (() => void) | undefined;
-		void import("@tauri-apps/api/event")
-			.then(({ listen }) =>
-				listen<AcpPermissionRequestPayload>("acp://permission-request", (event) => {
-					setQueue((prev) => [...prev, event.payload]);
-					setSelected((prev) => prev ?? event.payload.options[0]?.option_id ?? null);
-				}),
-			)
-			.then((dispose) => {
-				unsubscribe = dispose;
-			})
-			.catch((error) => {
-				console.error("Failed to bind ACP permission listener", error);
-			});
-
-		return () => {
-			if (unsubscribe) {
-				unsubscribe();
-			}
-		};
-	}, [tauriEnabled]);
-
-	useEffect(() => {
-		if (!serverEnabled) return;
-		const unsubscribe = socketService.on("acp://permission-request", (message) => {
-			setQueue((prev) => [...prev, message.request]);
-			setSelected((prev) => prev ?? message.request.options[0]?.option_id ?? null);
+		if (!externalAgentClient) return;
+		const unsubscribe = externalAgentClient.onPermissionRequest((payload) => {
+			setQueue((prev) => [...prev, payload]);
+			setSelected((prev) => prev ?? payload.options[0]?.option_id ?? null);
 		});
 		return () => {
 			unsubscribe();
 		};
-	}, [serverEnabled]);
+	}, [externalAgentClient]);
 
 	const optionLabel = (option: AcpPermissionOption) => {
 		const kind = option.kind.replace(/_/g, " ");
@@ -74,19 +48,8 @@ export function PermissionRequestManager(): JSX.Element | null {
 				outcome,
 			};
 			if (remember_scope !== "none") baseDecision.remember_scope = remember_scope;
-			if (tauriEnabled) {
-				const { invoke } = await import("@tauri-apps/api/core");
-				await invoke("acp_respond_to_permission", {
-					decision: baseDecision,
-				});
-			} else if (serverEnabled) {
-				const sent = socketService.send({
-					type: "acp_permission_decision",
-					decision: baseDecision,
-				});
-				if (!sent) {
-					throw new Error("Failed to send ACP permission decision");
-				}
+			if (externalAgentClient) {
+				await externalAgentClient.decidePermission(baseDecision);
 			}
 		} catch (error) {
 			console.error("Failed to send permission decision", error);

--- a/client/src/components/agent/__tests__/PermissionRequestManager.test.tsx
+++ b/client/src/components/agent/__tests__/PermissionRequestManager.test.tsx
@@ -4,40 +4,37 @@ import { PermissionRequestManager } from "../PermissionRequestManager";
 
 vi.mock("@/constants/features", () => ({
 	ACP_FEATURE_ENABLED: true,
-	IS_TAURI: true,
 }));
 
-const invokeMock = vi.fn();
-const socketSendMock = vi.fn();
-const socketOnMock = vi.fn().mockReturnValue(() => {});
-let listener: ((event: { payload: any }) => void) | null = null;
+const decidePermissionMock = vi.fn();
+let permissionListener: ((payload: any) => void) | null = null;
 
-vi.mock("@tauri-apps/api/core", () => ({
-	invoke: (...args: any[]) => invokeMock(...args),
-}));
-
-vi.mock("@tauri-apps/api/event", () => ({
-	listen: (_evt: string, handler: (event: { payload: any }) => void) => {
-		listener = handler;
-		return Promise.resolve(() => {
-			listener = null;
-		});
+const externalAgentClientMock = {
+	onSessionUpdate: vi.fn(),
+	onPermissionRequest: (cb: (payload: any) => void) => {
+		permissionListener = cb;
+		return () => {
+			permissionListener = null;
+		};
 	},
-}));
+	createSession: vi.fn(),
+	prompt: vi.fn(),
+	cancel: vi.fn(),
+	decidePermission: (...args: any[]) => decidePermissionMock(...args),
+};
 
-vi.mock("@/services/socket", () => ({
-	socketService: {
-		on: (...args: any[]) => socketOnMock(...args),
-		send: (...args: any[]) => socketSendMock(...args),
-	},
+vi.mock("@/services/externalAgentClient", () => ({
+	getExternalAgentClient: () => externalAgentClientMock,
 }));
 
 describe("PermissionRequestManager", () => {
 	beforeEach(() => {
-		invokeMock.mockReset();
-		socketSendMock.mockReset();
-		socketOnMock.mockClear();
-		listener = null;
+		decidePermissionMock.mockReset();
+		permissionListener = null;
+		externalAgentClientMock.onSessionUpdate.mockReset();
+		externalAgentClientMock.createSession.mockReset();
+		externalAgentClientMock.prompt.mockReset();
+		externalAgentClientMock.cancel.mockReset();
 	});
 
 	it("renders request with context, allow/deny/remember, and sends decision", async () => {
@@ -56,8 +53,8 @@ describe("PermissionRequestManager", () => {
 
 		render(<PermissionRequestManager />);
 
-		await waitFor(() => expect(listener).toBeInstanceOf(Function));
-		act(() => listener?.({ payload }));
+		await waitFor(() => expect(permissionListener).toBeInstanceOf(Function));
+		act(() => permissionListener?.(payload));
 
 		expect(screen.getByText(/read file/)).toBeInTheDocument();
 		expect(screen.getByText("/workspace/file.txt")).toBeInTheDocument();
@@ -68,12 +65,10 @@ describe("PermissionRequestManager", () => {
 		fireEvent.click(screen.getByRole("button", { name: /Allow/ }));
 
 		await waitFor(() =>
-			expect(invokeMock).toHaveBeenCalledWith("acp_respond_to_permission", {
-				decision: {
-					request_id: "req-1",
-					option_id: "allow",
-					outcome: "AllowOnce",
-				},
+			expect(decidePermissionMock).toHaveBeenCalledWith({
+				request_id: "req-1",
+				option_id: "allow",
+				outcome: "AllowOnce",
 			}),
 		);
 	});
@@ -97,16 +92,18 @@ describe("PermissionRequestManager", () => {
 		};
 
 		render(<PermissionRequestManager />);
-		await waitFor(() => expect(listener).toBeInstanceOf(Function));
-		act(() => listener?.({ payload: first }));
-		act(() => listener?.({ payload: second }));
+		await waitFor(() => expect(permissionListener).toBeInstanceOf(Function));
+		act(() => permissionListener?.(first));
+		act(() => permissionListener?.(second));
 
 		expect(screen.getByText("first")).toBeInTheDocument();
 		fireEvent.keyDown(document, { key: "Enter" });
 
 		await waitFor(() =>
-			expect(invokeMock).toHaveBeenCalledWith("acp_respond_to_permission", {
-				decision: { request_id: "req-1", option_id: "allow", outcome: "AllowOnce" },
+			expect(decidePermissionMock).toHaveBeenCalledWith({
+				request_id: "req-1",
+				option_id: "allow",
+				outcome: "AllowOnce",
 			}),
 		);
 
@@ -114,8 +111,10 @@ describe("PermissionRequestManager", () => {
 		fireEvent.keyDown(document, { key: "Escape" });
 
 		await waitFor(() =>
-			expect(invokeMock).toHaveBeenCalledWith("acp_respond_to_permission", {
-				decision: { request_id: "req-2", option_id: "deny", outcome: "RejectOnce" },
+			expect(decidePermissionMock).toHaveBeenCalledWith({
+				request_id: "req-2",
+				option_id: "deny",
+				outcome: "RejectOnce",
 			}),
 		);
 	});

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -1,10 +1,11 @@
 import type { AIMessage, AIMode } from "@/types";
 import type { AcpPromptMessage, AcpSessionUpdateEnvelope } from "@/types/generated";
-import { ACP_FEATURE_ENABLED, IS_TAURI } from "@/constants/features";
+import { ACP_FEATURE_ENABLED } from "@/constants/features";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useStore } from "@/core";
 import { buildPromptWithContext, createRequestId } from "@/core/ai/promptUtils";
 import { aiMessages } from "@/services/messageBuilders";
+import { getExternalAgentClient } from "@/services/externalAgentClient";
 import { socketService } from "@/services/socket";
 import { useAICodeApplication } from "./useAICodeApplication";
 import { useAIStreaming } from "./useAIStreaming";
@@ -33,13 +34,10 @@ export function useAIConversation() {
 	const [input, setInput] = useState("");
 	const activeRequestRef = useRef<{ id: string; dispose: () => void } | null>(null);
 	const acpSessionIdRef = useRef<string | null>(null);
-	const acpReadyRef = useRef(false);
 	const acpStreamsRef = useRef<Map<string, string>>(new Map());
-	const acpUnlistenRef = useRef<(() => void) | null>(null);
 	const acpConfigured =
 		ACP_FEATURE_ENABLED && activeMode === "external_agent" && Boolean(activeAgent);
-	const useDesktopAcp = acpConfigured && IS_TAURI;
-	const useServerAcp = acpConfigured && !IS_TAURI;
+	const externalAgentClient = acpConfigured ? getExternalAgentClient() : null;
 
 	const postAssistantMessage = useCallback(
 		(content: string, extras?: Partial<AIMessage>) => {
@@ -106,98 +104,44 @@ export function useAIConversation() {
 	);
 
 	useEffect(() => {
-		if (!useDesktopAcp) return;
-
-		let disposed = false;
-
-		const setup = async () => {
-			const { listen } = await import("@tauri-apps/api/event");
-			if (disposed) return;
-
-			acpUnlistenRef.current = await listen<AcpSessionUpdateEnvelope>(
-				"acp://session-update",
-				(event) => {
-					if (!event.payload) return;
-					handleSessionUpdate(event.payload);
-				},
-			);
-		};
-
-		void setup();
-
-		return () => {
-			disposed = true;
-			if (acpUnlistenRef.current) {
-				acpUnlistenRef.current();
-				acpUnlistenRef.current = null;
-			}
-		};
-	}, [handleSessionUpdate, useDesktopAcp]);
-
-	useEffect(() => {
-		if (!useServerAcp) return;
-		const unsubscribe = socketService.on("acp://session-update", (message) => {
-			handleSessionUpdate({ session_id: message.session_id, update: message.update });
+		if (!externalAgentClient) return;
+		const unsubscribe = externalAgentClient.onSessionUpdate((payload) => {
+			handleSessionUpdate(payload);
 		});
 		return () => {
 			unsubscribe();
 		};
-	}, [handleSessionUpdate, useServerAcp]);
+	}, [externalAgentClient, handleSessionUpdate]);
 
 	useEffect(() => {
 		if (!acpConfigured) {
 			acpSessionIdRef.current = null;
-			acpReadyRef.current = false;
 			acpStreamsRef.current.clear();
 		}
 	}, [acpConfigured]);
 
-	const ensureAcpInitialized = useCallback(async () => {
-		if (!useDesktopAcp) return false;
-		if (acpReadyRef.current) return true;
-
-		const { invoke } = await import("@tauri-apps/api/core");
-		await invoke("acp_initialize", {
-			command: null,
-			args: null,
-			workspaceRoot: null,
-		});
-		acpReadyRef.current = true;
-		return true;
-	}, [useDesktopAcp]);
-
 	const ensureAcpSession = useCallback(async (): Promise<string | null> => {
-		if (!acpConfigured) return null;
-		if (useDesktopAcp) {
-			if (!acpReadyRef.current) {
-				const ok = await ensureAcpInitialized();
-				if (!ok) return null;
-			}
-
-			if (acpSessionIdRef.current) {
-				return acpSessionIdRef.current;
-			}
-
-			const { invoke } = await import("@tauri-apps/api/core");
-			const sessionId = await invoke<string>("acp_create_session");
-			acpSessionIdRef.current = sessionId;
-			return sessionId;
+		if (!acpConfigured || !externalAgentClient) return null;
+		if (acpSessionIdRef.current) {
+			return acpSessionIdRef.current;
 		}
+		const sessionId = await externalAgentClient.createSession();
+		acpSessionIdRef.current = sessionId;
+		return sessionId;
+	}, [acpConfigured, externalAgentClient]);
 
-		if (useServerAcp) {
-			if (acpSessionIdRef.current) {
-				return acpSessionIdRef.current;
-			}
-			const response = await socketService.request(
-				{ type: "acp_session_create" },
-				"acp_session_created",
-			);
-			acpSessionIdRef.current = response.session_id;
-			return response.session_id;
+	const cancelAcpSession = useCallback(async () => {
+		if (!externalAgentClient || !acpSessionIdRef.current) return;
+		try {
+			await externalAgentClient.cancel(acpSessionIdRef.current);
+		} catch (error) {
+			console.error("Failed to cancel ACP session", error);
 		}
-
-		return null;
-	}, [acpConfigured, ensureAcpInitialized, useDesktopAcp, useServerAcp]);
+		const acpStreamId = acpStreamsRef.current.get(acpSessionIdRef.current);
+		if (acpStreamId) {
+			completeStreamingMessage(acpStreamId);
+		}
+	}, [completeStreamingMessage, externalAgentClient]);
 
 	const handleStop = useCallback(() => {
 		clearTimeoutRef();
@@ -206,26 +150,14 @@ export function useAIConversation() {
 		if (streamingId) {
 			completeStreamingMessage(streamingId);
 			clearActiveRequest();
-		} else if (useDesktopAcp && acpSessionIdRef.current) {
-			void import("@tauri-apps/api/core").then(({ invoke }) =>
-				invoke("acp_cancel", { request: { session_id: acpSessionIdRef.current } }),
-			);
-			const acpStreamId = acpStreamsRef.current.get(acpSessionIdRef.current);
-			if (acpStreamId) {
-				completeStreamingMessage(acpStreamId);
-			}
-		} else if (useServerAcp && acpSessionIdRef.current) {
-			socketService.send({ type: "acp_session_cancel", session_id: acpSessionIdRef.current });
-			const acpStreamId = acpStreamsRef.current.get(acpSessionIdRef.current);
-			if (acpStreamId) {
-				completeStreamingMessage(acpStreamId);
-			}
+		} else if (acpConfigured && acpSessionIdRef.current) {
+			void cancelAcpSession();
 		} else {
 			postAssistantMessage("Request stopped by user.");
 		}
 	}, [
-		useDesktopAcp,
-		useServerAcp,
+		acpConfigured,
+		cancelAcpSession,
 		clearActiveRequest,
 		clearTimeoutRef,
 		completeStreamingMessage,
@@ -267,7 +199,7 @@ export function useAIConversation() {
 
 				try {
 					const sessionId = await ensureAcpSession();
-					if (!sessionId) {
+					if (!sessionId || !externalAgentClient) {
 						throw new Error("ACP session unavailable");
 					}
 
@@ -278,24 +210,7 @@ export function useAIConversation() {
 						role: message.role,
 						content: message.content,
 					}));
-					if (useDesktopAcp) {
-						const { invoke } = await import("@tauri-apps/api/core");
-						await invoke("acp_send_prompt", {
-							request: {
-								session_id: sessionId,
-								messages: payload,
-							},
-						});
-					} else if (useServerAcp) {
-						const sent = socketService.send({
-							type: "acp_session_prompt",
-							session_id: sessionId,
-							messages: payload,
-						});
-						if (!sent) {
-							throw new Error("Failed to send ACP prompt");
-						}
-					}
+					await externalAgentClient.prompt(sessionId, payload);
 					completeStreamingMessage(requestId);
 				} catch (error) {
 					const reason = error instanceof Error ? error.message : "Unknown error";
@@ -368,14 +283,13 @@ export function useAIConversation() {
 			editorContent,
 			editorFilepath,
 			ensureAcpSession,
+			externalAgentClient,
 			input,
 			messages,
 			registerStreamingHandlers,
 			setAILoading,
 			startStreamingMessage,
 			startTimeout,
-			useDesktopAcp,
-			useServerAcp,
 		],
 	);
 

--- a/client/src/services/externalAgentClient.ts
+++ b/client/src/services/externalAgentClient.ts
@@ -1,0 +1,185 @@
+import { ACP_FEATURE_ENABLED, IS_TAURI } from "@/constants/features";
+import type {
+	AcpPermissionDecision,
+	AcpPermissionRequestPayload,
+	AcpPromptMessage,
+	AcpSessionUpdateEnvelope,
+} from "@/types/generated";
+import { socketService } from "@/services/socket";
+
+export type ExternalAgentClientMode = "desktop" | "web";
+export type ExternalAgentUnsubscribe = () => void;
+
+export interface ExternalAgentClient {
+	onSessionUpdate(cb: (payload: AcpSessionUpdateEnvelope) => void): ExternalAgentUnsubscribe;
+	onPermissionRequest(cb: (payload: AcpPermissionRequestPayload) => void): ExternalAgentUnsubscribe;
+	createSession(): Promise<string>;
+	prompt(sessionId: string, messages: AcpPromptMessage[]): Promise<void>;
+	cancel(sessionId: string): Promise<void>;
+	decidePermission(decision: AcpPermissionDecision): Promise<void>;
+}
+
+const defaultMode: ExternalAgentClientMode = IS_TAURI ? "desktop" : "web";
+const clients: Partial<Record<ExternalAgentClientMode, ExternalAgentClient>> = {};
+
+export const getExternalAgentClient = (
+	mode: ExternalAgentClientMode = defaultMode,
+): ExternalAgentClient => {
+	if (!clients[mode]) {
+		clients[mode] = mode === "desktop" ? new DesktopAcpClient() : new WebAcpClient();
+	}
+	return clients[mode] as ExternalAgentClient;
+};
+
+class DesktopAcpClient implements ExternalAgentClient {
+	private initialized = false;
+
+	onSessionUpdate(cb: (payload: AcpSessionUpdateEnvelope) => void): ExternalAgentUnsubscribe {
+		let disposed = false;
+		let unlisten: ExternalAgentUnsubscribe | null = null;
+
+		void import("@tauri-apps/api/event")
+			.then(({ listen }) =>
+				listen<AcpSessionUpdateEnvelope>("acp://session-update", (event) => {
+					if (!event.payload) return;
+					cb(event.payload);
+				}),
+			)
+			.then((dispose) => {
+				if (disposed) {
+					dispose();
+					return;
+				}
+				unlisten = dispose;
+			})
+			.catch((error) => {
+				console.error("Failed to bind ACP session update listener", error);
+			});
+
+		return () => {
+			disposed = true;
+			if (unlisten) {
+				unlisten();
+			}
+		};
+	}
+
+	onPermissionRequest(
+		cb: (payload: AcpPermissionRequestPayload) => void,
+	): ExternalAgentUnsubscribe {
+		let disposed = false;
+		let unlisten: ExternalAgentUnsubscribe | null = null;
+
+		void import("@tauri-apps/api/event")
+			.then(({ listen }) =>
+				listen<AcpPermissionRequestPayload>("acp://permission-request", (event) => {
+					if (!event.payload) return;
+					cb(event.payload);
+				}),
+			)
+			.then((dispose) => {
+				if (disposed) {
+					dispose();
+					return;
+				}
+				unlisten = dispose;
+			})
+			.catch((error) => {
+				console.error("Failed to bind ACP permission listener", error);
+			});
+
+		return () => {
+			disposed = true;
+			if (unlisten) {
+				unlisten();
+			}
+		};
+	}
+
+	async createSession(): Promise<string> {
+		await this.ensureInitialized();
+		const { invoke } = await import("@tauri-apps/api/core");
+		return invoke<string>("acp_create_session");
+	}
+
+	async prompt(sessionId: string, messages: AcpPromptMessage[]): Promise<void> {
+		await this.ensureInitialized();
+		const { invoke } = await import("@tauri-apps/api/core");
+		await invoke("acp_send_prompt", {
+			request: {
+				session_id: sessionId,
+				messages,
+			},
+		});
+	}
+
+	async cancel(sessionId: string): Promise<void> {
+		const { invoke } = await import("@tauri-apps/api/core");
+		await invoke("acp_cancel", { request: { session_id: sessionId } });
+	}
+
+	async decidePermission(decision: AcpPermissionDecision): Promise<void> {
+		const { invoke } = await import("@tauri-apps/api/core");
+		await invoke("acp_respond_to_permission", { decision });
+	}
+
+	private async ensureInitialized(): Promise<void> {
+		if (this.initialized || !ACP_FEATURE_ENABLED) return;
+		const { invoke } = await import("@tauri-apps/api/core");
+		await invoke("acp_initialize", {
+			command: null,
+			args: null,
+			workspaceRoot: null,
+		});
+		this.initialized = true;
+	}
+}
+
+class WebAcpClient implements ExternalAgentClient {
+	onSessionUpdate(cb: (payload: AcpSessionUpdateEnvelope) => void): ExternalAgentUnsubscribe {
+		return socketService.on("acp://session-update", (message) => {
+			cb({ session_id: message.session_id, update: message.update });
+		});
+	}
+
+	onPermissionRequest(
+		cb: (payload: AcpPermissionRequestPayload) => void,
+	): ExternalAgentUnsubscribe {
+		return socketService.on("acp://permission-request", (message) => {
+			cb(message.request);
+		});
+	}
+
+	async createSession(): Promise<string> {
+		const response = await socketService.request(
+			{ type: "acp_session_create" },
+			"acp_session_created",
+		);
+		return response.session_id;
+	}
+
+	async prompt(sessionId: string, messages: AcpPromptMessage[]): Promise<void> {
+		const sent = socketService.send({
+			type: "acp_session_prompt",
+			session_id: sessionId,
+			messages,
+		});
+		if (!sent) {
+			throw new Error("Failed to send ACP prompt");
+		}
+	}
+
+	async cancel(sessionId: string): Promise<void> {
+		const sent = socketService.send({ type: "acp_session_cancel", session_id: sessionId });
+		if (!sent) {
+			throw new Error("Failed to cancel ACP session");
+		}
+	}
+
+	async decidePermission(decision: AcpPermissionDecision): Promise<void> {
+		const sent = socketService.send({ type: "acp_permission_decision", decision });
+		if (!sent) {
+			throw new Error("Failed to send ACP permission decision");
+		}
+	}
+}

--- a/client/src/services/externalAgentClient.ts
+++ b/client/src/services/externalAgentClient.ts
@@ -1,4 +1,4 @@
-import { ACP_FEATURE_ENABLED, IS_TAURI } from "@/constants/features";
+import { IS_TAURI } from "@/constants/features";
 import type {
 	AcpPermissionDecision,
 	AcpPermissionRequestPayload,
@@ -124,7 +124,7 @@ class DesktopAcpClient implements ExternalAgentClient {
 	}
 
 	private async ensureInitialized(): Promise<void> {
-		if (this.initialized || !ACP_FEATURE_ENABLED) return;
+		if (this.initialized) return;
 		const { invoke } = await import("@tauri-apps/api/core");
 		await invoke("acp_initialize", {
 			command: null,

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = { workspace = true }
 reqwest = { workspace = true }
 tauri-plugin-pty = "0.1.1"
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 
 
 [features]

--- a/desktop/src/acp/commands.rs
+++ b/desktop/src/acp/commands.rs
@@ -4,8 +4,10 @@ use crate::acp::types::{
     AcpAgentConfig, AcpCancelRequest, AcpDetectedAgent, AcpInitializeResponse,
     AcpPermissionDecision, AcpPromptRequest,
 };
+use crate::acp::runtime::DesktopAcpRuntime;
 use crate::acp::{build_process_config, AcpManager};
 use reprod_acp::config::{load_acp_config, normalize_active_mode, save_acp_config, ACP_MODE_API};
+use reprod_acp::AcpRuntime;
 use reprod_acp::detection::{detect_agents, resolve_active_agent_command};
 use tauri::{AppHandle, State};
 use tokio::sync::Mutex;
@@ -40,11 +42,8 @@ pub async fn acp_initialize(
 
 #[tauri::command]
 pub async fn acp_create_session(state: AcpState<'_>) -> Result<String, String> {
-    let manager = &mut *state.lock().await;
-    manager
-        .create_session()
-        .await
-        .map_err(|err| err.to_string())
+    let runtime = DesktopAcpRuntime::new(state.inner().clone());
+    runtime.create_session().await.map_err(|err| err.to_string())
 }
 
 #[tauri::command]
@@ -53,8 +52,10 @@ pub async fn acp_send_prompt(state: AcpState<'_>, request: AcpPromptRequest) -> 
     if !manager.session_exists(&request.session_id) {
         return Err("Unknown session".to_string());
     }
+    drop(manager);
 
-    manager
+    let runtime = DesktopAcpRuntime::new(state.inner().clone());
+    runtime
         .send_prompt(
             &request.session_id,
             request.messages.iter().map(|m| m.content.clone()).collect(),
@@ -65,13 +66,11 @@ pub async fn acp_send_prompt(state: AcpState<'_>, request: AcpPromptRequest) -> 
 
 #[tauri::command]
 pub async fn acp_cancel(state: AcpState<'_>, request: AcpCancelRequest) -> Result<(), String> {
-    let mut manager = state.lock().await;
-    manager
+    let runtime = DesktopAcpRuntime::new(state.inner().clone());
+    runtime
         .cancel(&request.session_id)
         .await
-        .map_err(|err| err.to_string())?;
-    manager.remove_session(&request.session_id);
-    Ok(())
+        .map_err(|err| err.to_string())
 }
 
 #[tauri::command]
@@ -79,8 +78,8 @@ pub async fn acp_respond_to_permission(
     state: AcpState<'_>,
     decision: AcpPermissionDecision,
 ) -> Result<(), String> {
-    let manager = state.lock().await;
-    manager
+    let runtime = DesktopAcpRuntime::new(state.inner().clone());
+    runtime
         .respond_permission(decision)
         .await
         .map_err(|err| err.to_string())

--- a/desktop/src/acp/mod.rs
+++ b/desktop/src/acp/mod.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod runtime;
 
 pub use reprod_acp::types;
 
@@ -6,11 +7,15 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use reprod_acp::{
-    types::{AcpInitializeResponse, AcpPermissionDecision},
+    types::{
+        AcpInitializeResponse, AcpPermissionDecision, AcpPermissionRequestPayload,
+        AcpSessionUpdateEnvelope,
+    },
     AcpGateway, ProcessConfig,
 };
 use tauri::{AppHandle, Emitter};
 use tracing::{info, warn};
+use tokio::sync::broadcast;
 
 struct Forwarders {
     updates: tauri::async_runtime::JoinHandle<()>,
@@ -73,6 +78,18 @@ impl AcpManager {
         self.gateway.send_prompt(session_id, messages).await
     }
 
+    pub fn subscribe_session_updates(
+        &self,
+    ) -> broadcast::Receiver<AcpSessionUpdateEnvelope> {
+        self.gateway.subscribe_session_updates()
+    }
+
+    pub fn subscribe_permission_requests(
+        &self,
+    ) -> broadcast::Receiver<AcpPermissionRequestPayload> {
+        self.gateway.subscribe_permission_requests()
+    }
+
     pub async fn shutdown(&mut self) {
         if let Some(handles) = self.forwarders.take() {
             handles.updates.abort();
@@ -86,8 +103,8 @@ impl AcpManager {
             return;
         }
 
-        let mut updates_rx = self.gateway.subscribe_session_updates();
-        let mut permissions_rx = self.gateway.subscribe_permission_requests();
+        let mut updates_rx = self.subscribe_session_updates();
+        let mut permissions_rx = self.subscribe_permission_requests();
         let handle_for_updates = app_handle.clone();
         let update_handle = tauri::async_runtime::spawn(async move {
             loop {

--- a/desktop/src/acp/runtime.rs
+++ b/desktop/src/acp/runtime.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use reprod_acp::runtime::AcpRuntime;
+use reprod_acp::types::{
+	AcpPermissionDecision, AcpPermissionRequestPayload, AcpSessionUpdateEnvelope,
+};
+use tokio::sync::{broadcast, Mutex};
+
+use crate::acp::AcpManager;
+
+pub struct DesktopAcpRuntime {
+	manager: Arc<Mutex<AcpManager>>,
+}
+
+impl DesktopAcpRuntime {
+	pub fn new(manager: Arc<Mutex<AcpManager>>) -> Self {
+		Self { manager }
+	}
+}
+
+#[async_trait::async_trait]
+impl AcpRuntime for DesktopAcpRuntime {
+	async fn create_session(&self) -> Result<String> {
+		let mut guard = self.manager.lock().await;
+		guard.create_session().await
+	}
+
+	async fn send_prompt(&self, session_id: &str, messages: Vec<String>) -> Result<()> {
+		let guard = self.manager.lock().await;
+		guard.send_prompt(session_id, messages).await
+	}
+
+	async fn cancel(&self, session_id: &str) -> Result<()> {
+		let mut guard = self.manager.lock().await;
+		guard.cancel(session_id).await?;
+		guard.remove_session(session_id);
+		Ok(())
+	}
+
+	async fn respond_permission(&self, decision: AcpPermissionDecision) -> Result<()> {
+		let guard = self.manager.lock().await;
+		guard.respond_permission(decision).await
+	}
+
+	async fn subscribe_session_updates(&self) -> broadcast::Receiver<AcpSessionUpdateEnvelope> {
+		let guard = self.manager.lock().await;
+		guard.subscribe_session_updates()
+	}
+
+	async fn subscribe_permission_requests(
+		&self,
+	) -> broadcast::Receiver<AcpPermissionRequestPayload> {
+		let guard = self.manager.lock().await;
+		guard.subscribe_permission_requests()
+	}
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber = { workspace = true }
 
 # Error handling
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/server/src/acp.rs
+++ b/server/src/acp.rs
@@ -6,6 +6,7 @@ use reprod_acp::{
     build_process_config,
     config::{is_external_mode, load_acp_config},
     detection::{detect_agents, resolve_active_agent_command},
+    runtime::AcpRuntime,
     types::{AcpPermissionDecision, AcpPermissionRequestPayload, AcpSessionUpdateEnvelope},
     AcpGateway,
 };
@@ -118,6 +119,35 @@ impl AcpService {
     ) -> broadcast::Receiver<AcpPermissionRequestPayload> {
         let gateway = self.gateway.lock().await;
         gateway.subscribe_permission_requests()
+    }
+}
+
+#[async_trait::async_trait]
+impl AcpRuntime for AcpService {
+    async fn create_session(&self) -> Result<String> {
+        self.create_session().await
+    }
+
+    async fn send_prompt(&self, session_id: &str, messages: Vec<String>) -> Result<()> {
+        self.send_prompt(session_id, messages).await
+    }
+
+    async fn cancel(&self, session_id: &str) -> Result<()> {
+        self.cancel(session_id).await
+    }
+
+    async fn respond_permission(&self, decision: AcpPermissionDecision) -> Result<()> {
+        self.respond_permission(decision).await
+    }
+
+    async fn subscribe_session_updates(&self) -> broadcast::Receiver<AcpSessionUpdateEnvelope> {
+        self.subscribe_session_updates().await
+    }
+
+    async fn subscribe_permission_requests(
+        &self,
+    ) -> broadcast::Receiver<AcpPermissionRequestPayload> {
+        self.subscribe_permission_requests().await
     }
 }
 


### PR DESCRIPTION
## Description

Introduce a shared ACP runtime abstraction and client strategy to hide desktop vs web differences. This consolidates ACP execution behind stable interfaces and removes UI-side branching for ACP flows.

Highlights
- New `ExternalAgentClient` strategy in the client, with desktop + web implementations.
- Refactored ACP session updates, prompts, and permission handling in UI to use the strategy.
- Added `AcpRuntime` trait in `reprod-acp` and adapters for server/desktop runtimes.
- Desktop commands now delegate through the runtime adapter.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (TS lint + Rust checks)
- [x] New tests added for new features/bug fixes (updated PermissionRequestManager tests)
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ E2E tests ran successfully locally
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

Note: This PR is feature branch → `develop` (not a `develop` → `main` promotion). E2E is not run here.

## Testing

- `pnpm -r lint`
- `cargo check -p reprod-server`
- `cargo check -p reprod-desktop`

## Screenshots (if applicable)

N/A

## Related Issues

Closes #261
