### PR TITLE
fix: remove eslint-disable-next-line in useTimelineData hook (#305)

### DIFF
--- a/client/src/core/state/slices/timelineSlice.ts
+++ b/client/src/core/state/slices/timelineSlice.ts
@@ -20,6 +20,7 @@ export interface TimelineState {
 
 	// Actions
 	setEvents: (events: ExecutionEventPayload[], total: number, hasMore: boolean) => void;
+	appendEvents: (newEvents: ExecutionEventPayload[], total: number, hasMore: boolean) => void;
 	addEvent: (event: ExecutionEventPayload) => void;
 	setFilters: (filters: TimelineQuery["filters"]) => void;
 	setSort: (sort: "asc" | "desc") => void;
@@ -56,6 +57,23 @@ export const createTimelineSlice: StateCreator<TimelineState> = (set) => ({
 			loading: false,
 			error: null,
 		})),
+
+	appendEvents: (newEvents, total, hasMore) =>
+		set((state) => {
+			// Filter out duplicates by event_id
+			const existingIds = new Set(state.events.map((e) => e.event_id));
+			const uniqueNewEvents = newEvents.filter((e) => !existingIds.has(e.event_id));
+			const mergedEvents = [...state.events, ...uniqueNewEvents];
+
+			return {
+				events: mergedEvents,
+				total,
+				hasMore,
+				offset: mergedEvents.length,
+				loading: false,
+				error: null,
+			};
+		}),
 
 	addEvent: (event) =>
 		set((state) => {

--- a/client/src/hooks/useTimelineData.ts
+++ b/client/src/hooks/useTimelineData.ts
@@ -44,6 +44,7 @@ export function useTimelineData(): UseTimelineDataReturn {
 		limit,
 		offset,
 		setEvents,
+		appendEvents,
 		addEvent,
 		setFilters,
 		setSort,
@@ -61,6 +62,7 @@ export function useTimelineData(): UseTimelineDataReturn {
 		limit: state.limit,
 		offset: state.offset,
 		setEvents: state.setEvents,
+		appendEvents: state.appendEvents,
 		addEvent: state.addEvent,
 		setFilters: state.setFilters,
 		setSort: state.setSort,
@@ -117,16 +119,14 @@ export function useTimelineData(): UseTimelineDataReturn {
 					offset,
 				});
 
-				setEvents([...events, ...response.events], response.total, response.hasMore);
+				appendEvents(response.events, response.total, response.hasMore);
 			} catch (err) {
 				setError(getErrorMessage(err, "Failed to load more events"));
 			}
 		};
 
 		void fetchMoreEvents();
-		// We intentionally omit `events` from deps to avoid infinite fetch loops when new data is set.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [offset, isConnected, filters, sort, limit, setEvents, setLoading, setError]);
+	}, [offset, isConnected, filters, sort, limit, appendEvents, setLoading, setError]);
 
 	useEffect(() => {
 		if (!isConnected) {


### PR DESCRIPTION
## Description

Fixed the React Hook exhaustive-deps warning in `useTimelineData` by introducing a new `appendEvents` function that uses the functional state update pattern. This eliminates the need for the `eslint-disable-next-line` comment while maintaining correct behavior.

## Related Issue

Closes #305

## Changes

### `client/src/core/state/slices/timelineSlice.ts`
- Added `appendEvents` action to `TimelineState` interface
- Implemented `appendEvents` with functional state update pattern that:
  - Uses `set((state) => ...)` to access current events without external closure
  - Filters out duplicate events by `event_id`
  - Merges new events with existing events

### `client/src/hooks/useTimelineData.ts`
- Replaced `setEvents([...events, ...response.events], ...)` with `appendEvents(response.events, ...)`
- Removed the `eslint-disable-next-line react-hooks/exhaustive-deps` comment
- Removed the explanatory comment about the workaround

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality / refactoring

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test` - all 179 tests passing)
- [x] Frontend lint passes (`pnpm lint`)
- [x] Build passes (`pnpm build`)
- [x] No `eslint-disable` comments in modified files

## Testing

- [x] TypeScript compilation passes
- [x] ESLint passes without exhaustive-deps warnings
- [x] All 179 existing tests pass
- [x] Build completes successfully

## Technical Details

The root cause was that `fetchMoreEvents` needed to read current `events` to merge with new events. By adding `appendEvents` that uses `set((state) => ...)`, we can access the current events through the state parameter instead of the closure, eliminating the dependency warning while preventing infinite loops.

```typescript
// Before (required eslint-disable)
setEvents([...events, ...response.events], response.total, response.hasMore);

// After (no eslint-disable needed)
appendEvents(response.events, response.total, response.hasMore);
```