### PR TITLE
feat(ui): migrate AI assistant to flat/inline chat style

### DIFF
--- a/client/src/components/ai-panel/AIPanel.tsx
+++ b/client/src/components/ai-panel/AIPanel.tsx
@@ -147,9 +147,6 @@ export const AIPanel = forwardRef<AIPanelRef, AIPanelProps>(({ hasConfiguredProv
 									/>
 								) : (
 									<div key={message.id} className="message message-user">
-										<div className="message-header">
-											<span className="message-role">You</span>
-										</div>
 										<div className="message-content">{message.content}</div>
 									</div>
 								),

--- a/client/src/components/ai-panel/StreamingMessage.tsx
+++ b/client/src/components/ai-panel/StreamingMessage.tsx
@@ -90,9 +90,11 @@ export function StreamingMessage({ message, onApplyCode }: Props): JSX.Element {
 			className={classNames("message", `message-${message.role}`)}
 			data-streaming={isStreaming ? "true" : "false"}
 		>
-			<div className="message-header">
-				<span className="message-role">{isAssistant ? "AI" : "You"}</span>
-			</div>
+			{isStreaming && (
+				<div className="message-header">
+					<span className="message-role">💡 Thinking</span>
+				</div>
+			)}
 			<div className="message-content message-streaming">
 				{isStreaming && (
 					<div className="message-streaming-indicator">

--- a/client/src/css/components/ai-panel/message.css
+++ b/client/src/css/components/ai-panel/message.css
@@ -149,7 +149,7 @@
 }
 
 .message-content {
-	font-size: 12px;
+	font-size: 13px;
 	line-height: 1.6;
 	display: flex;
 	flex-direction: column;

--- a/client/src/css/components/ai-panel/message.css
+++ b/client/src/css/components/ai-panel/message.css
@@ -94,40 +94,58 @@
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
-	max-width: 92%; /* Increased from 88% */
+	max-width: 100%;
 }
 
 .message-user {
-	align-self: flex-end;
-	background: linear-gradient(180deg, rgba(47, 111, 237, 0.92), rgba(37, 87, 200, 0.92));
-	color: white;
-	padding: 10px 14px;
-	border-radius: 12px 12px 4px 12px;
-	box-shadow: 0 12px 24px rgba(47, 111, 237, 0.28);
-}
-
-.message-assistant {
-	align-self: flex-start;
+	align-self: stretch;
 	background: transparent;
+	border: 1px solid var(--border-medium);
+	border-radius: 8px;
 	padding: 12px 16px;
-	border-radius: 12px 12px 12px 4px;
-	border: 1px solid var(--border-light);
+	margin-bottom: 16px;
+	color: var(--text-primary);
 	box-shadow: none;
 }
 
+.message-assistant {
+	align-self: stretch;
+	background: transparent;
+	padding: 0;
+	border: none;
+	border-radius: 0;
+	box-shadow: none;
+	margin-bottom: 24px;
+}
+
+.message-assistant:not(:last-child)::after {
+	content: "";
+	display: block;
+	height: 1px;
+	background: var(--border-faint);
+	margin-top: 24px;
+}
+
 .message-header {
-	font-size: 11px; /* Reverted from 10px */
+	font-size: 11px;
 	font-weight: 600;
 	color: rgba(255, 255, 255, 0.85);
 	margin-bottom: 4px;
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
-	/* Removed opacity: 0.8; */
+}
+
+.message-user .message-header {
+	display: none;
 }
 
 .message-assistant .message-header {
-	color: var(--text-muted);
-	/* Removed opacity: 0.7; */
+	font-size: 13px;
+	font-weight: 500;
+	color: var(--text-secondary);
+	margin-bottom: 12px;
+	text-transform: none;
+	letter-spacing: normal;
 }
 
 .message-content {

--- a/client/src/css/components/ai-panel/plan-card.css
+++ b/client/src/css/components/ai-panel/plan-card.css
@@ -1,7 +1,8 @@
 .ai-plan-card {
 	margin-top: 12px;
-	border-radius: 12px;
-	border: 1px solid var(--border-medium);
+	border-radius: 8px;
+	border: none;
+	background: var(--bg-secondary);
 	overflow: hidden;
 }
 

--- a/client/src/css/components/ai-panel/tool-log.css
+++ b/client/src/css/components/ai-panel/tool-log.css
@@ -6,10 +6,12 @@
 }
 
 .ai-tool-call {
-	border: 1px solid #ccc;
+	border: none;
+	border-left: 2px solid var(--border-medium);
 	margin: 4px 0;
-	padding: 4px;
+	padding: 4px 8px;
 	font-family: monospace;
+	background: rgba(0, 0, 0, 0.02);
 }
 
 .ai-tool-call__summary {


### PR DESCRIPTION
## Description

Migrate the AI assistant UI from the chat bubble style to a modern flat/inline style.
- Removed chat bubbles; messages now take full width.
- User messages are displayed in a simple bordered box without the "You" label.
- Assistant messages are displayed inline with a "Thinking" indicator only during streaming.
- Added visual separators between message exchanges.
- Improved readability for Markdown content.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

Ran `pnpm type-check` and `pnpm test` in the `client` directory. All tests passed.

## Screenshots (if applicable)

<!-- Add screenshots to demonstrate UI changes -->

## Related Issues

Closes #317
