### PR TITLE
refactor(desktop): migrate ACP event listeners to async/await

### DIFF
--- a/client/src/services/externalAgentClient.ts
+++ b/client/src/services/externalAgentClient.ts
@@ -38,24 +38,26 @@ class DesktopAcpClient implements ExternalAgentClient {
 		let disposed = false;
 		let unlisten: ExternalAgentUnsubscribe | null = null;
 
-		void import("@tauri-apps/api/event")
-			.then(({ listen }) =>
-				listen<AcpSessionUpdateEnvelope>("acp://session-update", (event) => {
+		(async () => {
+			try {
+				const tauriEvent = await import("@tauri-apps/api/event");
+				const listen: typeof tauriEvent.listen = tauriEvent.listen;
+
+				const dispose = await listen<AcpSessionUpdateEnvelope>("acp://session-update", (event) => {
 					if (!event.payload) return;
 					cb(event.payload);
-				}),
-			)
-			.then((dispose) => {
+				});
+
 				if (disposed) {
 					dispose();
 					return;
 				}
-				unlisten = dispose;
-			})
-			.catch((error) => {
-				console.error("Failed to bind ACP session update listener", error);
-			});
 
+				unlisten = dispose;
+			} catch (error) {
+				console.error("Failed to bind ACP session update listener", error);
+			}
+		})();
 		return () => {
 			disposed = true;
 			if (unlisten) {
@@ -70,24 +72,29 @@ class DesktopAcpClient implements ExternalAgentClient {
 		let disposed = false;
 		let unlisten: ExternalAgentUnsubscribe | null = null;
 
-		void import("@tauri-apps/api/event")
-			.then(({ listen }) =>
-				listen<AcpPermissionRequestPayload>("acp://permission-request", (event) => {
-					if (!event.payload) return;
-					cb(event.payload);
-				}),
-			)
-			.then((dispose) => {
+		(async () => {
+			try {
+				const tauriEvent = await import("@tauri-apps/api/event");
+				const listen: typeof tauriEvent.listen = tauriEvent.listen;
+
+				const dispose = await listen<AcpPermissionRequestPayload>(
+					"acp://permission-request",
+					(event) => {
+						if (!event.payload) return;
+						cb(event.payload);
+					},
+				);
+
 				if (disposed) {
 					dispose();
 					return;
 				}
-				unlisten = dispose;
-			})
-			.catch((error) => {
-				console.error("Failed to bind ACP permission listener", error);
-			});
 
+				unlisten = dispose;
+			} catch (error) {
+				console.error("Failed to bind ACP permission listener", error);
+			}
+		})();
 		return () => {
 			disposed = true;
 			if (unlisten) {

--- a/desktop/src/acp/commands.rs
+++ b/desktop/src/acp/commands.rs
@@ -1,20 +1,19 @@
 use std::{path::PathBuf, sync::Arc};
 
+use crate::acp::runtime::DesktopAcpRuntime;
 use crate::acp::types::{
     AcpAgentConfig, AcpCancelRequest, AcpDetectedAgent, AcpInitializeResponse,
     AcpPermissionDecision, AcpPromptRequest,
 };
-use crate::acp::runtime::DesktopAcpRuntime;
 use crate::acp::{build_process_config, AcpManager};
 use reprod_core::acp::config::{
-    load_acp_config, normalize_active_mode, save_acp_config, ACP_MODE_API,
-    ACP_MODE_EXTERNAL_AGENT,
+    load_acp_config, normalize_active_mode, save_acp_config, ACP_MODE_API, ACP_MODE_EXTERNAL_AGENT,
 };
 use reprod_core::acp::detection::{detect_agents, resolve_active_agent_command};
 use reprod_core::acp::AcpRuntime;
 use tauri::{AppHandle, State};
-use tracing::info;
 use tokio::sync::Mutex;
+use tracing::info;
 
 pub type SharedAcpManager = Arc<Mutex<AcpManager>>;
 pub type AcpState<'a> = State<'a, SharedAcpManager>;
@@ -64,7 +63,10 @@ pub async fn acp_initialize(
 #[tauri::command]
 pub async fn acp_create_session(state: AcpState<'_>) -> Result<String, String> {
     let runtime = DesktopAcpRuntime::new(state.inner().clone());
-    runtime.create_session().await.map_err(|err| err.to_string())
+    runtime
+        .create_session()
+        .await
+        .map_err(|err| err.to_string())
 }
 
 #[tauri::command]

--- a/desktop/src/acp/mod.rs
+++ b/desktop/src/acp/mod.rs
@@ -14,8 +14,8 @@ use reprod_core::acp::{
     AcpGateway, ProcessConfig,
 };
 use tauri::{AppHandle, Emitter};
-use tracing::{info, warn};
 use tokio::sync::broadcast;
+use tracing::{info, warn};
 
 struct Forwarders {
     updates: tauri::async_runtime::JoinHandle<()>,
@@ -78,9 +78,7 @@ impl AcpManager {
         self.gateway.send_prompt(session_id, messages).await
     }
 
-    pub fn subscribe_session_updates(
-        &self,
-    ) -> broadcast::Receiver<AcpSessionUpdateEnvelope> {
+    pub fn subscribe_session_updates(&self) -> broadcast::Receiver<AcpSessionUpdateEnvelope> {
         self.gateway.subscribe_session_updates()
     }
 

--- a/desktop/src/acp/runtime.rs
+++ b/desktop/src/acp/runtime.rs
@@ -3,55 +3,55 @@ use std::sync::Arc;
 use anyhow::Result;
 use reprod_core::acp::runtime::AcpRuntime;
 use reprod_core::acp::types::{
-	AcpPermissionDecision, AcpPermissionRequestPayload, AcpSessionUpdateEnvelope,
+    AcpPermissionDecision, AcpPermissionRequestPayload, AcpSessionUpdateEnvelope,
 };
 use tokio::sync::{broadcast, Mutex};
 
 use crate::acp::AcpManager;
 
 pub struct DesktopAcpRuntime {
-	manager: Arc<Mutex<AcpManager>>,
+    manager: Arc<Mutex<AcpManager>>,
 }
 
 impl DesktopAcpRuntime {
-	pub fn new(manager: Arc<Mutex<AcpManager>>) -> Self {
-		Self { manager }
-	}
+    pub fn new(manager: Arc<Mutex<AcpManager>>) -> Self {
+        Self { manager }
+    }
 }
 
 #[async_trait::async_trait]
 impl AcpRuntime for DesktopAcpRuntime {
-	async fn create_session(&self) -> Result<String> {
-		let mut guard = self.manager.lock().await;
-		guard.create_session().await
-	}
+    async fn create_session(&self) -> Result<String> {
+        let mut guard = self.manager.lock().await;
+        guard.create_session().await
+    }
 
-	async fn send_prompt(&self, session_id: &str, messages: Vec<String>) -> Result<()> {
-		let guard = self.manager.lock().await;
-		guard.send_prompt(session_id, messages).await
-	}
+    async fn send_prompt(&self, session_id: &str, messages: Vec<String>) -> Result<()> {
+        let guard = self.manager.lock().await;
+        guard.send_prompt(session_id, messages).await
+    }
 
-	async fn cancel(&self, session_id: &str) -> Result<()> {
-		let mut guard = self.manager.lock().await;
-		guard.cancel(session_id).await?;
-		guard.remove_session(session_id);
-		Ok(())
-	}
+    async fn cancel(&self, session_id: &str) -> Result<()> {
+        let mut guard = self.manager.lock().await;
+        guard.cancel(session_id).await?;
+        guard.remove_session(session_id);
+        Ok(())
+    }
 
-	async fn respond_permission(&self, decision: AcpPermissionDecision) -> Result<()> {
-		let guard = self.manager.lock().await;
-		guard.respond_permission(decision).await
-	}
+    async fn respond_permission(&self, decision: AcpPermissionDecision) -> Result<()> {
+        let guard = self.manager.lock().await;
+        guard.respond_permission(decision).await
+    }
 
-	async fn subscribe_session_updates(&self) -> broadcast::Receiver<AcpSessionUpdateEnvelope> {
-		let guard = self.manager.lock().await;
-		guard.subscribe_session_updates()
-	}
+    async fn subscribe_session_updates(&self) -> broadcast::Receiver<AcpSessionUpdateEnvelope> {
+        let guard = self.manager.lock().await;
+        guard.subscribe_session_updates()
+    }
 
-	async fn subscribe_permission_requests(
-		&self,
-	) -> broadcast::Receiver<AcpPermissionRequestPayload> {
-		let guard = self.manager.lock().await;
-		guard.subscribe_permission_requests()
-	}
+    async fn subscribe_permission_requests(
+        &self,
+    ) -> broadcast::Receiver<AcpPermissionRequestPayload> {
+        let guard = self.manager.lock().await;
+        guard.subscribe_permission_requests()
+    }
 }

--- a/desktop/src/server_launcher.rs
+++ b/desktop/src/server_launcher.rs
@@ -5,8 +5,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use reqwest::StatusCode;
 use reprod_core::config::{server_binary_override, PORT_ENV};
+use reqwest::StatusCode;
 use thiserror::Error;
 use tokio::time::sleep;
 

--- a/server/src/acp.rs
+++ b/server/src/acp.rs
@@ -189,7 +189,6 @@ async fn resolve_agent_command() -> Result<String> {
         bail!("External agent mode not enabled");
     }
     let detected = detect_agents().await?;
-    resolve_active_agent_command(&cfg, &detected).ok_or_else(|| {
-        anyhow!("Selected ACP agent unavailable or not set for external_agent mode")
-    })
+    resolve_active_agent_command(&cfg, &detected)
+        .ok_or_else(|| anyhow!("Selected ACP agent unavailable or not set for external_agent mode"))
 }

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -4,7 +4,9 @@ use crate::projects::ProjectRuntime;
 use reprod_core::{
     ai::{
         self,
-        tools::{get_console_tools, get_filesystem_tools, get_r_context_tools, get_web_search_tools},
+        tools::{
+            get_console_tools, get_filesystem_tools, get_r_context_tools, get_web_search_tools,
+        },
     },
     ChatMessage,
 };

--- a/server/src/handlers/tool_handler.rs
+++ b/server/src/handlers/tool_handler.rs
@@ -91,10 +91,7 @@ pub(super) async fn execute_ai_tool_call(
             };
             let output = serde_json::to_value(result)
                 .map_err(|e| format!("Failed to serialize edit result: {}", e))?;
-            Ok(ToolCallOutcome {
-                output,
-                summary,
-            })
+            Ok(ToolCallOutcome { output, summary })
         }
         "edit_text_file" => {
             let request: EditTextFileRequest = serde_json::from_value(tool_call.input.clone())
@@ -112,10 +109,7 @@ pub(super) async fn execute_ai_tool_call(
             };
             let output = serde_json::to_value(result)
                 .map_err(|e| format!("Failed to serialize edit result: {}", e))?;
-            Ok(ToolCallOutcome {
-                output,
-                summary,
-            })
+            Ok(ToolCallOutcome { output, summary })
         }
         "list_files" => {
             let request: ListFilesRequest = serde_json::from_value(tool_call.input.clone())

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -182,7 +182,6 @@ pub async fn set_provider(
     config.save().map(|_| StatusCode::OK).map_err(err_500)
 }
 
-
 pub async fn acp_detect_agents() -> Resp<Vec<AcpDetectedAgent>> {
     info!("Detecting ACP agents");
     detect_agents().await.map(Json).map_err(err_500)


### PR DESCRIPTION
## Description

refactor(desktop): migrate ACP event listeners to async/await>

This PR refactors the Desktop ACP event listener setup to use async/await
instead of Promise `.then()` chains.

The change improves readability, error handling, and consistency with modern
TypeScript patterns while preserving existing behavior and cleanup logic.
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist
- [x] Code follows the project's style guidelines
- [x] Tests pass locally
- [ ] New tests added for new features/bug fixes (not applicable)
- [ ] Documentation updated (not required)


### For PRs from `develop` → `main` (REQUIRED):
- [ ] E2E tests ran successfully locally
- [x] All acceptance criteria met
- [ ] Breaking changes documented
- [ ] Version bump prepared


## Testing
- Manually verified ACP session update events are received correctly
- Manually verified ACP permission request events are received correctly
- Confirmed cleanup/unsubscribe logic works as expected


## Related Issues
Not applicable (no UI changes).

Closes #301
