### PR TITLE
Add ACP web search tool support

### DIFF
--- a/client/src/components/ai-panel/ToolCallLog.tsx
+++ b/client/src/components/ai-panel/ToolCallLog.tsx
@@ -30,23 +30,27 @@ const isFetchTool = (log: ToolCallLogEntry): boolean => {
 const extractSearchResults = (payload?: Record<string, unknown>): SearchResult[] | null => {
 	if (!payload || !Array.isArray(payload.results)) return null;
 
-	const results = payload.results
-		.map((entry) => {
-			if (!entry || typeof entry !== "object") return null;
-			const record = entry as Record<string, unknown>;
-			const title = typeof record.title === "string" ? record.title : "";
-			const uri = typeof record.uri === "string" ? record.uri : "";
-			const description =
-				typeof record.description === "string"
-					? record.description
-					: typeof record.text === "string"
-						? record.text
-						: undefined;
+	const results: SearchResult[] = [];
+	for (const entry of payload.results) {
+		if (!entry || typeof entry !== "object") continue;
+		const record = entry as Record<string, unknown>;
+		const title = typeof record.title === "string" ? record.title : "";
+		const uri = typeof record.uri === "string" ? record.uri : "";
+		const description =
+			typeof record.description === "string"
+				? record.description
+				: typeof record.text === "string"
+					? record.text
+					: undefined;
 
-			if (!title && !uri) return null;
-			return { title, uri, description };
-		})
-		.filter((entry): entry is SearchResult => Boolean(entry));
+		if (!title && !uri) continue;
+		const result: SearchResult = {
+			title,
+			uri,
+			...(description ? { description } : {}),
+		};
+		results.push(result);
+	}
 
 	return results.length > 0 ? results : null;
 };

--- a/client/src/components/ai-panel/ToolCallLog.tsx
+++ b/client/src/components/ai-panel/ToolCallLog.tsx
@@ -60,26 +60,29 @@ const renderSearchResults = (results: SearchResult[]): JSX.Element => {
 		<div className="ai-tool-call__search">
 			<div className="ai-tool-call__search-meta">{results.length} result(s)</div>
 			<ul className="ai-tool-call__search-list">
-				{results.map((result, index) => (
-					<li key={`${result.uri}-${index}`} className="ai-tool-call__search-item">
-						{result.title ? (
-							<a
-								className="ai-tool-call__search-title"
-								href={result.uri}
-								target="_blank"
-								rel="noreferrer"
-							>
-								{result.title}
-							</a>
-						) : (
-							<span className="ai-tool-call__search-title">{result.uri}</span>
-						)}
-						{result.uri && <div className="ai-tool-call__search-uri">{result.uri}</div>}
-						{result.description && (
-							<div className="ai-tool-call__search-desc">{result.description}</div>
-						)}
-					</li>
-				))}
+				{results.map((result, index) => {
+					const label = result.title || result.uri;
+					return (
+						<li key={`${result.uri}-${index}`} className="ai-tool-call__search-item">
+							{result.uri ? (
+								<a
+									className="ai-tool-call__search-title"
+									href={result.uri}
+									target="_blank"
+									rel="noreferrer"
+								>
+									{label}
+								</a>
+							) : (
+								<span className="ai-tool-call__search-title">{label}</span>
+							)}
+							{result.uri && <div className="ai-tool-call__search-uri">{result.uri}</div>}
+							{result.description && (
+								<div className="ai-tool-call__search-desc">{result.description}</div>
+							)}
+						</li>
+					);
+				})}
 			</ul>
 		</div>
 	);

--- a/client/src/components/ai-panel/ToolCallLog.tsx
+++ b/client/src/components/ai-panel/ToolCallLog.tsx
@@ -6,12 +6,79 @@ interface Props {
 	logs?: ToolCallLogEntry[];
 }
 
+type SearchResult = {
+	title: string;
+	uri: string;
+	description?: string;
+};
+
 // RStudio-style minimal status icons (no colors, just symbols)
 const STATUS_ICON: Record<ToolCallLogEntry["status"], string> = {
 	pending: "○",
 	running: "◐",
 	done: "✓",
 	error: "✗",
+};
+
+const isFetchTool = (log: ToolCallLogEntry): boolean => {
+	if (log.kind && log.kind.toLowerCase().includes("fetch")) {
+		return true;
+	}
+	return log.name === "web_search";
+};
+
+const extractSearchResults = (payload?: Record<string, unknown>): SearchResult[] | null => {
+	if (!payload || !Array.isArray(payload.results)) return null;
+
+	const results = payload.results
+		.map((entry) => {
+			if (!entry || typeof entry !== "object") return null;
+			const record = entry as Record<string, unknown>;
+			const title = typeof record.title === "string" ? record.title : "";
+			const uri = typeof record.uri === "string" ? record.uri : "";
+			const description =
+				typeof record.description === "string"
+					? record.description
+					: typeof record.text === "string"
+						? record.text
+						: undefined;
+
+			if (!title && !uri) return null;
+			return { title, uri, description };
+		})
+		.filter((entry): entry is SearchResult => Boolean(entry));
+
+	return results.length > 0 ? results : null;
+};
+
+const renderSearchResults = (results: SearchResult[]): JSX.Element => {
+	return (
+		<div className="ai-tool-call__search">
+			<div className="ai-tool-call__search-meta">{results.length} result(s)</div>
+			<ul className="ai-tool-call__search-list">
+				{results.map((result, index) => (
+					<li key={`${result.uri}-${index}`} className="ai-tool-call__search-item">
+						{result.title ? (
+							<a
+								className="ai-tool-call__search-title"
+								href={result.uri}
+								target="_blank"
+								rel="noreferrer"
+							>
+								{result.title}
+							</a>
+						) : (
+							<span className="ai-tool-call__search-title">{result.uri}</span>
+						)}
+						{result.uri && <div className="ai-tool-call__search-uri">{result.uri}</div>}
+						{result.description && (
+							<div className="ai-tool-call__search-desc">{result.description}</div>
+						)}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 };
 
 export function ToolCallLog({ logs }: Props): JSX.Element | null {
@@ -30,6 +97,9 @@ export function ToolCallLog({ logs }: Props): JSX.Element | null {
 							<span className="ai-tool-call__location">{log.locations[0]}</span>
 						)}
 					</summary>
+					{log.status === "running" && isFetchTool(log) && (
+						<div className="ai-tool-call__loading">Searching...</div>
+					)}
 					{log.output &&
 						(() => {
 							const diff = extractDiffFromToolOutput(log.output);
@@ -44,6 +114,11 @@ export function ToolCallLog({ logs }: Props): JSX.Element | null {
 										<DiffPreview diff={diff} />
 									</>
 								);
+							}
+
+							const searchResults = extractSearchResults(log.output);
+							if (searchResults) {
+								return renderSearchResults(searchResults);
 							}
 
 							return (

--- a/client/src/css/components/ai-panel/tool-log.css
+++ b/client/src/css/components/ai-panel/tool-log.css
@@ -55,3 +55,55 @@
 .ai-tool-call__error {
 	color: #c00;
 }
+
+.ai-tool-call__loading {
+	margin: 4px 0 0 0;
+	padding: 4px;
+	border-top: 1px solid #eee;
+	font-size: 12px;
+	color: #555;
+}
+
+.ai-tool-call__search {
+	margin-top: 4px;
+	padding-top: 4px;
+	border-top: 1px solid #eee;
+	font-size: 12px;
+}
+
+.ai-tool-call__search-meta {
+	color: #555;
+	margin-bottom: 4px;
+}
+
+.ai-tool-call__search-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.ai-tool-call__search-item {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.ai-tool-call__search-title {
+	color: #001a66;
+	text-decoration: underline;
+	font-weight: 500;
+}
+
+.ai-tool-call__search-uri {
+	color: #666;
+	font-size: 11px;
+	word-break: break-all;
+}
+
+.ai-tool-call__search-desc {
+	color: #333;
+	white-space: pre-wrap;
+}

--- a/core/src/ai/tools/mod.rs
+++ b/core/src/ai/tools/mod.rs
@@ -1,6 +1,7 @@
 mod console;
 mod filesystem;
 mod r_context;
+mod web_search;
 
 pub use console::{
     fetch_console_logs, get_console_tools, ConsoleLogSummary, GetConsoleLogsRequest,
@@ -13,3 +14,4 @@ pub use r_context::{
     get_r_context_tools, GetInstalledPackagesRequest, GetVariablesRequest, GetWorkingDirRequest,
     RContextTool, VariableInfo,
 };
+pub use web_search::{get_web_search_tools, WebSearchRequest};

--- a/core/src/ai/tools/web_search.rs
+++ b/core/src/ai/tools/web_search.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WebSearchRequest {
+    pub query: String,
+}
+
+/// Tool definitions for AI provider
+pub fn get_web_search_tools() -> Vec<Value> {
+    serde_json::json!([
+        {
+            "name": "web_search",
+            "description": "Search the web for up-to-date information and return source links.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query"
+                    }
+                },
+                "required": ["query"]
+            }
+        }
+    ])
+    .as_array()
+    .expect("get_web_search_tools: json! array literal should always be an array")
+    .clone()
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod protocol;
 pub mod terminal;
 pub mod timeline;
 pub mod tools;
+pub mod web_search;
 
 // Re-export protocol types (for API boundaries)
 pub use edit::*;

--- a/core/src/web_search/cloud_provider.rs
+++ b/core/src/web_search/cloud_provider.rs
@@ -1,0 +1,93 @@
+use std::env;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+use reqwest::Client;
+use serde_json::json;
+
+use super::{WebSearchProvider, WebSearchProviderId, WebSearchResponse};
+
+const WEB_SEARCH_URL_ENV: &str = "REPROD_WEB_SEARCH_URL";
+const WEB_SEARCH_TOKEN_ENV: &str = "REPROD_WEB_SEARCH_TOKEN";
+const MAX_TOKEN_RETRIES: usize = 3;
+
+pub struct CloudWebSearchProvider {
+    endpoint: String,
+    client: Client,
+    token: Option<String>,
+}
+
+impl CloudWebSearchProvider {
+    pub fn new(endpoint: String, token: Option<String>) -> Self {
+        Self {
+            endpoint: normalize_endpoint(endpoint),
+            client: Client::new(),
+            token,
+        }
+    }
+
+    pub fn from_env() -> Result<Option<Arc<Self>>> {
+        let endpoint = match env::var(WEB_SEARCH_URL_ENV) {
+            Ok(value) => value,
+            Err(_) => return Ok(None),
+        };
+        let token = env::var(WEB_SEARCH_TOKEN_ENV).ok();
+        Ok(Some(Arc::new(Self::new(endpoint, token))))
+    }
+
+    fn current_token(&self) -> Option<String> {
+        env::var(WEB_SEARCH_TOKEN_ENV)
+            .ok()
+            .or_else(|| self.token.clone())
+    }
+}
+
+#[async_trait::async_trait]
+impl WebSearchProvider for CloudWebSearchProvider {
+    fn id(&self) -> WebSearchProviderId {
+        WebSearchProviderId("cloud.provider".to_string())
+    }
+
+    async fn search(&self, query: String) -> Result<WebSearchResponse> {
+        for attempt in 1..=MAX_TOKEN_RETRIES {
+            let mut request = self
+                .client
+                .post(&self.endpoint)
+                .json(&json!({ "query": query }));
+
+            if let Some(token) = self.current_token() {
+                request = request.bearer_auth(token);
+            }
+
+            let response = request.send().await.context("Web search request failed")?;
+
+            if response.headers().contains_key("x-expired-token") {
+                if attempt >= MAX_TOKEN_RETRIES {
+                    return Err(anyhow!("Token expired, max retries exceeded"));
+                }
+                continue;
+            }
+
+            let status = response.status();
+            if !status.is_success() {
+                let body = response.text().await.unwrap_or_default();
+                return Err(anyhow!("Web search error ({}): {}", status, body));
+            }
+
+            let body = response
+                .json::<WebSearchResponse>()
+                .await
+                .context("Invalid web search response")?;
+            return Ok(body);
+        }
+
+        Err(anyhow!("Web search failed after retries"))
+    }
+}
+
+fn normalize_endpoint(endpoint: String) -> String {
+    if endpoint.contains("/web_search") {
+        return endpoint;
+    }
+    format!("{}/web_search", endpoint.trim_end_matches('/'))
+}

--- a/core/src/web_search/mod.rs
+++ b/core/src/web_search/mod.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+pub mod cloud_provider;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WebSearchProviderId(pub String);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebSearchResult {
+    pub title: String,
+    pub url: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebSearchResponse {
+    pub results: Vec<WebSearchResult>,
+}
+
+#[async_trait]
+pub trait WebSearchProvider: Send + Sync {
+    fn id(&self) -> WebSearchProviderId;
+    async fn search(&self, query: String) -> Result<WebSearchResponse>;
+}
+
+#[derive(Default)]
+pub struct WebSearchRegistry {
+    providers: HashMap<WebSearchProviderId, Arc<dyn WebSearchProvider>>,
+    active_provider_id: Option<WebSearchProviderId>,
+}
+
+impl WebSearchRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register_provider(&mut self, provider: Arc<dyn WebSearchProvider>) {
+        let id = provider.id();
+        self.providers.insert(id.clone(), provider);
+        if self.active_provider_id.is_none() {
+            self.active_provider_id = Some(id);
+        }
+    }
+
+    pub fn active_provider(&self) -> Option<Arc<dyn WebSearchProvider>> {
+        self.active_provider_id
+            .as_ref()
+            .and_then(|id| self.providers.get(id).cloned())
+    }
+}

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -4,7 +4,7 @@ use crate::projects::ProjectRuntime;
 use reprod_core::{
     ai::{
         self,
-        tools::{get_console_tools, get_filesystem_tools, get_r_context_tools},
+        tools::{get_console_tools, get_filesystem_tools, get_r_context_tools, get_web_search_tools},
     },
     ChatMessage,
 };
@@ -90,6 +90,7 @@ pub(super) async fn handle_ai_message(
         let mut tools = get_filesystem_tools();
         tools.extend(get_r_context_tools());
         tools.extend(get_console_tools());
+        tools.extend(get_web_search_tools());
         let mut responses = Vec::new();
 
         // Mark fetch/inspect/execute phases as running in order as we start tool processing.

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -409,6 +409,8 @@ pub(super) struct ToolLogPayload {
     pub name: String,
     pub status: ToolLogStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub input: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output: Option<Value>,
@@ -435,12 +437,20 @@ pub(super) fn tool_log_from_call(tool_call: &reprod_core::ToolCall) -> ToolLogPa
         id: tool_call.id.clone(),
         name: tool_call.name.clone(),
         status: ToolLogStatus::Running,
+        kind: tool_kind_from_name(&tool_call.name),
         input: Some(tool_call.input.clone()),
         output: None,
         error: None,
         started_at: Some(now_millis()),
         finished_at: None,
     }
+}
+
+fn tool_kind_from_name(name: &str) -> Option<String> {
+    if name == "web_search" {
+        return Some("Fetch".to_string());
+    }
+    None
 }
 
 pub(super) fn now_millis() -> i64 {

--- a/server/src/handlers/tool_handler.rs
+++ b/server/src/handlers/tool_handler.rs
@@ -6,7 +6,7 @@ use reprod_core::{
     edit::{EditOperation, EditTextFileRequest},
     ToolCall,
 };
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::common::{error_response, single_response, AppState, WSResponse};
 
@@ -198,6 +198,41 @@ pub(super) async fn execute_ai_tool_call(
                 .map_err(|e| e.to_string())?;
 
             let output = serde_json::to_value(&logs).map_err(|e| e.to_string())?;
+            Ok(ToolCallOutcome {
+                summary: output.to_string(),
+                output,
+            })
+        }
+        "web_search" => {
+            let request: WebSearchRequest = serde_json::from_value(tool_call.input.clone())
+                .map_err(|e| format!("Invalid request: {}", e))?;
+            let provider = runtime
+                .web_search_registry
+                .lock()
+                .await
+                .active_provider()
+                .ok_or_else(|| "No web search provider available".to_string())?;
+            let response = provider
+                .search(request.query)
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let results = response
+                .results
+                .into_iter()
+                .map(|result| {
+                    json!({
+                        "title": result.title,
+                        "uri": result.url,
+                        "description": result.text,
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            let output = json!({
+                "results": results,
+                "count": results.len(),
+            });
             Ok(ToolCallOutcome {
                 summary: output.to_string(),
                 output,

--- a/server/src/projects.rs
+++ b/server/src/projects.rs
@@ -9,6 +9,7 @@ use reprod_core::{
     plot_history::PlotHistoryEntry,
     plot_history::PlotHistoryManager,
     timeline::JsonTimeline,
+    web_search::{cloud_provider::CloudWebSearchProvider, WebSearchRegistry},
 };
 use reprod_core::{
     project::{
@@ -144,6 +145,7 @@ pub struct ProjectRuntime {
     pub r_executor: Arc<Mutex<RExecutor>>,
     pub plot_history: Arc<Mutex<PlotHistoryManager>>,
     pub acp: Arc<AcpService>,
+    pub web_search_registry: Arc<Mutex<WebSearchRegistry>>,
 }
 
 impl ProjectRuntime {
@@ -192,6 +194,22 @@ impl ProjectRuntime {
         let filesystem_root = descriptor.root_path.clone();
         let (run_events, _) = broadcast::channel(1024);
         let acp = Arc::new(AcpService::new(descriptor.root_path.clone()));
+        let web_search_registry = Arc::new(Mutex::new(WebSearchRegistry::new()));
+        match CloudWebSearchProvider::from_env() {
+            Ok(Some(provider)) => {
+                if let Ok(mut registry) = web_search_registry.try_lock() {
+                    registry.register_provider(provider);
+                } else {
+                    tracing::warn!("Web search registry locked during initialization");
+                }
+            }
+            Ok(None) => {
+                tracing::info!("Web search provider not configured; skipping initialization");
+            }
+            Err(error) => {
+                tracing::warn!("Failed to initialize web search provider: {}", error);
+            }
+        }
         Ok(Self {
             descriptor,
             timeline,
@@ -205,6 +223,7 @@ impl ProjectRuntime {
             r_executor: Arc::new(Mutex::new(r_executor)),
             plot_history,
             acp,
+            web_search_registry,
         })
     }
 }


### PR DESCRIPTION
## Description

Add unified web search tooling across core/provider registry, server tool execution, and UI rendering for fetch results via ACP-style tool logs.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `.husky/pre-push`
- `pnpm run lint`
- `pnpm --filter client build`
- `cargo check --workspace`
- `cargo test --workspace --lib --all-features` (fails: ACP test imports unresolved in `core/src/acp/*`)

## Screenshots (if applicable)

Not provided.

## Related Issues

Closes #298
