### PR TITLE
Default ACP mode on by removing feature flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,6 @@ wt-*/
 
 # Codex
 .codex/
+.shared-skills/
 
 AGENTS.*.md

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,7 +23,6 @@ import { useProjectSession } from "@/hooks/useProjectSession";
 import { useSettingsPersistence } from "@/hooks/useSettingsPersistence";
 import { useSocketConnection } from "@/hooks/useSocketConnection";
 import { setupSocketListeners } from "@/core/init/socketListeners";
-import { ACP_FEATURE_ENABLED } from "@/constants/features";
 import { PermissionRequestManager } from "@/components/agent/PermissionRequestManager";
 import { getAcpAdminClient } from "@/services/acpAdminClient";
 
@@ -41,14 +40,9 @@ function App(): JSX.Element {
 	const setModalOpen = useStore((state) => state.setModalOpen);
 
 	const timelineDialogRef = useRef<TimelineDialogRef | null>(null);
-	const { fetchSettings, providers, activeProvider } = useSettingsStore();
+	const { fetchSettings } = useSettingsStore();
 
-	const activeProviderConfig = providers.find((provider) => provider.name === activeProvider);
-	const isActiveProviderConfigured = Boolean(activeProviderConfig?.isConfigured);
-	const canUseAssistant =
-		activeMode === "external_agent"
-			? ACP_FEATURE_ENABLED && Boolean(activeAgent)
-			: isActiveProviderConfigured || ACP_FEATURE_ENABLED;
+	const canUseAssistant = activeMode === "external_agent" ? Boolean(activeAgent) : true;
 
 	// Enable global keyboard shortcuts
 	useKeyboardShortcuts();
@@ -75,7 +69,6 @@ function App(): JSX.Element {
 	}, [fetchSettings]);
 
 	useEffect(() => {
-		if (!ACP_FEATURE_ENABLED) return;
 		const bootstrap = async () => {
 			try {
 				const acpAdminClient = getAcpAdminClient();

--- a/client/src/components/agent/ExternalAgentSettingsPane.tsx
+++ b/client/src/components/agent/ExternalAgentSettingsPane.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo } from "react";
-import { ACP_FEATURE_ENABLED } from "@/constants/features";
 import { useStore } from "@/core";
 import { useAsyncState } from "@/hooks/useAsyncState";
 import { getAcpAdminClient } from "@/services/acpAdminClient";
@@ -12,7 +11,6 @@ export function ExternalAgentSettingsPane(): JSX.Element {
 	const setActiveMode = useStore((state) => state.setActiveMode);
 	const setActiveAgent = useStore((state) => state.setActiveAgent);
 	const setDetectedAgents = useStore((state) => state.setDetectedAgents);
-	const enabled = ACP_FEATURE_ENABLED;
 	const isWindows = typeof navigator !== "undefined" && navigator.userAgent.includes("Windows");
 	const acpAdminClient = useMemo(() => getAcpAdminClient(), []);
 
@@ -22,26 +20,22 @@ export function ExternalAgentSettingsPane(): JSX.Element {
 	);
 
 	const fetchAgentsAsync = useCallback(async () => {
-		if (!enabled) return null;
 		const { config, agents } = await acpAdminClient.bootstrap();
 		setDetectedAgents(agents);
 		setActiveMode((config.active_mode as "api" | "external_agent") ?? "api");
 		setActiveAgent(config.active_agent);
 		return null;
-	}, [acpAdminClient, enabled, setDetectedAgents, setActiveMode, setActiveAgent]);
+	}, [acpAdminClient, setDetectedAgents, setActiveMode, setActiveAgent]);
 
 	const { loading, execute: fetchAgents } = useAsyncState(fetchAgentsAsync, {
 		onError: (error) => console.error("Failed to load ACP agents/config", error),
 	});
 
 	useEffect(() => {
-		if (enabled) {
-			void fetchAgents();
-		}
-	}, [enabled, fetchAgents]);
+		void fetchAgents();
+	}, [fetchAgents]);
 
 	const persistConfig = async (mode: "api" | "external_agent", agent: string | null) => {
-		if (!enabled) return;
 		await acpAdminClient.setConfig(mode, agent);
 	};
 
@@ -87,12 +81,8 @@ export function ExternalAgentSettingsPane(): JSX.Element {
 							name="agent-mode"
 							checked={activeMode === "external_agent"}
 							onChange={() => handleModeChange("external_agent")}
-							disabled={!ACP_FEATURE_ENABLED}
 						/>
 						External agent (ACP)
-						{!ACP_FEATURE_ENABLED && (
-							<small className="hint">Enable ACP feature flag to activate.</small>
-						)}
 					</label>
 				</div>
 			</div>

--- a/client/src/components/agent/PermissionRequestManager.tsx
+++ b/client/src/components/agent/PermissionRequestManager.tsx
@@ -1,7 +1,6 @@
 import type { CSSProperties } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { AcpPermissionOption, AcpPermissionRequestPayload } from "@/types/generated";
-import { ACP_FEATURE_ENABLED } from "@/constants/features";
 import { getExternalAgentClient } from "@/services/externalAgentClient";
 
 type DecisionOutcome = "AllowOnce" | "AllowAlways" | "RejectOnce" | "RejectAlways" | "Cancelled";
@@ -12,8 +11,7 @@ export function PermissionRequestManager(): JSX.Element | null {
 	const [remember, setRemember] = useState(false);
 	const allowButtonRef = useRef<HTMLButtonElement | null>(null);
 
-	const enabled = ACP_FEATURE_ENABLED;
-	const externalAgentClient = enabled ? getExternalAgentClient() : null;
+	const externalAgentClient = getExternalAgentClient();
 	const pending = queue[0] ?? null;
 
 	useEffect(() => {
@@ -146,7 +144,7 @@ export function PermissionRequestManager(): JSX.Element | null {
 		allowButtonRef.current?.focus();
 	}, [pending]);
 
-	if (!enabled || !pending || !hasOptions) return null;
+	if (!pending || !hasOptions) return null;
 
 	const overlayStyle: CSSProperties = {
 		position: "fixed",

--- a/client/src/components/agent/__tests__/ExternalAgentSettingsPane.test.tsx
+++ b/client/src/components/agent/__tests__/ExternalAgentSettingsPane.test.tsx
@@ -3,11 +3,6 @@ import { fireEvent, render, waitFor } from "@testing-library/react";
 import { ExternalAgentSettingsPane } from "../ExternalAgentSettingsPane";
 import { useStore } from "@/core";
 
-vi.mock("@/constants/features", () => ({
-	ACP_FEATURE_ENABLED: true,
-	IS_TAURI: false,
-}));
-
 const bootstrapMock = vi.fn();
 const setConfigMock = vi.fn();
 

--- a/client/src/components/agent/__tests__/PermissionRequestManager.test.tsx
+++ b/client/src/components/agent/__tests__/PermissionRequestManager.test.tsx
@@ -2,10 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { PermissionRequestManager } from "../PermissionRequestManager";
 
-vi.mock("@/constants/features", () => ({
-	ACP_FEATURE_ENABLED: true,
-}));
-
 const decidePermissionMock = vi.fn();
 let permissionListener: ((payload: any) => void) | null = null;
 

--- a/client/src/config/env.ts
+++ b/client/src/config/env.ts
@@ -1,3 +1,3 @@
 export const env = {
-	enableAcp: import.meta.env.VITE_ENABLE_ACP === "true",
+	enableAcp: true,
 };

--- a/client/src/config/env.ts
+++ b/client/src/config/env.ts
@@ -1,3 +1,0 @@
-export const env = {
-	enableAcp: true,
-};

--- a/client/src/constants/features.ts
+++ b/client/src/constants/features.ts
@@ -1,5 +1,3 @@
-import { env } from "@/config/env";
-
 const detectTauri = (): boolean => {
 	if (typeof window === "undefined") return false;
 	const win = window as typeof window & {
@@ -11,4 +9,3 @@ const detectTauri = (): boolean => {
 };
 
 export const IS_TAURI = detectTauri();
-export const ACP_FEATURE_ENABLED = env.enableAcp;

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ACP_FEATURE_ENABLED } from "@/constants/features";
 import { useStore } from "@/core";
 import { buildPromptWithContext, createRequestId } from "@/core/ai/promptUtils";
 import { getAcpSystemPrompts } from "@/core/ai/systemPrompts";
@@ -76,8 +75,7 @@ export function useAIConversation() {
 	});
 	const acpSessionIdRef = useRef<string | null>(null);
 	const acpStreamsRef = useRef<Map<string, string>>(new Map());
-	const acpConfigured =
-		ACP_FEATURE_ENABLED && activeMode === "external_agent" && Boolean(activeAgent);
+	const acpConfigured = activeMode === "external_agent" && Boolean(activeAgent);
 	const externalAgentClient = acpConfigured ? getExternalAgentClient() : null;
 
 	const postAssistantMessage = useCallback(

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"prepare": "husky",
 		"dev": "concurrently \"RUST_LOG=info cargo run -p reprod-server\" \"pnpm --filter client dev\"",
 		"dev:client": "pnpm --filter client dev",
-		"dev:tauri:acp": "VITE_ENABLE_ACP=true cargo tauri dev",
+		"dev:tauri:acp": "cargo tauri dev",
 		"build": "pnpm -r build",
 		"build:client": "pnpm --filter client build",
 		"lint": "pnpm -r --if-present lint",


### PR DESCRIPTION
## Description

Remove the ACP feature flag and default ACP to always-on behavior in the client, cleaning up gating code and related tests.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `.husky/pre-push`

## Screenshots (if applicable)

Not provided.

## Related Issues

Closes #310
