### PR TITLE
Refactor React hooks to use structured return pattern (state/actions)

### DIFF
--- a/client/src/components/Terminal/TerminalPane.tsx
+++ b/client/src/components/Terminal/TerminalPane.tsx
@@ -6,11 +6,9 @@ import { TerminalSession } from "./TerminalSession";
 const TERMINAL_NEW_EVENT = "terminal:new";
 
 export function TerminalPane(): JSX.Element {
+	const { state, actions } = useTerminal();
+	const { terminalState, isAvailable, error, errorDetail } = state;
 	const {
-		state,
-		isAvailable,
-		error,
-		errorDetail,
 		createSession,
 		closeSession,
 		setActiveSession,
@@ -18,9 +16,9 @@ export function TerminalPane(): JSX.Element {
 		resizeSession,
 		registerOutputHandler,
 		unregisterOutputHandler,
-	} = useTerminal();
+	} = actions;
 
-	const { sessions, activeSessionId } = state;
+	const { sessions, activeSessionId } = terminalState;
 	const didBootstrapRef = useRef(false);
 
 	const sessionTabs = useMemo(

--- a/client/src/components/bottom-pane/BottomPane.tsx
+++ b/client/src/components/bottom-pane/BottomPane.tsx
@@ -5,15 +5,9 @@ import { PlotHistoryPanel } from "@/components/plot-history";
 import { useBottomPaneState } from "@/hooks/useBottomPaneState";
 
 export function BottomPane(): JSX.Element {
-	const {
-		tabs,
-		activeTab,
-		setActiveTab,
-		navigation,
-		goToPreviousPlot,
-		goToNextPlot,
-		clearExecutionResults,
-	} = useBottomPaneState();
+	const { state, actions } = useBottomPaneState();
+	const { tabs, activeTab, navigation } = state;
+	const { setActiveTab, goToPreviousPlot, goToNextPlot, clearExecutionResults } = actions;
 
 	const { selectedPlotIndex, totalPlots } = navigation;
 	const showClear = activeTab === "console" || activeTab === "history";

--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -32,10 +32,12 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
 
 	const cells = useEditorCells(editor.content, editor.filepath);
-	const { executingCellIndex, handleRunAll, handleRunCurrentCell } = useEditorExecution({
+	const { state, actions } = useEditorExecution({
 		editorRef: monacoEditorRef,
 		cells,
 	});
+	const { executingCellIndex } = state;
+	const { handleRunAll, handleRunCurrentCell } = actions;
 
 	useEditorDecorations(monacoEditorRef, cells, {
 		showCellDecorations: settings.showCellDecorations,

--- a/client/src/components/export/ExportDialog.tsx
+++ b/client/src/components/export/ExportDialog.tsx
@@ -8,25 +8,28 @@ interface ExportDialogProps {
 }
 
 export function ExportDialog({ open, onClose }: ExportDialogProps): JSX.Element | null {
+	const { state, actions } = useExportDialog({ open, onClose });
 	const {
 		format,
-		setFormat,
 		mode,
-		setMode,
 		options,
-		setOption,
 		codeFolding,
-		setCodeFolding,
 		pdfOptions,
-		setPdfOption,
 		documentPath,
-		setDocumentPath,
 		outputPath,
-		setOutputPath,
 		exporting,
 		error,
+	} = state;
+	const {
+		setFormat,
+		setMode,
+		setOption,
+		setCodeFolding,
+		setPdfOption,
+		setDocumentPath,
+		setOutputPath,
 		handleExport,
-	} = useExportDialog({ open, onClose });
+	} = actions;
 
 	if (!open) return null;
 

--- a/client/src/components/file-browser/FileBrowserPane.tsx
+++ b/client/src/components/file-browser/FileBrowserPane.tsx
@@ -159,8 +159,9 @@ export function FileBrowserPane(): JSX.Element {
 	const setActivePath = useFileSystemStore((state) => state.setActivePath);
 	const workspaceRoot = useFileSystemStore((state) => state.workspaceRoot);
 
+	const { state, actions } = useFileBrowserState();
+	const { fileBrowserState: uiState } = state;
 	const {
-		state: uiState,
 		setClipboard,
 		clearClipboard,
 		setAnchorPath,
@@ -169,7 +170,7 @@ export function FileBrowserPane(): JSX.Element {
 		showContextMenu,
 		hideContextMenu,
 		setDragOverPath,
-	} = useFileBrowserState();
+	} = actions;
 	const { clipboard, selection, contextMenu, dragOverPath } = uiState;
 	const { anchorPath, focusedPath } = selection;
 

--- a/client/src/components/timeline/TimelineDialog.tsx
+++ b/client/src/components/timeline/TimelineDialog.tsx
@@ -38,20 +38,9 @@ export const TimelineDialog = forwardRef<TimelineDialogRef, TimelineDialogProps>
 			onClose?.();
 		}, [onClose]);
 
-		const {
-			events,
-			total,
-			hasMore,
-			loading,
-			error,
-			filters,
-			sort,
-			setFilters,
-			setSort,
-			loadMore,
-			stats,
-			statsLoading,
-		} = useTimelineData();
+		const { state, actions } = useTimelineData();
+		const { events, total, hasMore, loading, error, filters, sort, stats, statsLoading } = state;
+		const { setFilters, setSort, loadMore } = actions;
 
 		const editorRef = useStore((state) => state.editorRef);
 

--- a/client/src/hooks/__tests__/useFileBrowserState.test.ts
+++ b/client/src/hooks/__tests__/useFileBrowserState.test.ts
@@ -7,7 +7,7 @@ describe("useFileBrowserState", () => {
 		it("should have correct initial state", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
-			expect(result.current.state).toEqual({
+			expect(result.current.state.fileBrowserState).toEqual({
 				clipboard: null,
 				selection: {
 					anchorPath: null,
@@ -24,10 +24,10 @@ describe("useFileBrowserState", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.setClipboard({ mode: "copy", paths: ["/src/file.ts"] });
+				result.current.actions.setClipboard({ mode: "copy", paths: ["/src/file.ts"] });
 			});
 
-			expect(result.current.state.clipboard).toEqual({
+			expect(result.current.state.fileBrowserState.clipboard).toEqual({
 				mode: "copy",
 				paths: ["/src/file.ts"],
 			});
@@ -37,16 +37,16 @@ describe("useFileBrowserState", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.setClipboard({ mode: "cut", paths: ["/src/file.ts"] });
+				result.current.actions.setClipboard({ mode: "cut", paths: ["/src/file.ts"] });
 			});
 
-			expect(result.current.state.clipboard).not.toBeNull();
+			expect(result.current.state.fileBrowserState.clipboard).not.toBeNull();
 
 			act(() => {
-				result.current.clearClipboard();
+				result.current.actions.clearClipboard();
 			});
 
-			expect(result.current.state.clipboard).toBeNull();
+			expect(result.current.state.fileBrowserState.clipboard).toBeNull();
 		});
 	});
 
@@ -55,32 +55,32 @@ describe("useFileBrowserState", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.setAnchorPath("/src/anchor.ts");
+				result.current.actions.setAnchorPath("/src/anchor.ts");
 			});
 
-			expect(result.current.state.selection.anchorPath).toBe("/src/anchor.ts");
-			expect(result.current.state.selection.focusedPath).toBeNull();
+			expect(result.current.state.fileBrowserState.selection.anchorPath).toBe("/src/anchor.ts");
+			expect(result.current.state.fileBrowserState.selection.focusedPath).toBeNull();
 		});
 
 		it("should set focused path", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.setFocusedPath("/src/focused.ts");
+				result.current.actions.setFocusedPath("/src/focused.ts");
 			});
 
-			expect(result.current.state.selection.focusedPath).toBe("/src/focused.ts");
-			expect(result.current.state.selection.anchorPath).toBeNull();
+			expect(result.current.state.fileBrowserState.selection.focusedPath).toBe("/src/focused.ts");
+			expect(result.current.state.fileBrowserState.selection.anchorPath).toBeNull();
 		});
 
 		it("should set both anchor and focused paths", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.setSelection("/src/anchor.ts", "/src/focused.ts");
+				result.current.actions.setSelection("/src/anchor.ts", "/src/focused.ts");
 			});
 
-			expect(result.current.state.selection).toEqual({
+			expect(result.current.state.fileBrowserState.selection).toEqual({
 				anchorPath: "/src/anchor.ts",
 				focusedPath: "/src/focused.ts",
 			});
@@ -90,14 +90,14 @@ describe("useFileBrowserState", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.setSelection("/src/anchor.ts", "/src/focused.ts");
+				result.current.actions.setSelection("/src/anchor.ts", "/src/focused.ts");
 			});
 
 			act(() => {
-				result.current.setSelection(null, null);
+				result.current.actions.setSelection(null, null);
 			});
 
-			expect(result.current.state.selection).toEqual({
+			expect(result.current.state.fileBrowserState.selection).toEqual({
 				anchorPath: null,
 				focusedPath: null,
 			});
@@ -109,7 +109,7 @@ describe("useFileBrowserState", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.showContextMenu({
+				result.current.actions.showContextMenu({
 					x: 100,
 					y: 200,
 					path: "/src/file.ts",
@@ -117,7 +117,7 @@ describe("useFileBrowserState", () => {
 				});
 			});
 
-			expect(result.current.state.contextMenu).toEqual({
+			expect(result.current.state.fileBrowserState.contextMenu).toEqual({
 				x: 100,
 				y: 200,
 				path: "/src/file.ts",
@@ -129,7 +129,7 @@ describe("useFileBrowserState", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.showContextMenu({
+				result.current.actions.showContextMenu({
 					x: 100,
 					y: 200,
 					path: "/src/file.ts",
@@ -138,10 +138,10 @@ describe("useFileBrowserState", () => {
 			});
 
 			act(() => {
-				result.current.hideContextMenu();
+				result.current.actions.hideContextMenu();
 			});
 
-			expect(result.current.state.contextMenu).toBeNull();
+			expect(result.current.state.fileBrowserState.contextMenu).toBeNull();
 		});
 	});
 
@@ -150,24 +150,24 @@ describe("useFileBrowserState", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.setDragOverPath("/src/folder");
+				result.current.actions.setDragOverPath("/src/folder");
 			});
 
-			expect(result.current.state.dragOverPath).toBe("/src/folder");
+			expect(result.current.state.fileBrowserState.dragOverPath).toBe("/src/folder");
 		});
 
 		it("should clear drag over path", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.setDragOverPath("/src/folder");
+				result.current.actions.setDragOverPath("/src/folder");
 			});
 
 			act(() => {
-				result.current.setDragOverPath(null);
+				result.current.actions.setDragOverPath(null);
 			});
 
-			expect(result.current.state.dragOverPath).toBeNull();
+			expect(result.current.state.fileBrowserState.dragOverPath).toBeNull();
 		});
 	});
 
@@ -177,25 +177,25 @@ describe("useFileBrowserState", () => {
 
 			// Set up some state
 			act(() => {
-				result.current.setClipboard({ mode: "copy", paths: ["/file.ts"] });
-				result.current.setSelection("/anchor.ts", "/focused.ts");
-				result.current.showContextMenu({ x: 10, y: 20, path: "/menu.ts", isDir: false });
-				result.current.setDragOverPath("/folder");
+				result.current.actions.setClipboard({ mode: "copy", paths: ["/file.ts"] });
+				result.current.actions.setSelection("/anchor.ts", "/focused.ts");
+				result.current.actions.showContextMenu({ x: 10, y: 20, path: "/menu.ts", isDir: false });
+				result.current.actions.setDragOverPath("/folder");
 			});
 
 			// Verify state is set
-			expect(result.current.state.clipboard).not.toBeNull();
-			expect(result.current.state.selection.anchorPath).not.toBeNull();
-			expect(result.current.state.contextMenu).not.toBeNull();
-			expect(result.current.state.dragOverPath).not.toBeNull();
+			expect(result.current.state.fileBrowserState.clipboard).not.toBeNull();
+			expect(result.current.state.fileBrowserState.selection.anchorPath).not.toBeNull();
+			expect(result.current.state.fileBrowserState.contextMenu).not.toBeNull();
+			expect(result.current.state.fileBrowserState.dragOverPath).not.toBeNull();
 
 			// Reset
 			act(() => {
-				result.current.reset();
+				result.current.actions.reset();
 			});
 
 			// Verify all state is reset
-			expect(result.current.state).toEqual({
+			expect(result.current.state.fileBrowserState).toEqual({
 				clipboard: null,
 				selection: {
 					anchorPath: null,
@@ -212,13 +212,13 @@ describe("useFileBrowserState", () => {
 			const { result } = renderHook(() => useFileBrowserState());
 
 			act(() => {
-				result.current.dispatch({
+				result.current.actions.dispatch({
 					type: "SET_CLIPBOARD",
 					payload: { mode: "cut", paths: ["/direct.ts"] },
 				});
 			});
 
-			expect(result.current.state.clipboard).toEqual({
+			expect(result.current.state.fileBrowserState.clipboard).toEqual({
 				mode: "cut",
 				paths: ["/direct.ts"],
 			});

--- a/client/src/hooks/useBottomPaneState.ts
+++ b/client/src/hooks/useBottomPaneState.ts
@@ -10,18 +10,26 @@ import type {
 	PlotNavigationState,
 } from "@/types/panels";
 
-interface UseBottomPaneStateResult {
+interface UseBottomPaneState {
 	tabs: PanelTabItem<BottomPaneTab>[];
 	activeTab: BottomPaneTab;
-	setActiveTab: (tab: BottomPaneTab) => void;
 	navigation: PlotNavigationState;
 	allPlots: ExecutionLogPlot[];
 	currentPlot: ExecutionLogPlot | null;
+}
+
+interface UseBottomPaneActions {
+	setActiveTab: (tab: BottomPaneTab) => void;
 	selectPreviousPlot: () => void;
 	selectNextPlot: () => void;
 	goToPreviousPlot: () => void;
 	goToNextPlot: () => void;
 	clearExecutionResults: () => void;
+}
+
+interface UseBottomPaneStateResult {
+	state: UseBottomPaneState;
+	actions: UseBottomPaneActions;
 }
 
 const DEFAULT_TAB: BottomPaneTab = "console";
@@ -153,16 +161,20 @@ export function useBottomPaneState(): UseBottomPaneStateResult {
 	}, [allPlots, persistActivePlot, selectNextPlot, selectedPlotIndex]);
 
 	return {
-		tabs,
-		activeTab,
-		setActiveTab,
-		navigation,
-		allPlots,
-		currentPlot,
-		selectPreviousPlot,
-		selectNextPlot,
-		goToPreviousPlot,
-		goToNextPlot,
-		clearExecutionResults,
+		state: {
+			tabs,
+			activeTab,
+			navigation,
+			allPlots,
+			currentPlot,
+		},
+		actions: {
+			setActiveTab,
+			selectPreviousPlot,
+			selectNextPlot,
+			goToPreviousPlot,
+			goToNextPlot,
+			clearExecutionResults,
+		},
 	};
 }

--- a/client/src/hooks/useEditorExecution.ts
+++ b/client/src/hooks/useEditorExecution.ts
@@ -17,7 +17,25 @@ interface UseEditorExecutionProps {
 	cells: Cell[];
 }
 
-export function useEditorExecution({ editorRef, cells }: UseEditorExecutionProps) {
+interface UseEditorExecutionState {
+	executingCellIndex: number | null;
+}
+
+interface UseEditorExecutionActions {
+	handleRunAll: () => void;
+	handleRunCurrentCell: () => void;
+	handleRunCellAndMoveNext: () => void;
+}
+
+interface UseEditorExecutionReturn {
+	state: UseEditorExecutionState;
+	actions: UseEditorExecutionActions;
+}
+
+export function useEditorExecution({
+	editorRef,
+	cells,
+}: UseEditorExecutionProps): UseEditorExecutionReturn {
 	const editorContent = useStore((state) => state.editor.content);
 	const editorFilepath = useStore((state) => state.editor.filepath);
 	const cursorLine = useStore((state) => state.editor.cursorPosition.line);
@@ -99,9 +117,13 @@ export function useEditorExecution({ editorRef, cells }: UseEditorExecutionProps
 	}, [cells, cursorLine, editorRef, executeCode]);
 
 	return {
-		executingCellIndex,
-		handleRunAll,
-		handleRunCurrentCell,
-		handleRunCellAndMoveNext,
+		state: {
+			executingCellIndex,
+		},
+		actions: {
+			handleRunAll,
+			handleRunCurrentCell,
+			handleRunCellAndMoveNext,
+		},
 	};
 }

--- a/client/src/hooks/useExportDialog.ts
+++ b/client/src/hooks/useExportDialog.ts
@@ -49,24 +49,32 @@ function reducer(state: ExportDialogState, action: ExportDialogAction): ExportDi
 	}
 }
 
-interface UseExportDialogReturn {
+interface UseExportDialogState {
 	format: ExportDialogFormat;
-	setFormat: (next: ExportDialogFormat) => void;
 	mode: ExportRMarkdownRequestPayload["mode"];
-	setMode: (next: ExportRMarkdownRequestPayload["mode"]) => void;
 	options: ExportDialogOptions;
-	setOption: (key: ExportOptionKey, value: boolean) => void;
 	codeFolding: CodeFolding;
-	setCodeFolding: (next: CodeFolding) => void;
 	pdfOptions: ExportPdfOptions;
-	setPdfOption: <TKey extends ExportPdfOptionKey>(key: TKey, value: ExportPdfOptions[TKey]) => void;
 	documentPath: string;
-	setDocumentPath: (value: string) => void;
 	outputPath: string;
-	setOutputPath: (value: string) => void;
 	exporting: boolean;
 	error: string;
+}
+
+interface UseExportDialogActions {
+	setFormat: (next: ExportDialogFormat) => void;
+	setMode: (next: ExportRMarkdownRequestPayload["mode"]) => void;
+	setOption: (key: ExportOptionKey, value: boolean) => void;
+	setCodeFolding: (next: CodeFolding) => void;
+	setPdfOption: <TKey extends ExportPdfOptionKey>(key: TKey, value: ExportPdfOptions[TKey]) => void;
+	setDocumentPath: (value: string) => void;
+	setOutputPath: (value: string) => void;
 	handleExport: () => Promise<void>;
+}
+
+interface UseExportDialogReturn {
+	state: UseExportDialogState;
+	actions: UseExportDialogActions;
 }
 
 interface UseExportDialogProps {
@@ -197,22 +205,26 @@ export function useExportDialog({ open, onClose }: UseExportDialogProps): UseExp
 	}, [format, mode, options, codeFolding, pdfOptions, documentPath, outputPath, onClose]);
 
 	return {
-		format,
-		setFormat: (next) => dispatch({ type: "set-format", payload: next }),
-		mode,
-		setMode: (next) => dispatch({ type: "set-mode", payload: next }),
-		options,
-		setOption,
-		codeFolding,
-		setCodeFolding: (next) => dispatch({ type: "set-code-folding", payload: next }),
-		pdfOptions,
-		setPdfOption,
-		documentPath,
-		setDocumentPath: (value) => dispatch({ type: "set-document-path", payload: value }),
-		outputPath,
-		setOutputPath: (value) => dispatch({ type: "set-output-path", payload: value }),
-		exporting,
-		error,
-		handleExport,
+		state: {
+			format,
+			mode,
+			options,
+			codeFolding,
+			pdfOptions,
+			documentPath,
+			outputPath,
+			exporting,
+			error,
+		},
+		actions: {
+			setFormat: (next) => dispatch({ type: "set-format", payload: next }),
+			setMode: (next) => dispatch({ type: "set-mode", payload: next }),
+			setOption,
+			setCodeFolding: (next) => dispatch({ type: "set-code-folding", payload: next }),
+			setPdfOption,
+			setDocumentPath: (value) => dispatch({ type: "set-document-path", payload: value }),
+			setOutputPath: (value) => dispatch({ type: "set-output-path", payload: value }),
+			handleExport,
+		},
 	};
 }

--- a/client/src/hooks/useFileBrowserState.ts
+++ b/client/src/hooks/useFileBrowserState.ts
@@ -8,12 +8,17 @@ import type {
 import { fileBrowserUIInitialState, fileBrowserUIReducer } from "@/types/fileBrowser";
 
 /**
- * Return type for the useFileBrowserState hook.
+ * State returned by the useFileBrowserState hook.
  */
-export interface UseFileBrowserStateReturn {
+export interface UseFileBrowserState {
 	/** Current UI state */
-	state: FileBrowserUIState;
+	fileBrowserState: FileBrowserUIState;
+}
 
+/**
+ * Actions returned by the useFileBrowserState hook.
+ */
+export interface UseFileBrowserActions {
 	/** Raw dispatch function for custom actions */
 	dispatch: React.Dispatch<FileBrowserUIAction>;
 
@@ -47,6 +52,14 @@ export interface UseFileBrowserStateReturn {
 }
 
 /**
+ * Return type for the useFileBrowserState hook.
+ */
+export interface UseFileBrowserStateReturn {
+	state: UseFileBrowserState;
+	actions: UseFileBrowserActions;
+}
+
+/**
  * A hook for managing FileBrowser local UI state.
  *
  * Consolidates related states that often update together:
@@ -58,16 +71,17 @@ export interface UseFileBrowserStateReturn {
  * @example
  * ```tsx
  * function FileBrowserPane() {
+ *   const { state, actions } = useFileBrowserState();
+ *   const { fileBrowserState } = state;
  *   const {
- *     state,
  *     setClipboard,
  *     setSelection,
  *     showContextMenu,
  *     hideContextMenu,
  *     setDragOverPath,
- *   } = useFileBrowserState();
+ *   } = actions;
  *
- *   const { clipboard, selection, contextMenu, dragOverPath } = state;
+ *   const { clipboard, selection, contextMenu, dragOverPath } = fileBrowserState;
  *   const { anchorPath, focusedPath } = selection;
  *
  *   // Use in handlers...
@@ -75,7 +89,7 @@ export interface UseFileBrowserStateReturn {
  * ```
  */
 export function useFileBrowserState(): UseFileBrowserStateReturn {
-	const [state, dispatch] = useReducer(fileBrowserUIReducer, fileBrowserUIInitialState);
+	const [fileBrowserState, dispatch] = useReducer(fileBrowserUIReducer, fileBrowserUIInitialState);
 
 	// Clipboard operations
 	const setClipboard = useCallback((clipboard: ClipboardState) => {
@@ -119,16 +133,20 @@ export function useFileBrowserState(): UseFileBrowserStateReturn {
 	}, []);
 
 	return {
-		state,
-		dispatch,
-		setClipboard,
-		clearClipboard,
-		setAnchorPath,
-		setFocusedPath,
-		setSelection,
-		showContextMenu,
-		hideContextMenu,
-		setDragOverPath,
-		reset,
+		state: {
+			fileBrowserState,
+		},
+		actions: {
+			dispatch,
+			setClipboard,
+			clearClipboard,
+			setAnchorPath,
+			setFocusedPath,
+			setSelection,
+			showContextMenu,
+			hideContextMenu,
+			setDragOverPath,
+			reset,
+		},
 	};
 }

--- a/client/src/hooks/useTerminal.ts
+++ b/client/src/hooks/useTerminal.ts
@@ -17,11 +17,14 @@ const isTauriAvailable =
 			(window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__,
 	);
 
-interface UseTerminalResult {
-	state: TerminalState;
+interface UseTerminalState {
+	terminalState: TerminalState;
 	isAvailable: boolean;
 	error: string | null;
 	errorDetail: string | null;
+}
+
+interface UseTerminalActions {
 	createSession: () => Promise<void>;
 	closeSession: (sessionId: string) => Promise<void>;
 	setActiveSession: (sessionId: string) => void;
@@ -31,8 +34,13 @@ interface UseTerminalResult {
 	unregisterOutputHandler: (sessionId: string) => void;
 }
 
+interface UseTerminalResult {
+	state: UseTerminalState;
+	actions: UseTerminalActions;
+}
+
 export function useTerminal(): UseTerminalResult {
-	const [state, setState] = useState<TerminalState>({
+	const [terminalState, setTerminalState] = useState<TerminalState>({
 		sessions: [],
 		activeSessionId: null,
 	});
@@ -43,7 +51,7 @@ export function useTerminal(): UseTerminalResult {
 	const processesRef = useRef(new Map<string, SimplePty>());
 
 	const addSession = useCallback((sessionId: string, title: string) => {
-		setState((prev) => ({
+		setTerminalState((prev) => ({
 			sessions: [
 				...prev.sessions.map((session) => ({ ...session, isActive: false })),
 				{ id: sessionId, title, isActive: true },
@@ -53,7 +61,7 @@ export function useTerminal(): UseTerminalResult {
 	}, []);
 
 	const removeSession = useCallback((sessionId: string) => {
-		setState((prev) => {
+		setTerminalState((prev) => {
 			const sessions = prev.sessions.filter((session) => session.id !== sessionId);
 			const nextActive =
 				prev.activeSessionId === sessionId
@@ -75,7 +83,7 @@ export function useTerminal(): UseTerminalResult {
 	}, []);
 
 	const setActiveSession = useCallback((sessionId: string) => {
-		setState((prev) => ({
+		setTerminalState((prev) => ({
 			sessions: prev.sessions.map((session) => ({
 				...session,
 				isActive: session.id === sessionId,
@@ -180,17 +188,21 @@ export function useTerminal(): UseTerminalResult {
 	useEffect(() => {}, []);
 
 	return {
-		state,
-		isAvailable: isTauriAvailable,
-		error,
-		errorDetail,
-		createSession,
-		closeSession,
-		setActiveSession,
-		writeToSession,
-		resizeSession,
-		registerOutputHandler,
-		unregisterOutputHandler,
+		state: {
+			terminalState,
+			isAvailable: isTauriAvailable,
+			error,
+			errorDetail,
+		},
+		actions: {
+			createSession,
+			closeSession,
+			setActiveSession,
+			writeToSession,
+			resizeSession,
+			registerOutputHandler,
+			unregisterOutputHandler,
+		},
 	};
 }
 

--- a/client/src/hooks/useTimelineData.ts
+++ b/client/src/hooks/useTimelineData.ts
@@ -9,7 +9,30 @@ import {
 } from "@/services/timelineService";
 import { getErrorMessage } from "@/utils/error";
 
-export function useTimelineData() {
+interface UseTimelineDataState {
+	events: ExecutionEventPayload[];
+	total: number;
+	hasMore: boolean;
+	loading: boolean;
+	error: string | null;
+	filters: any;
+	sort: any;
+	stats: TimelineStats | null;
+	statsLoading: boolean;
+}
+
+interface UseTimelineDataActions {
+	loadMore: () => void;
+	setFilters: (filters: any) => void;
+	setSort: (sort: any) => void;
+}
+
+interface UseTimelineDataReturn {
+	state: UseTimelineDataState;
+	actions: UseTimelineDataActions;
+}
+
+export function useTimelineData(): UseTimelineDataReturn {
 	const {
 		events,
 		total,
@@ -143,17 +166,21 @@ export function useTimelineData() {
 	}, [isConnected, filters, addEvent]);
 
 	return {
-		events,
-		total,
-		hasMore,
-		loading,
-		error,
-		filters,
-		sort,
-		loadMore,
-		setFilters,
-		setSort,
-		stats,
-		statsLoading,
+		state: {
+			events,
+			total,
+			hasMore,
+			loading,
+			error,
+			filters,
+			sort,
+			stats,
+			statsLoading,
+		},
+		actions: {
+			loadMore,
+			setFilters,
+			setSort,
+		},
 	};
 }

--- a/core/src/acp/client.rs
+++ b/core/src/acp/client.rs
@@ -531,8 +531,8 @@ fn select_timeout_outcome(options: &[PermissionOption]) -> RequestPermissionOutc
 
 #[cfg(test)]
 mod tests {
-    use super::test_support::ENV_LOCK;
     use super::*;
+    use crate::acp::test_support::ENV_LOCK;
     use crate::config::APP_DIR_ENV;
     use agent_client_protocol::{
         PermissionOption, PermissionOptionId, PermissionOptionKind, SelectedPermissionOutcome,

--- a/core/src/acp/config.rs
+++ b/core/src/acp/config.rs
@@ -152,8 +152,8 @@ pub fn is_external_mode(mode: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::acp::test_support::ENV_LOCK;
     use crate::config::{APP_DIR_ENV, WORKSPACE_ROOT_ENV};
-    use crate::test_support::ENV_LOCK;
     use std::{env, fs};
 
     fn with_env_lock<T>(f: impl FnOnce() -> T) -> T {

--- a/core/src/acp/connection.rs
+++ b/core/src/acp/connection.rs
@@ -342,9 +342,11 @@ mod tests {
 
     #[test]
     fn converts_decision_into_protocol_message() {
+        use crate::acp::types::AcpPermissionDecisionOutcome;
+
         let decision = AcpPermissionDecision {
             request_id: "req-1".to_string(),
-            outcome: super::types::AcpPermissionDecisionOutcome::AllowOnce,
+            outcome: AcpPermissionDecisionOutcome::AllowOnce,
             option_id: Some("opt-1".to_string()),
             remember_scope: None,
         };
@@ -361,9 +363,11 @@ mod tests {
 
     #[test]
     fn converts_cancelled_decision() {
+        use crate::acp::types::AcpPermissionDecisionOutcome;
+
         let decision = AcpPermissionDecision {
             request_id: "req-2".to_string(),
-            outcome: super::types::AcpPermissionDecisionOutcome::Cancelled,
+            outcome: AcpPermissionDecisionOutcome::Cancelled,
             option_id: None,
             remember_scope: None,
         };

--- a/core/src/acp/detection.rs
+++ b/core/src/acp/detection.rs
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn resolves_active_agent_command_from_config() {
         let cfg = AcpConfig {
-            active_mode: crate::config::ACP_MODE_EXTERNAL_AGENT.to_string(),
+            active_mode: ACP_MODE_EXTERNAL_AGENT.to_string(),
             active_agent: Some("codex".to_string()),
             active_agent_command: None,
         };
@@ -186,7 +186,7 @@ mod tests {
     #[test]
     fn resolves_active_agent_command_override() {
         let cfg = AcpConfig {
-            active_mode: crate::config::ACP_MODE_EXTERNAL_AGENT.to_string(),
+            active_mode: ACP_MODE_EXTERNAL_AGENT.to_string(),
             active_agent: Some("codex".to_string()),
             active_agent_command: Some("/opt/bin/codex-acp".to_string()),
         };


### PR DESCRIPTION
## Summary

Refactored 6 React hooks to return structured objects with separate `state` and `actions` properties, following the pattern established in issue-290 (useAIConversation refactoring).

## Changes

### Refactored Hooks

1. **useExportDialog** - 16 items → `{ state, actions }`
2. **useTerminal** - 11 items → `{ state, actions }`
3. **useFileBrowserState** - 11 items → `{ state, actions }`
4. **useBottomPaneState** - 11 items → `{ state, actions }`
5. **useTimelineData** - 10 items → `{ state, actions }`
6. **useEditorExecution** - 4 items → `{ state, actions }`

### Pattern

**Before:**
```typescript
const [state1, state2, action1, action2, ...] = useHook();
```

**After:**
```typescript
const { state, actions } = useHook();
const { state1, state2 } = state;
const { action1, action2 } = actions;
```

## Benefits

- ✅ Clear separation between state (data) and actions (functions)
- ✅ Improved code readability and maintainability
- ✅ Better IntelliSense/autocomplete support
- ✅ Easier to understand hook responsibilities
- ✅ Reduced cognitive load when using the hooks

## Testing

- ✅ TypeScript compilation successful (no errors)
- ✅ All pre-commit hooks passed (Biome formatting)
- ✅ All pre-push hooks passed (linting, clippy, formatting)
- ✅ Updated all call sites to use new destructuring pattern
- ✅ No breaking changes in functionality

## Related Issues

Closes #296
