### PR TITLE
feat: add reusable state management hooks (#269)

### DIFF
--- a/client/src/components/agent/ExternalAgentSettingsPane.tsx
+++ b/client/src/components/agent/ExternalAgentSettingsPane.tsx
@@ -1,7 +1,8 @@
 import type { AcpAgentConfig, AcpDetectedAgent } from "@/types/generated";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { ACP_FEATURE_ENABLED, IS_TAURI } from "@/constants/features";
 import { useStore } from "@/core";
+import { useAsyncState } from "@/hooks/useAsyncState";
 
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
 	const response = await fetch(url, init);
@@ -18,7 +19,6 @@ export function ExternalAgentSettingsPane(): JSX.Element {
 	const setActiveMode = useStore((state) => state.setActiveMode);
 	const setActiveAgent = useStore((state) => state.setActiveAgent);
 	const setDetectedAgents = useStore((state) => state.setDetectedAgents);
-	const [loading, setLoading] = useState(false);
 	const enabled = ACP_FEATURE_ENABLED;
 	const isWindows = typeof navigator !== "undefined" && navigator.userAgent.includes("Windows");
 
@@ -27,39 +27,38 @@ export function ExternalAgentSettingsPane(): JSX.Element {
 		[detectedAgents],
 	);
 
-	const fetchAgents = async () => {
-		if (!enabled) return;
-		setLoading(true);
-		try {
-			if (IS_TAURI) {
-				const { invoke } = await import("@tauri-apps/api/core");
-				const [agents, config] = await Promise.all([
-					invoke<AcpDetectedAgent[]>("acp_detect_agents"),
-					invoke<{ active_mode: string; active_agent: string | null }>("acp_get_agent_config"),
-				]);
-				setDetectedAgents(agents);
-				setActiveMode((config.active_mode as "api" | "external_agent") ?? "api");
-				setActiveAgent(config.active_agent);
-			} else {
-				const [agents, config] = await Promise.all([
-					fetchJson<AcpDetectedAgent[]>("/api/acp/agents"),
-					fetchJson<AcpAgentConfig>("/api/acp/config"),
-				]);
-				setDetectedAgents(agents);
-				setActiveMode((config.active_mode as "api" | "external_agent") ?? "api");
-				setActiveAgent(config.active_agent ?? null);
-			}
-		} catch (error) {
-			console.error("Failed to load ACP agents/config", error);
-		} finally {
-			setLoading(false);
+	const fetchAgentsAsync = useCallback(async () => {
+		if (!enabled) return null;
+		if (IS_TAURI) {
+			const { invoke } = await import("@tauri-apps/api/core");
+			const [agents, config] = await Promise.all([
+				invoke<AcpDetectedAgent[]>("acp_detect_agents"),
+				invoke<{ active_mode: string; active_agent: string | null }>("acp_get_agent_config"),
+			]);
+			setDetectedAgents(agents);
+			setActiveMode((config.active_mode as "api" | "external_agent") ?? "api");
+			setActiveAgent(config.active_agent);
+		} else {
+			const [agents, config] = await Promise.all([
+				fetchJson<AcpDetectedAgent[]>("/api/acp/agents"),
+				fetchJson<AcpAgentConfig>("/api/acp/config"),
+			]);
+			setDetectedAgents(agents);
+			setActiveMode((config.active_mode as "api" | "external_agent") ?? "api");
+			setActiveAgent(config.active_agent ?? null);
 		}
-	};
+		return null;
+	}, [enabled, setDetectedAgents, setActiveMode, setActiveAgent]);
+
+	const { loading, execute: fetchAgents } = useAsyncState(fetchAgentsAsync, {
+		onError: (error) => console.error("Failed to load ACP agents/config", error),
+	});
 
 	useEffect(() => {
-		void fetchAgents();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [enabled]);
+		if (enabled) {
+			void fetchAgents();
+		}
+	}, [enabled, fetchAgents]);
 
 	const persistConfig = async (mode: "api" | "external_agent", agent: string | null) => {
 		if (!enabled) return;

--- a/client/src/components/agent/ExternalAgentSettingsPane.tsx
+++ b/client/src/components/agent/ExternalAgentSettingsPane.tsx
@@ -45,7 +45,7 @@ export function ExternalAgentSettingsPane(): JSX.Element {
 			]);
 			setDetectedAgents(agents);
 			setActiveMode((config.active_mode as "api" | "external_agent") ?? "api");
-			setActiveAgent(config.active_agent ?? null);
+			setActiveAgent(config.active_agent);
 		}
 		return null;
 	}, [enabled, setDetectedAgents, setActiveMode, setActiveAgent]);

--- a/client/src/components/file-browser/FileBrowserPane.tsx
+++ b/client/src/components/file-browser/FileBrowserPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { IconFile } from "@/components/icons/IconFile";
 import {
 	IconChevronDown,
@@ -10,8 +10,9 @@ import {
 } from "@/components/shared";
 import { useFileSystemStore, useStore } from "@/core";
 import { normalizeRelativePath, normalizeSeparators, ROOT_PATH } from "@/core/pathUtils";
-import { useFileSystemData } from "@/hooks/useFileSystemData";
 import { useConfirmDialog } from "@/hooks/useConfirmDialog";
+import { useFileBrowserState } from "@/hooks/useFileBrowserState";
+import { useFileSystemData } from "@/hooks/useFileSystemData";
 import { type FileEntry, fileSystem } from "@/services/fileSystem";
 import {
 	alertWorkspaceNotReady,
@@ -21,18 +22,6 @@ import {
 
 const ROOT_LABEL = "Workspace";
 const DRAG_DATA_MIME = "application/x-reprod-paths";
-
-type ClipboardState = {
-	mode: "copy" | "cut";
-	paths: string[];
-} | null;
-
-type ContextMenuState = {
-	x: number;
-	y: number;
-	path: string;
-	isDir: boolean;
-} | null;
 
 interface TreeNode extends FileEntry {
 	depth: number;
@@ -170,11 +159,20 @@ export function FileBrowserPane(): JSX.Element {
 	const setActivePath = useFileSystemStore((state) => state.setActivePath);
 	const workspaceRoot = useFileSystemStore((state) => state.workspaceRoot);
 
-	const [clipboard, setClipboard] = useState<ClipboardState>(null);
-	const [anchorPath, setAnchorPath] = useState<string | null>(null);
-	const [focusedPath, setFocusedPath] = useState<string | null>(null);
-	const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
-	const [dragOverPath, setDragOverPath] = useState<string | null>(null);
+	const {
+		state: uiState,
+		setClipboard,
+		clearClipboard,
+		setAnchorPath,
+		setFocusedPath,
+		setSelection,
+		showContextMenu,
+		hideContextMenu,
+		setDragOverPath,
+	} = useFileBrowserState();
+	const { clipboard, selection, contextMenu, dragOverPath } = uiState;
+	const { anchorPath, focusedPath } = selection;
+
 	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
 
 	const nodes = useMemo(
@@ -182,18 +180,16 @@ export function FileBrowserPane(): JSX.Element {
 		[files, expandedFolders, pendingFolders],
 	);
 
-	const closeContextMenu = useCallback(() => setContextMenu(null), []);
-
 	useEffect(() => {
 		if (!contextMenu) return;
-		const close = () => closeContextMenu();
+		const close = () => hideContextMenu();
 		window.addEventListener("click", close);
 		window.addEventListener("contextmenu", close);
 		return () => {
 			window.removeEventListener("click", close);
 			window.removeEventListener("contextmenu", close);
 		};
-	}, [contextMenu, closeContextMenu]);
+	}, [contextMenu, hideContextMenu]);
 
 	const refreshParents = useCallback(
 		async (paths: Iterable<string>) => {
@@ -338,19 +334,19 @@ export function FileBrowserPane(): JSX.Element {
 			if (!selectedFiles.has(node.path)) {
 				selectSinglePath(node.path);
 			}
-			setContextMenu({
+			showContextMenu({
 				x: event.clientX,
 				y: event.clientY,
 				path: node.path,
 				isDir: node.is_dir,
 			});
 		},
-		[selectedFiles, selectSinglePath],
+		[selectedFiles, selectSinglePath, showContextMenu],
 	);
 
 	const handleCreateEntry = useCallback(
 		async (targetPath: string, isDir: boolean, targetIsFolder = true) => {
-			closeContextMenu();
+			hideContextMenu();
 			const defaultName = isDir ? "New Folder" : "New File.R";
 			const name = window.prompt(`Enter ${isDir ? "folder" : "file"} name`, defaultName);
 			if (!name) return;
@@ -371,12 +367,12 @@ export function FileBrowserPane(): JSX.Element {
 				);
 			}
 		},
-		[closeContextMenu, refreshPath, toast],
+		[hideContextMenu, refreshPath, toast],
 	);
 
 	const handleRename = useCallback(
 		async (path: string) => {
-			closeContextMenu();
+			hideContextMenu();
 			const currentName = getNameFromPath(path);
 			const parent = getParentPath(path);
 			const newName = window.prompt("Enter new name", currentName);
@@ -389,7 +385,7 @@ export function FileBrowserPane(): JSX.Element {
 				alertFileOperationError(toast, `Failed to rename: ${(error as Error).message}`);
 			}
 		},
-		[closeContextMenu, refreshPath, toast],
+		[hideContextMenu, refreshPath, toast],
 	);
 
 	const handleDeleteClick = useCallback(async () => {
@@ -417,16 +413,16 @@ export function FileBrowserPane(): JSX.Element {
 
 		await refreshParents(targets);
 		clearSelection();
-		closeContextMenu();
-	}, [selectedFiles, showConfirm, refreshParents, clearSelection, closeContextMenu, toast]);
+		hideContextMenu();
+	}, [selectedFiles, showConfirm, refreshParents, clearSelection, hideContextMenu, toast]);
 
 	const handleCopyCut = useCallback(
 		(mode: "copy" | "cut") => {
 			if (!selectedFiles.size) return;
 			setClipboard({ mode, paths: Array.from(selectedFiles) });
-			closeContextMenu();
+			hideContextMenu();
 		},
-		[selectedFiles, closeContextMenu],
+		[selectedFiles, hideContextMenu],
 	);
 
 	const performTransfer = useCallback(
@@ -472,11 +468,11 @@ export function FileBrowserPane(): JSX.Element {
 					: ROOT_PATH);
 			await performTransfer(clipboard.paths, destination, clipboard.mode);
 			if (clipboard.mode === "cut") {
-				setClipboard(null);
+				clearClipboard();
 			}
-			closeContextMenu();
+			hideContextMenu();
 		},
-		[clipboard, contextMenu, closeContextMenu, performTransfer],
+		[clipboard, contextMenu, hideContextMenu, performTransfer, clearClipboard],
 	);
 
 	const handleCopyPath = useCallback(
@@ -492,22 +488,22 @@ export function FileBrowserPane(): JSX.Element {
 			} catch (error) {
 				// Silent failure - clipboard operation failed
 			}
-			closeContextMenu();
+			hideContextMenu();
 		},
-		[closeContextMenu, resolveAbsolutePath],
+		[hideContextMenu, resolveAbsolutePath],
 	);
 
 	const handleRevealInFinder = useCallback(
 		async (path: string) => {
 			if (!workspaceRoot) {
-				closeContextMenu();
+				hideContextMenu();
 				alertWorkspaceNotReady(toast);
 				return;
 			}
 			const absolute = resolveAbsolutePath(path);
 			const tauriWindow = window as TauriWindow;
 			const shell = tauriWindow.__TAURI__?.shell;
-			closeContextMenu();
+			hideContextMenu();
 			if (shell?.open) {
 				try {
 					await shell.open(absolute);
@@ -523,7 +519,7 @@ export function FileBrowserPane(): JSX.Element {
 				alertDesktopOnlyFeature(toast, "Reveal");
 			}
 		},
-		[closeContextMenu, resolveAbsolutePath, workspaceRoot, toast],
+		[hideContextMenu, resolveAbsolutePath, workspaceRoot, toast],
 	);
 
 	const handleNodeDragStart = useCallback(
@@ -842,8 +838,7 @@ export function FileBrowserPane(): JSX.Element {
 				onKeyDown={handleKeyDown}
 				onClick={() => {
 					clearSelection();
-					setFocusedPath(null);
-					setAnchorPath(null);
+					setSelection(null, null);
 					setActivePath(null);
 				}}
 				onDragOver={handleRootDragOver}

--- a/client/src/components/menu/MenuBar.tsx
+++ b/client/src/components/menu/MenuBar.tsx
@@ -5,8 +5,9 @@
  */
 
 import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useStore } from "@/core/state/store";
+import { useListNavigation } from "@/hooks/useListNavigation";
 import { useMenuSections } from "@/hooks/useMenuSections";
 import type { ConnectionIndicatorProps, MenuItem, MenuSectionComponentProps } from "@/types/menu";
 
@@ -90,24 +91,24 @@ function MenuSectionComponent({
 		}
 	};
 
-	const getFocusableItems = (): HTMLButtonElement[] => {
+	const getFocusableItems = useCallback((): HTMLButtonElement[] => {
 		if (!menuRef.current) return [];
 		return Array.from(
 			menuRef.current.querySelectorAll<HTMLButtonElement>(
 				'button[role="menuitem"]:not([disabled])',
 			),
 		);
-	};
+	}, []);
 
-	const focusFirstItem = () => {
+	const focusFirstItem = useCallback(() => {
 		const items = getFocusableItems();
 		items[0]?.focus();
-	};
+	}, [getFocusableItems]);
 
-	const focusLastItem = () => {
+	const focusLastItem = useCallback(() => {
 		const items = getFocusableItems();
 		items[items.length - 1]?.focus();
-	};
+	}, [getFocusableItems]);
 
 	const handleButtonClick = (event: ReactMouseEvent<HTMLButtonElement>) => {
 		event.preventDefault();
@@ -142,50 +143,12 @@ function MenuSectionComponent({
 		}
 	};
 
-	const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-		const items = getFocusableItems();
-		if (items.length === 0) {
-			if (event.key === "Escape") {
-				event.preventDefault();
-				closeMenu(true);
-			}
-			return;
-		}
-
-		const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
-
-		switch (event.key) {
-			case "ArrowDown": {
-				event.preventDefault();
-				const nextIndex = (currentIndex + 1) % items.length;
-				items[nextIndex]?.focus();
-				break;
-			}
-			case "ArrowUp": {
-				event.preventDefault();
-				const nextIndex = (currentIndex - 1 + items.length) % items.length;
-				items[nextIndex]?.focus();
-				break;
-			}
-			case "Home":
-				event.preventDefault();
-				items[0]?.focus();
-				break;
-			case "End":
-				event.preventDefault();
-				items[items.length - 1]?.focus();
-				break;
-			case "Escape":
-				event.preventDefault();
-				closeMenu(true);
-				break;
-			case "Tab":
-				closeMenu();
-				break;
-			default:
-				break;
-		}
-	};
+	const handleMenuKeyDown = useListNavigation({
+		getItems: getFocusableItems,
+		onEscape: (focusButton) => closeMenu(focusButton),
+		onTab: () => closeMenu(),
+		wrap: true,
+	});
 
 	const handleMouseEnter = () => {
 		if (anyMenuOpen && !isOpen) {

--- a/client/src/components/modals/SessionInfoModal.tsx
+++ b/client/src/components/modals/SessionInfoModal.tsx
@@ -102,7 +102,7 @@ export function SessionInfoModal({ open, onClose }: SessionInfoModalProps): JSX.
 		onSuccess: () => setLastUpdated(Date.now()),
 	});
 
-	const sessionInfo = data?.sessionInfo ?? null;
+	const sessionInfo = data?.sessionInfo;
 	const displayError = error || data?.warning || null;
 
 	const totalRuns = execution.history.length;
@@ -113,7 +113,7 @@ export function SessionInfoModal({ open, onClose }: SessionInfoModalProps): JSX.
 	const lastRunEntry = execution.history.length
 		? execution.history[execution.history.length - 1]
 		: null;
-	const lastRunTimestamp = lastRunEntry?.timestamp ?? null;
+	const lastRunTimestamp = lastRunEntry?.timestamp;
 
 	useEffect(() => {
 		if (!open) {

--- a/client/src/components/modals/SessionInfoModal.tsx
+++ b/client/src/components/modals/SessionInfoModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { IconInfo, IconRefresh } from "@/components/shared";
 import { buildExecutionRequest, useStore } from "@/core";
+import { useAsyncState } from "@/hooks/useAsyncState";
 import {
 	ExecutionServiceError,
 	executeRequestAwaitRunCompletion,
@@ -17,6 +18,11 @@ interface ParsedSessionInfo {
 	rVersion?: string;
 	packages: Array<{ name: string; version?: string }>;
 	rawOutput: string;
+}
+
+interface SessionInfoResult {
+	sessionInfo: ParsedSessionInfo;
+	warning?: string;
 }
 
 const SESSION_INFO_COMMAND = "sessionInfo()";
@@ -61,22 +67,9 @@ export function SessionInfoModal({ open, onClose }: SessionInfoModalProps): JSX.
 	const settings = useStore((state) => state.settings);
 	const execution = useStore((state) => state.execution);
 	const isConnected = useStore((state) => state.isConnected);
-	const [sessionInfo, setSessionInfo] = useState<ParsedSessionInfo | null>(null);
-	const [loading, setLoading] = useState(false);
-	const [error, setError] = useState<string | null>(null);
 	const [lastUpdated, setLastUpdated] = useState<number | null>(null);
 
-	const totalRuns = execution.history.length;
-	const totalErrors = useMemo(
-		() => execution.history.filter((result) => !result.success).length,
-		[execution.history],
-	);
-	const lastRunEntry = execution.history.length
-		? execution.history[execution.history.length - 1]
-		: null;
-	const lastRunTimestamp = lastRunEntry?.timestamp ?? null;
-
-	const fetchSessionInfo = useCallback(async () => {
+	const fetchSessionInfoAsync = useCallback(async (): Promise<SessionInfoResult> => {
 		const request = buildExecutionRequest({
 			target: {
 				code: SESSION_INFO_COMMAND,
@@ -88,27 +81,39 @@ export function SessionInfoModal({ open, onClose }: SessionInfoModalProps): JSX.
 			filepath: undefined,
 		});
 
-		setLoading(true);
-		setError(null);
-
 		try {
 			const completion = await executeRequestAwaitRunCompletion(request);
-			setSessionInfo(parseSessionInfoOutput(completion.stdout || ""));
-			setLastUpdated(Date.now());
-			if (completion.run.error) {
-				setError(completion.run.error);
-			} else if (completion.stderr) {
-				setError(completion.stderr);
-			}
+			const sessionInfo = parseSessionInfoOutput(completion.stdout || "");
+			const warning = completion.run.error || completion.stderr || undefined;
+			return { sessionInfo, warning };
 		} catch (err) {
 			const message =
 				err instanceof ExecutionServiceError ? err.message : "Unable to fetch session information.";
-			setError(message);
-			setSessionInfo(null);
-		} finally {
-			setLoading(false);
+			throw new Error(message);
 		}
 	}, []);
+
+	const {
+		data,
+		loading,
+		error,
+		execute: fetchSessionInfo,
+	} = useAsyncState(fetchSessionInfoAsync, {
+		onSuccess: () => setLastUpdated(Date.now()),
+	});
+
+	const sessionInfo = data?.sessionInfo ?? null;
+	const displayError = error || data?.warning || null;
+
+	const totalRuns = execution.history.length;
+	const totalErrors = useMemo(
+		() => execution.history.filter((result) => !result.success).length,
+		[execution.history],
+	);
+	const lastRunEntry = execution.history.length
+		? execution.history[execution.history.length - 1]
+		: null;
+	const lastRunTimestamp = lastRunEntry?.timestamp ?? null;
 
 	useEffect(() => {
 		if (!open) {
@@ -192,7 +197,7 @@ export function SessionInfoModal({ open, onClose }: SessionInfoModalProps): JSX.
 					)}
 				</div>
 			</div>
-			{error && <div className="session-info-error">{error}</div>}
+			{displayError && <div className="session-info-error">{displayError}</div>}
 			{sessionInfo?.rawOutput && (
 				<div className="session-info-output">
 					<div className="session-info-output-header">Raw sessionInfo() output</div>

--- a/client/src/hooks/__tests__/useAsyncState.test.ts
+++ b/client/src/hooks/__tests__/useAsyncState.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useAsyncState } from "../useAsyncState";
+
+describe("useAsyncState", () => {
+	describe("initial state", () => {
+		it("should have correct initial state", () => {
+			const asyncFn = vi.fn().mockResolvedValue("data");
+			const { result } = renderHook(() => useAsyncState(asyncFn));
+
+			expect(result.current.data).toBeNull();
+			expect(result.current.loading).toBe(false);
+			expect(result.current.error).toBeNull();
+		});
+
+		it("should use initialData when provided", () => {
+			const asyncFn = vi.fn().mockResolvedValue("new data");
+			const { result } = renderHook(() => useAsyncState(asyncFn, { initialData: "initial data" }));
+
+			expect(result.current.data).toBe("initial data");
+		});
+	});
+
+	describe("execute", () => {
+		it("should set data on successful execution", async () => {
+			const asyncFn = vi.fn().mockResolvedValue("success data");
+			const { result } = renderHook(() => useAsyncState(asyncFn));
+
+			await act(async () => {
+				await result.current.execute();
+			});
+
+			await waitFor(() => {
+				expect(result.current.data).toBe("success data");
+			});
+
+			expect(result.current.loading).toBe(false);
+			expect(result.current.error).toBeNull();
+		});
+
+		it("should set error on failed execution", async () => {
+			const asyncFn = vi.fn().mockRejectedValue(new Error("Test error"));
+			const { result } = renderHook(() => useAsyncState(asyncFn));
+
+			await act(async () => {
+				await result.current.execute();
+			});
+
+			await waitFor(() => {
+				expect(result.current.error).toBe("Test error");
+			});
+
+			expect(result.current.data).toBeNull();
+			expect(result.current.loading).toBe(false);
+		});
+
+		it("should handle non-Error throws", async () => {
+			const asyncFn = vi.fn().mockRejectedValue("string error");
+			const { result } = renderHook(() => useAsyncState(asyncFn));
+
+			await act(async () => {
+				await result.current.execute();
+			});
+
+			await waitFor(() => {
+				expect(result.current.error).toBe("string error");
+			});
+		});
+	});
+
+	describe("immediate option", () => {
+		it("should execute immediately when immediate is true", async () => {
+			const asyncFn = vi.fn().mockResolvedValue("immediate data");
+
+			const { result } = renderHook(() => useAsyncState(asyncFn, { immediate: true }));
+
+			await waitFor(() => {
+				expect(result.current.data).toBe("immediate data");
+			});
+
+			expect(asyncFn).toHaveBeenCalledTimes(1);
+		});
+
+		it("should not execute immediately when immediate is false", () => {
+			const asyncFn = vi.fn().mockResolvedValue("data");
+
+			renderHook(() => useAsyncState(asyncFn, { immediate: false }));
+
+			expect(asyncFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("callbacks", () => {
+		it("should call onSuccess callback on successful execution", async () => {
+			const onSuccess = vi.fn();
+			const asyncFn = vi.fn().mockResolvedValue("success data");
+
+			const { result } = renderHook(() => useAsyncState(asyncFn, { onSuccess }));
+
+			await act(async () => {
+				await result.current.execute();
+			});
+
+			await waitFor(() => {
+				expect(onSuccess).toHaveBeenCalledWith("success data");
+			});
+		});
+
+		it("should call onError callback on failed execution", async () => {
+			const onError = vi.fn();
+			const asyncFn = vi.fn().mockRejectedValue(new Error("Test error"));
+
+			const { result } = renderHook(() => useAsyncState(asyncFn, { onError }));
+
+			await act(async () => {
+				await result.current.execute();
+			});
+
+			await waitFor(() => {
+				expect(onError).toHaveBeenCalledWith(expect.any(Error));
+			});
+		});
+	});
+
+	describe("reset", () => {
+		it("should reset state to initial values", async () => {
+			const asyncFn = vi.fn().mockResolvedValue("data");
+			const { result } = renderHook(() => useAsyncState(asyncFn));
+
+			await act(async () => {
+				await result.current.execute();
+			});
+
+			await waitFor(() => {
+				expect(result.current.data).toBe("data");
+			});
+
+			act(() => {
+				result.current.reset();
+			});
+
+			expect(result.current.data).toBeNull();
+			expect(result.current.loading).toBe(false);
+			expect(result.current.error).toBeNull();
+		});
+	});
+
+	describe("setData", () => {
+		it("should manually set data", () => {
+			const asyncFn = vi.fn().mockResolvedValue("async data");
+			const { result } = renderHook(() => useAsyncState(asyncFn));
+
+			act(() => {
+				result.current.setData("manual data");
+			});
+
+			expect(result.current.data).toBe("manual data");
+		});
+
+		it("should allow setting data to null", async () => {
+			const asyncFn = vi.fn().mockResolvedValue("data");
+			const { result } = renderHook(() => useAsyncState(asyncFn));
+
+			await act(async () => {
+				await result.current.execute();
+			});
+
+			await waitFor(() => {
+				expect(result.current.data).toBe("data");
+			});
+
+			act(() => {
+				result.current.setData(null);
+			});
+
+			expect(result.current.data).toBeNull();
+		});
+	});
+
+	describe("typed data", () => {
+		interface User {
+			id: number;
+			name: string;
+		}
+
+		it("should work with typed data", async () => {
+			const user: User = { id: 1, name: "John" };
+			const asyncFn = vi.fn().mockResolvedValue(user);
+
+			const { result } = renderHook(() => useAsyncState<User>(asyncFn));
+
+			await act(async () => {
+				await result.current.execute();
+			});
+
+			await waitFor(() => {
+				expect(result.current.data).toEqual({ id: 1, name: "John" });
+			});
+
+			expect(result.current.data?.name).toBe("John");
+		});
+	});
+});

--- a/client/src/hooks/__tests__/useFileBrowserState.test.ts
+++ b/client/src/hooks/__tests__/useFileBrowserState.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFileBrowserState } from "../useFileBrowserState";
+
+describe("useFileBrowserState", () => {
+	describe("initial state", () => {
+		it("should have correct initial state", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			expect(result.current.state).toEqual({
+				clipboard: null,
+				selection: {
+					anchorPath: null,
+					focusedPath: null,
+				},
+				contextMenu: null,
+				dragOverPath: null,
+			});
+		});
+	});
+
+	describe("clipboard operations", () => {
+		it("should set clipboard state", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.setClipboard({ mode: "copy", paths: ["/src/file.ts"] });
+			});
+
+			expect(result.current.state.clipboard).toEqual({
+				mode: "copy",
+				paths: ["/src/file.ts"],
+			});
+		});
+
+		it("should clear clipboard", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.setClipboard({ mode: "cut", paths: ["/src/file.ts"] });
+			});
+
+			expect(result.current.state.clipboard).not.toBeNull();
+
+			act(() => {
+				result.current.clearClipboard();
+			});
+
+			expect(result.current.state.clipboard).toBeNull();
+		});
+	});
+
+	describe("selection operations", () => {
+		it("should set anchor path", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.setAnchorPath("/src/anchor.ts");
+			});
+
+			expect(result.current.state.selection.anchorPath).toBe("/src/anchor.ts");
+			expect(result.current.state.selection.focusedPath).toBeNull();
+		});
+
+		it("should set focused path", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.setFocusedPath("/src/focused.ts");
+			});
+
+			expect(result.current.state.selection.focusedPath).toBe("/src/focused.ts");
+			expect(result.current.state.selection.anchorPath).toBeNull();
+		});
+
+		it("should set both anchor and focused paths", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.setSelection("/src/anchor.ts", "/src/focused.ts");
+			});
+
+			expect(result.current.state.selection).toEqual({
+				anchorPath: "/src/anchor.ts",
+				focusedPath: "/src/focused.ts",
+			});
+		});
+
+		it("should clear selection paths", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.setSelection("/src/anchor.ts", "/src/focused.ts");
+			});
+
+			act(() => {
+				result.current.setSelection(null, null);
+			});
+
+			expect(result.current.state.selection).toEqual({
+				anchorPath: null,
+				focusedPath: null,
+			});
+		});
+	});
+
+	describe("context menu operations", () => {
+		it("should show context menu", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.showContextMenu({
+					x: 100,
+					y: 200,
+					path: "/src/file.ts",
+					isDir: false,
+				});
+			});
+
+			expect(result.current.state.contextMenu).toEqual({
+				x: 100,
+				y: 200,
+				path: "/src/file.ts",
+				isDir: false,
+			});
+		});
+
+		it("should hide context menu", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.showContextMenu({
+					x: 100,
+					y: 200,
+					path: "/src/file.ts",
+					isDir: false,
+				});
+			});
+
+			act(() => {
+				result.current.hideContextMenu();
+			});
+
+			expect(result.current.state.contextMenu).toBeNull();
+		});
+	});
+
+	describe("drag-drop operations", () => {
+		it("should set drag over path", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.setDragOverPath("/src/folder");
+			});
+
+			expect(result.current.state.dragOverPath).toBe("/src/folder");
+		});
+
+		it("should clear drag over path", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.setDragOverPath("/src/folder");
+			});
+
+			act(() => {
+				result.current.setDragOverPath(null);
+			});
+
+			expect(result.current.state.dragOverPath).toBeNull();
+		});
+	});
+
+	describe("reset operation", () => {
+		it("should reset all state to initial values", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			// Set up some state
+			act(() => {
+				result.current.setClipboard({ mode: "copy", paths: ["/file.ts"] });
+				result.current.setSelection("/anchor.ts", "/focused.ts");
+				result.current.showContextMenu({ x: 10, y: 20, path: "/menu.ts", isDir: false });
+				result.current.setDragOverPath("/folder");
+			});
+
+			// Verify state is set
+			expect(result.current.state.clipboard).not.toBeNull();
+			expect(result.current.state.selection.anchorPath).not.toBeNull();
+			expect(result.current.state.contextMenu).not.toBeNull();
+			expect(result.current.state.dragOverPath).not.toBeNull();
+
+			// Reset
+			act(() => {
+				result.current.reset();
+			});
+
+			// Verify all state is reset
+			expect(result.current.state).toEqual({
+				clipboard: null,
+				selection: {
+					anchorPath: null,
+					focusedPath: null,
+				},
+				contextMenu: null,
+				dragOverPath: null,
+			});
+		});
+	});
+
+	describe("dispatch", () => {
+		it("should allow direct dispatch of actions", () => {
+			const { result } = renderHook(() => useFileBrowserState());
+
+			act(() => {
+				result.current.dispatch({
+					type: "SET_CLIPBOARD",
+					payload: { mode: "cut", paths: ["/direct.ts"] },
+				});
+			});
+
+			expect(result.current.state.clipboard).toEqual({
+				mode: "cut",
+				paths: ["/direct.ts"],
+			});
+		});
+	});
+});

--- a/client/src/hooks/__tests__/useListNavigation.test.ts
+++ b/client/src/hooks/__tests__/useListNavigation.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useListNavigation } from "../useListNavigation";
+
+describe("useListNavigation", () => {
+	let container: HTMLDivElement;
+	let items: HTMLButtonElement[];
+
+	beforeEach(() => {
+		container = document.createElement("div");
+		document.body.appendChild(container);
+
+		items = [];
+		for (let i = 0; i < 5; i++) {
+			const button = document.createElement("button");
+			button.textContent = `Item ${i}`;
+			container.appendChild(button);
+			items.push(button);
+		}
+	});
+
+	afterEach(() => {
+		document.body.removeChild(container);
+	});
+
+	const createKeyboardEvent = (key: string): React.KeyboardEvent => {
+		return {
+			key,
+			preventDefault: vi.fn(),
+		} as unknown as React.KeyboardEvent;
+	};
+
+	describe("ArrowDown navigation", () => {
+		it("should focus the next item on ArrowDown", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+				}),
+			);
+
+			items[0].focus();
+			const event = createKeyboardEvent("ArrowDown");
+			result.current(event);
+
+			expect(document.activeElement).toBe(items[1]);
+			expect(event.preventDefault).toHaveBeenCalled();
+		});
+
+		it("should wrap to first item when at the end (wrap=true)", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+					wrap: true,
+				}),
+			);
+
+			items[4].focus();
+			const event = createKeyboardEvent("ArrowDown");
+			result.current(event);
+
+			expect(document.activeElement).toBe(items[0]);
+		});
+
+		it("should not wrap when wrap=false", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+					wrap: false,
+				}),
+			);
+
+			items[4].focus();
+			const event = createKeyboardEvent("ArrowDown");
+			result.current(event);
+
+			expect(document.activeElement).toBe(items[4]);
+		});
+
+		it("should focus first item when no item is focused", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+				}),
+			);
+
+			// Focus something outside the list
+			document.body.focus();
+			const event = createKeyboardEvent("ArrowDown");
+			result.current(event);
+
+			expect(document.activeElement).toBe(items[0]);
+		});
+	});
+
+	describe("ArrowUp navigation", () => {
+		it("should focus the previous item on ArrowUp", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+				}),
+			);
+
+			items[2].focus();
+			const event = createKeyboardEvent("ArrowUp");
+			result.current(event);
+
+			expect(document.activeElement).toBe(items[1]);
+			expect(event.preventDefault).toHaveBeenCalled();
+		});
+
+		it("should wrap to last item when at the beginning (wrap=true)", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+					wrap: true,
+				}),
+			);
+
+			items[0].focus();
+			const event = createKeyboardEvent("ArrowUp");
+			result.current(event);
+
+			expect(document.activeElement).toBe(items[4]);
+		});
+
+		it("should not wrap when wrap=false", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+					wrap: false,
+				}),
+			);
+
+			items[0].focus();
+			const event = createKeyboardEvent("ArrowUp");
+			result.current(event);
+
+			expect(document.activeElement).toBe(items[0]);
+		});
+
+		it("should focus last item when no item is focused", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+				}),
+			);
+
+			document.body.focus();
+			const event = createKeyboardEvent("ArrowUp");
+			result.current(event);
+
+			expect(document.activeElement).toBe(items[4]);
+		});
+	});
+
+	describe("Home/End navigation", () => {
+		it("should focus the first item on Home", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+				}),
+			);
+
+			items[3].focus();
+			const event = createKeyboardEvent("Home");
+			result.current(event);
+
+			expect(document.activeElement).toBe(items[0]);
+			expect(event.preventDefault).toHaveBeenCalled();
+		});
+
+		it("should focus the last item on End", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+				}),
+			);
+
+			items[1].focus();
+			const event = createKeyboardEvent("End");
+			result.current(event);
+
+			expect(document.activeElement).toBe(items[4]);
+			expect(event.preventDefault).toHaveBeenCalled();
+		});
+	});
+
+	describe("Escape handling", () => {
+		it("should call onEscape when Escape is pressed", () => {
+			const onEscape = vi.fn();
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+					onEscape,
+				}),
+			);
+
+			items[0].focus();
+			const event = createKeyboardEvent("Escape");
+			result.current(event);
+
+			expect(onEscape).toHaveBeenCalledWith(true);
+			expect(event.preventDefault).toHaveBeenCalled();
+		});
+
+		it("should call onEscape even when list is empty", () => {
+			const onEscape = vi.fn();
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => [],
+					onEscape,
+				}),
+			);
+
+			const event = createKeyboardEvent("Escape");
+			result.current(event);
+
+			expect(onEscape).toHaveBeenCalledWith(true);
+		});
+
+		it("should not call onEscape when not provided", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+				}),
+			);
+
+			items[0].focus();
+			const event = createKeyboardEvent("Escape");
+
+			// Should not throw
+			expect(() => result.current(event)).not.toThrow();
+		});
+	});
+
+	describe("Tab handling", () => {
+		it("should call onTab when Tab is pressed", () => {
+			const onTab = vi.fn();
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+					onTab,
+				}),
+			);
+
+			items[0].focus();
+			const event = createKeyboardEvent("Tab");
+			result.current(event);
+
+			expect(onTab).toHaveBeenCalled();
+			// Tab should not prevent default to allow natural focus movement
+			expect(event.preventDefault).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("Enter/Space selection", () => {
+		it("should call onSelect with current index on Enter", () => {
+			const onSelect = vi.fn();
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+					onSelect,
+				}),
+			);
+
+			items[2].focus();
+			const event = createKeyboardEvent("Enter");
+			result.current(event);
+
+			expect(onSelect).toHaveBeenCalledWith(2);
+			expect(event.preventDefault).toHaveBeenCalled();
+		});
+
+		it("should call onSelect with current index on Space", () => {
+			const onSelect = vi.fn();
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+					onSelect,
+				}),
+			);
+
+			items[3].focus();
+			const event = createKeyboardEvent(" ");
+			result.current(event);
+
+			expect(onSelect).toHaveBeenCalledWith(3);
+			expect(event.preventDefault).toHaveBeenCalled();
+		});
+
+		it("should not call onSelect when no item is focused", () => {
+			const onSelect = vi.fn();
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+					onSelect,
+				}),
+			);
+
+			document.body.focus();
+			const event = createKeyboardEvent("Enter");
+			result.current(event);
+
+			expect(onSelect).not.toHaveBeenCalled();
+		});
+
+		it("should not call onSelect when onSelect is not provided", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+				}),
+			);
+
+			items[0].focus();
+			const event = createKeyboardEvent("Enter");
+
+			// Should not throw
+			expect(() => result.current(event)).not.toThrow();
+			// Should not prevent default when no handler
+			expect(event.preventDefault).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("empty list handling", () => {
+		it("should handle empty list gracefully for navigation keys", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => [],
+				}),
+			);
+
+			const event = createKeyboardEvent("ArrowDown");
+
+			// Should not throw
+			expect(() => result.current(event)).not.toThrow();
+		});
+	});
+
+	describe("unknown keys", () => {
+		it("should not prevent default for unknown keys", () => {
+			const { result } = renderHook(() =>
+				useListNavigation({
+					getItems: () => items,
+				}),
+			);
+
+			items[0].focus();
+			const event = createKeyboardEvent("a");
+			result.current(event);
+
+			expect(event.preventDefault).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/client/src/hooks/useAsyncState.ts
+++ b/client/src/hooks/useAsyncState.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import type { AsyncState, AsyncStateAction } from "@/types/asyncState";
+import { asyncStateReducer } from "@/types/asyncState";
+
+/**
+ * Options for configuring the useAsyncState hook.
+ * @template T The type of the data being loaded
+ */
+export interface UseAsyncStateOptions<T> {
+	/**
+	 * Whether to execute the async function immediately on mount.
+	 * @default false
+	 */
+	immediate?: boolean;
+
+	/**
+	 * Callback invoked when the async operation succeeds.
+	 */
+	onSuccess?: (data: T) => void;
+
+	/**
+	 * Callback invoked when the async operation fails.
+	 */
+	onError?: (error: Error) => void;
+
+	/**
+	 * Initial data to use before the async function is executed.
+	 */
+	initialData?: T | null;
+}
+
+/**
+ * Return type for the useAsyncState hook.
+ * @template T The type of the data being loaded
+ */
+export interface UseAsyncStateReturn<T> extends AsyncState<T> {
+	/**
+	 * Execute the async function.
+	 * Returns a promise that resolves when the operation completes.
+	 */
+	execute: () => Promise<void>;
+
+	/**
+	 * Reset the state to initial values.
+	 */
+	reset: () => void;
+
+	/**
+	 * Manually set the data.
+	 */
+	setData: (data: T | null) => void;
+}
+
+/**
+ * A hook for managing async state with loading, error, and data states.
+ *
+ * Handles the common pattern of:
+ * 1. Setting loading to true
+ * 2. Executing an async function
+ * 3. Setting data on success or error on failure
+ * 4. Setting loading to false
+ *
+ * @example
+ * ```tsx
+ * const { data, loading, error, execute } = useAsyncState(
+ *   async () => {
+ *     const response = await fetch('/api/data');
+ *     return response.json();
+ *   },
+ *   { immediate: true }
+ * );
+ *
+ * if (loading) return <Spinner />;
+ * if (error) return <Error message={error} />;
+ * return <DataDisplay data={data} />;
+ * ```
+ *
+ * @template T The type of the data being loaded
+ * @param asyncFn The async function to execute
+ * @param options Configuration options
+ */
+export function useAsyncState<T>(
+	asyncFn: () => Promise<T>,
+	options: UseAsyncStateOptions<T> = {},
+): UseAsyncStateReturn<T> {
+	const { immediate = false, onSuccess, onError, initialData = null } = options;
+
+	const [state, dispatch] = useReducer(asyncStateReducer<T>, {
+		data: initialData,
+		loading: false,
+		error: null,
+	});
+
+	// Track if the component is mounted to avoid state updates after unmount
+	const mountedRef = useRef(true);
+
+	// Keep the latest callbacks in refs to avoid dependency issues
+	const asyncFnRef = useRef(asyncFn);
+	const onSuccessRef = useRef(onSuccess);
+	const onErrorRef = useRef(onError);
+
+	// Update refs when values change
+	asyncFnRef.current = asyncFn;
+	onSuccessRef.current = onSuccess;
+	onErrorRef.current = onError;
+
+	useEffect(() => {
+		return () => {
+			mountedRef.current = false;
+		};
+	}, []);
+
+	const execute = useCallback(async (): Promise<void> => {
+		dispatch({ type: "loading" } as AsyncStateAction<T>);
+
+		try {
+			const result = await asyncFnRef.current();
+
+			if (mountedRef.current) {
+				dispatch({ type: "success", payload: result } as AsyncStateAction<T>);
+				onSuccessRef.current?.(result);
+			}
+		} catch (err) {
+			if (mountedRef.current) {
+				const error = err instanceof Error ? err : new Error(String(err));
+				dispatch({ type: "error", payload: error.message } as AsyncStateAction<T>);
+				onErrorRef.current?.(error);
+			}
+		}
+	}, []);
+
+	const reset = useCallback(() => {
+		dispatch({ type: "reset" } as AsyncStateAction<T>);
+	}, []);
+
+	const setData = useCallback((data: T | null) => {
+		dispatch({ type: "set-data", payload: data } as AsyncStateAction<T>);
+	}, []);
+
+	// Execute immediately if requested
+	useEffect(() => {
+		if (immediate) {
+			void execute();
+		}
+	}, [immediate, execute]);
+
+	return {
+		data: state.data,
+		loading: state.loading,
+		error: state.error,
+		execute,
+		reset,
+		setData,
+	};
+}

--- a/client/src/hooks/useFileBrowserState.ts
+++ b/client/src/hooks/useFileBrowserState.ts
@@ -1,0 +1,134 @@
+import { useCallback, useReducer } from "react";
+import type {
+	ClipboardState,
+	ContextMenuState,
+	FileBrowserUIAction,
+	FileBrowserUIState,
+} from "@/types/fileBrowser";
+import { fileBrowserUIInitialState, fileBrowserUIReducer } from "@/types/fileBrowser";
+
+/**
+ * Return type for the useFileBrowserState hook.
+ */
+export interface UseFileBrowserStateReturn {
+	/** Current UI state */
+	state: FileBrowserUIState;
+
+	/** Raw dispatch function for custom actions */
+	dispatch: React.Dispatch<FileBrowserUIAction>;
+
+	// Clipboard operations
+	/** Set the clipboard state */
+	setClipboard: (clipboard: ClipboardState) => void;
+	/** Clear the clipboard */
+	clearClipboard: () => void;
+
+	// Selection operations
+	/** Set the selection anchor path */
+	setAnchorPath: (path: string | null) => void;
+	/** Set the focused path */
+	setFocusedPath: (path: string | null) => void;
+	/** Set both anchor and focused paths at once */
+	setSelection: (anchor: string | null, focused: string | null) => void;
+
+	// Context menu operations
+	/** Show the context menu at the specified position */
+	showContextMenu: (menu: ContextMenuState) => void;
+	/** Hide the context menu */
+	hideContextMenu: () => void;
+
+	// Drag-drop operations
+	/** Set the current drag-over path */
+	setDragOverPath: (path: string | null) => void;
+
+	// Utility operations
+	/** Reset all state to initial values */
+	reset: () => void;
+}
+
+/**
+ * A hook for managing FileBrowser local UI state.
+ *
+ * Consolidates related states that often update together:
+ * - Clipboard (copy/cut operations)
+ * - Selection anchor/focus
+ * - Context menu
+ * - Drag-drop state
+ *
+ * @example
+ * ```tsx
+ * function FileBrowserPane() {
+ *   const {
+ *     state,
+ *     setClipboard,
+ *     setSelection,
+ *     showContextMenu,
+ *     hideContextMenu,
+ *     setDragOverPath,
+ *   } = useFileBrowserState();
+ *
+ *   const { clipboard, selection, contextMenu, dragOverPath } = state;
+ *   const { anchorPath, focusedPath } = selection;
+ *
+ *   // Use in handlers...
+ * }
+ * ```
+ */
+export function useFileBrowserState(): UseFileBrowserStateReturn {
+	const [state, dispatch] = useReducer(fileBrowserUIReducer, fileBrowserUIInitialState);
+
+	// Clipboard operations
+	const setClipboard = useCallback((clipboard: ClipboardState) => {
+		dispatch({ type: "SET_CLIPBOARD", payload: clipboard });
+	}, []);
+
+	const clearClipboard = useCallback(() => {
+		dispatch({ type: "CLEAR_CLIPBOARD" });
+	}, []);
+
+	// Selection operations
+	const setAnchorPath = useCallback((path: string | null) => {
+		dispatch({ type: "SET_ANCHOR", payload: path });
+	}, []);
+
+	const setFocusedPath = useCallback((path: string | null) => {
+		dispatch({ type: "SET_FOCUSED", payload: path });
+	}, []);
+
+	const setSelection = useCallback((anchor: string | null, focused: string | null) => {
+		dispatch({ type: "SET_SELECTION", anchor, focused });
+	}, []);
+
+	// Context menu operations
+	const showContextMenu = useCallback((menu: ContextMenuState) => {
+		dispatch({ type: "SHOW_CONTEXT_MENU", payload: menu });
+	}, []);
+
+	const hideContextMenu = useCallback(() => {
+		dispatch({ type: "HIDE_CONTEXT_MENU" });
+	}, []);
+
+	// Drag-drop operations
+	const setDragOverPath = useCallback((path: string | null) => {
+		dispatch({ type: "SET_DRAG_OVER", payload: path });
+	}, []);
+
+	// Utility operations
+	const reset = useCallback(() => {
+		dispatch({ type: "RESET" });
+	}, []);
+
+	return {
+		state,
+		dispatch,
+		setClipboard,
+		clearClipboard,
+		setAnchorPath,
+		setFocusedPath,
+		setSelection,
+		showContextMenu,
+		hideContextMenu,
+		setDragOverPath,
+		reset,
+	};
+}

--- a/client/src/hooks/useListNavigation.ts
+++ b/client/src/hooks/useListNavigation.ts
@@ -1,0 +1,140 @@
+import { useCallback } from "react";
+
+/**
+ * Options for configuring list navigation behavior.
+ */
+export interface UseListNavigationOptions {
+	/**
+	 * Function to retrieve the list of focusable elements.
+	 * Should return an array of HTMLElements that can receive focus.
+	 */
+	getItems: () => HTMLElement[];
+
+	/**
+	 * Callback invoked when Escape is pressed.
+	 * @param focusButton - If true, focus should return to the trigger button
+	 */
+	onEscape?: (focusButton?: boolean) => void;
+
+	/**
+	 * Callback invoked when Tab is pressed.
+	 * Useful for closing menus on tab-out.
+	 */
+	onTab?: () => void;
+
+	/**
+	 * Callback invoked when Enter or Space is pressed on an item.
+	 * @param index - The index of the currently focused item
+	 */
+	onSelect?: (index: number) => void;
+
+	/**
+	 * Whether navigation should wrap around at the ends.
+	 * @default true
+	 */
+	wrap?: boolean;
+}
+
+/**
+ * A reusable hook for keyboard navigation in list-like UI components.
+ *
+ * Handles common keyboard interactions:
+ * - ArrowDown/ArrowUp: Navigate between items
+ * - Home/End: Jump to first/last item
+ * - Escape: Close/dismiss the list
+ * - Tab: Close the list (optional)
+ * - Enter/Space: Select the current item (optional)
+ *
+ * @example
+ * ```tsx
+ * const handleKeyDown = useListNavigation({
+ *   getItems: () => Array.from(menuRef.current?.querySelectorAll('button') ?? []),
+ *   onEscape: () => closeMenu(),
+ *   onTab: () => closeMenu(),
+ *   wrap: true,
+ * });
+ *
+ * return <div onKeyDown={handleKeyDown}>...</div>;
+ * ```
+ */
+export function useListNavigation(options: UseListNavigationOptions) {
+	const { getItems, onEscape, onTab, onSelect, wrap = true } = options;
+
+	return useCallback(
+		(event: React.KeyboardEvent | KeyboardEvent) => {
+			const items = getItems();
+
+			// Handle Escape even when there are no items
+			if (items.length === 0) {
+				if (event.key === "Escape" && onEscape) {
+					event.preventDefault();
+					onEscape(true);
+				}
+				return;
+			}
+
+			const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+
+			const focusItem = (index: number) => {
+				items[index]?.focus();
+			};
+
+			const navigateDown = () => {
+				if (currentIndex === -1) {
+					focusItem(0);
+				} else if (wrap) {
+					focusItem((currentIndex + 1) % items.length);
+				} else {
+					focusItem(Math.min(currentIndex + 1, items.length - 1));
+				}
+			};
+
+			const navigateUp = () => {
+				if (currentIndex === -1) {
+					focusItem(items.length - 1);
+				} else if (wrap) {
+					focusItem((currentIndex - 1 + items.length) % items.length);
+				} else {
+					focusItem(Math.max(currentIndex - 1, 0));
+				}
+			};
+
+			switch (event.key) {
+				case "ArrowDown":
+					event.preventDefault();
+					navigateDown();
+					break;
+				case "ArrowUp":
+					event.preventDefault();
+					navigateUp();
+					break;
+				case "Home":
+					event.preventDefault();
+					focusItem(0);
+					break;
+				case "End":
+					event.preventDefault();
+					focusItem(items.length - 1);
+					break;
+				case "Escape":
+					event.preventDefault();
+					onEscape?.(true);
+					break;
+				case "Tab":
+					// Don't prevent default - let the focus move naturally
+					onTab?.();
+					break;
+				case "Enter":
+				case " ":
+					if (onSelect && currentIndex >= 0) {
+						event.preventDefault();
+						onSelect(currentIndex);
+					}
+					break;
+				default:
+					break;
+			}
+		},
+		[getItems, onEscape, onTab, onSelect, wrap],
+	);
+}

--- a/client/src/types/asyncState.ts
+++ b/client/src/types/asyncState.ts
@@ -1,0 +1,56 @@
+/**
+ * Represents the state of an async operation.
+ * @template T The type of the data being loaded
+ */
+export interface AsyncState<T> {
+	/** The loaded data, or null if not yet loaded */
+	data: T | null;
+	/** Whether an async operation is in progress */
+	loading: boolean;
+	/** Error message if the operation failed, or null if successful */
+	error: string | null;
+}
+
+/**
+ * Action types for the async state reducer.
+ * @template T The type of the data being loaded
+ */
+export type AsyncStateAction<T> =
+	| { type: "loading" }
+	| { type: "success"; payload: T }
+	| { type: "error"; payload: string }
+	| { type: "reset" }
+	| { type: "set-data"; payload: T | null };
+
+/**
+ * Initial state for async operations.
+ */
+export const asyncStateInitial: AsyncState<unknown> = {
+	data: null,
+	loading: false,
+	error: null,
+};
+
+/**
+ * Reducer function for async state management.
+ * @template T The type of the data being loaded
+ */
+export function asyncStateReducer<T>(
+	state: AsyncState<T>,
+	action: AsyncStateAction<T>,
+): AsyncState<T> {
+	switch (action.type) {
+		case "loading":
+			return { ...state, loading: true, error: null };
+		case "success":
+			return { data: action.payload, loading: false, error: null };
+		case "error":
+			return { ...state, loading: false, error: action.payload };
+		case "reset":
+			return { data: null, loading: false, error: null };
+		case "set-data":
+			return { ...state, data: action.payload };
+		default:
+			return state;
+	}
+}

--- a/client/src/types/fileBrowser.ts
+++ b/client/src/types/fileBrowser.ts
@@ -1,0 +1,130 @@
+/**
+ * Types and reducer for FileBrowser local UI state management.
+ *
+ * This consolidates related states that often update together:
+ * - Clipboard (copy/cut operations)
+ * - Selection anchor/focus
+ * - Context menu
+ * - Drag-drop state
+ */
+
+/**
+ * Clipboard state for copy/cut operations.
+ */
+export type ClipboardState = {
+	mode: "copy" | "cut";
+	paths: string[];
+} | null;
+
+/**
+ * Context menu state for right-click operations.
+ */
+export type ContextMenuState = {
+	x: number;
+	y: number;
+	path: string;
+	isDir: boolean;
+} | null;
+
+/**
+ * Selection state for tracking anchor and focus in the file tree.
+ */
+export interface SelectionState {
+	/** The path that serves as the anchor for shift-selection */
+	anchorPath: string | null;
+	/** The path that is currently focused (keyboard navigation) */
+	focusedPath: string | null;
+}
+
+/**
+ * Combined UI state for the FileBrowser component.
+ */
+export interface FileBrowserUIState {
+	clipboard: ClipboardState;
+	selection: SelectionState;
+	contextMenu: ContextMenuState;
+	dragOverPath: string | null;
+}
+
+/**
+ * Actions for modifying FileBrowser UI state.
+ */
+export type FileBrowserUIAction =
+	| { type: "SET_CLIPBOARD"; payload: ClipboardState }
+	| { type: "SET_ANCHOR"; payload: string | null }
+	| { type: "SET_FOCUSED"; payload: string | null }
+	| { type: "SET_SELECTION"; anchor: string | null; focused: string | null }
+	| { type: "SHOW_CONTEXT_MENU"; payload: ContextMenuState }
+	| { type: "HIDE_CONTEXT_MENU" }
+	| { type: "SET_DRAG_OVER"; payload: string | null }
+	| { type: "COPY_CUT"; clipboard: ClipboardState; clearSelection?: boolean }
+	| { type: "CLEAR_CLIPBOARD" }
+	| { type: "RESET" };
+
+/**
+ * Initial state for FileBrowser UI.
+ */
+export const fileBrowserUIInitialState: FileBrowserUIState = {
+	clipboard: null,
+	selection: {
+		anchorPath: null,
+		focusedPath: null,
+	},
+	contextMenu: null,
+	dragOverPath: null,
+};
+
+/**
+ * Reducer function for FileBrowser UI state.
+ */
+export function fileBrowserUIReducer(
+	state: FileBrowserUIState,
+	action: FileBrowserUIAction,
+): FileBrowserUIState {
+	switch (action.type) {
+		case "SET_CLIPBOARD":
+			return { ...state, clipboard: action.payload };
+
+		case "SET_ANCHOR":
+			return {
+				...state,
+				selection: { ...state.selection, anchorPath: action.payload },
+			};
+
+		case "SET_FOCUSED":
+			return {
+				...state,
+				selection: { ...state.selection, focusedPath: action.payload },
+			};
+
+		case "SET_SELECTION":
+			return {
+				...state,
+				selection: { anchorPath: action.anchor, focusedPath: action.focused },
+			};
+
+		case "SHOW_CONTEXT_MENU":
+			return { ...state, contextMenu: action.payload };
+
+		case "HIDE_CONTEXT_MENU":
+			return { ...state, contextMenu: null };
+
+		case "SET_DRAG_OVER":
+			return { ...state, dragOverPath: action.payload };
+
+		case "COPY_CUT":
+			return {
+				...state,
+				clipboard: action.clipboard,
+			};
+
+		case "CLEAR_CLIPBOARD":
+			return { ...state, clipboard: null };
+
+		case "RESET":
+			return fileBrowserUIInitialState;
+
+		default:
+			return state;
+	}
+}


### PR DESCRIPTION
## Summary

This PR introduces reusable state management patterns to reduce code duplication and improve maintainability across the codebase.

- Created `useListNavigation` hook for keyboard list navigation
- Created `useAsyncState` hook for async data loading pattern
- Created `useFileBrowserState` hook to consolidate FileBrowser UI state
- Refactored MenuBar to use useListNavigation
- Added 46 unit tests for all new hooks

## New Hooks

### useListNavigation
Extracts keyboard list navigation pattern (ArrowUp/Down, Home/End, Escape) into a reusable hook.

### useAsyncState
Generic hook for async data loading pattern with:
- data, loading, error states
- execute, reset, setData methods
- Callbacks for success/error
- Immediate execution option

### useFileBrowserState
Consolidates FileBrowser local UI state into a single reducer:
- Clipboard (copy/cut operations)
- Selection anchor/focus
- Context menu
- Drag-drop state

## Test plan

- [x] All 179 tests pass
- [x] Type checking passes
- [x] MenuBar keyboard navigation works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)