### PR TITLE
feat: implement R version extraction in reproduction bundle export

### DIFF
--- a/client/src/types/generated/EnvironmentSnapshot.ts
+++ b/client/src/types/generated/EnvironmentSnapshot.ts
@@ -3,4 +3,4 @@
 /**
  * Snapshot of the environment used when executing R code.
  */
-export type EnvironmentSnapshot = { r_path: string; working_dir: string; temp_dir: string };
+export type EnvironmentSnapshot = { r_version: string | null, r_path: string, working_dir: string, temp_dir: string, };

--- a/core/src/ai/tools/console.rs
+++ b/core/src/ai/tools/console.rs
@@ -194,6 +194,7 @@ mod tests {
                 execution_time_ms: 123,
             },
             environment: EnvironmentSnapshot {
+                r_version: None,
                 r_path: "Rscript".to_string(),
                 working_dir: "/tmp".to_string(),
                 temp_dir: "/tmp/reprod".to_string(),

--- a/core/src/edit.rs
+++ b/core/src/edit.rs
@@ -120,11 +120,10 @@ impl EditService {
 
         if let Some(expected) = request.expected_sha256.as_ref() {
             if &old_sha256 != expected {
-                let new_text = derive_new_text(&old_text, &request)?;
-                let unified_diff = unified_diff(&request.path, &old_text, &new_text);
-                let new_sha256 = sha256_hex(&new_text);
+                let new_text_snapshot = derive_new_text(&old_text, &request)?;
+                let unified_diff = unified_diff(&request.path, &old_text, &new_text_snapshot);
+                let new_sha256 = sha256_hex(&new_text_snapshot);
                 let old_sha256_snapshot = old_sha256.clone();
-                let new_text_snapshot = new_text.clone();
                 let structured_edits = match request.operation {
                     EditOperation::ApplyEdits => request.edits.clone().unwrap_or_default(),
                     _ => vec![TextEdit {

--- a/core/src/execution_repository.rs
+++ b/core/src/execution_repository.rs
@@ -147,6 +147,7 @@ mod tests {
                 execution_time_ms: 10,
             },
             environment: EnvironmentSnapshot {
+                r_version: None,
                 r_path: "Rscript".into(),
                 working_dir: "/tmp".into(),
                 temp_dir: "/tmp/reprod".into(),

--- a/core/src/executor/execution_utils.rs
+++ b/core/src/executor/execution_utils.rs
@@ -136,6 +136,7 @@ mod tests {
             execution_time_ms: 10,
         };
         let environment = EnvironmentSnapshot {
+            r_version: None,
             r_path: "Rscript".into(),
             working_dir: "/tmp".into(),
             temp_dir: "/tmp".into(),

--- a/core/src/executor/r_executor.rs
+++ b/core/src/executor/r_executor.rs
@@ -23,6 +23,7 @@ use super::{NoopTimeline, TimelineSink};
 pub struct RExecutor {
     pub(crate) temp_dir: PathBuf,
     pub(crate) r_path: String,
+    pub(crate) r_version: Option<String>,
     pub(crate) working_dir: PathBuf,
     pub(crate) timeline: Arc<dyn TimelineSink>,
     pub(crate) command_runner: Arc<dyn CommandRunner>,
@@ -33,9 +34,11 @@ pub struct RExecutor {
 
 impl RExecutor {
     pub fn new(temp_dir: PathBuf, r_path: String) -> Self {
+        let r_version = Self::detect_r_version(&r_path);
         Self {
             temp_dir,
             r_path,
+            r_version,
             working_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             timeline: Arc::new(NoopTimeline),
             command_runner: Arc::new(ProcessCommandRunner::default()),
@@ -43,6 +46,54 @@ impl RExecutor {
             persistent_mode: false,
             record_runs: true,
         }
+    }
+
+    /// Detect R version by running `R --version` and parsing the output.
+    pub(crate) fn detect_r_version(r_path: &str) -> Option<String> {
+        // Try to run R --version (works for both R and Rscript)
+        let output = std::process::Command::new(r_path)
+            .arg("--version")
+            .output()
+            .ok()?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // R version is usually in stdout, but some systems output to stderr
+        let combined = format!("{}{}", stdout, stderr);
+
+        // Parse version from output like "R version 4.3.1 (2023-06-16)" or "Rscript (R) version 4.3.1"
+        Self::parse_r_version(&combined)
+    }
+
+    /// Parse R version from R --version output.
+    pub(crate) fn parse_r_version(output: &str) -> Option<String> {
+        // Look for patterns like "R version 4.3.1" or "version 4.3.1"
+        for line in output.lines() {
+            let line_lower = line.to_lowercase();
+            if line_lower.contains("version") {
+                // Extract version number (e.g., "4.3.1")
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                for (i, part) in parts.iter().enumerate() {
+                    if part.to_lowercase() == "version" {
+                        if let Some(version) = parts.get(i + 1) {
+                            // Clean up the version string (remove parentheses if present)
+                            let clean_version = version.trim_matches(|c| c == '(' || c == ')');
+                            // Validate it looks like a version number
+                            if clean_version
+                                .chars()
+                                .next()
+                                .map(|c| c.is_ascii_digit())
+                                .unwrap_or(false)
+                            {
+                                return Some(clean_version.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
     }
 
     pub fn builder(temp_dir: PathBuf, r_path: String) -> RExecutorBuilder {
@@ -170,10 +221,10 @@ impl RExecutor {
                         let _ = tx.send(chunk.clone());
                     }
                     if is_stdout {
-                        streamed_stdout.push(line.clone());
+                        streamed_stdout.push(line);
                         streamed_chunks.push(chunk);
                     } else {
-                        streamed_stderr.push(line.clone());
+                        streamed_stderr.push(line);
                         streamed_chunks.push(chunk);
                     }
                 },
@@ -281,6 +332,7 @@ if (length(dev.list()) > 0) {
 
     pub fn environment_snapshot(&self) -> EnvironmentSnapshot {
         EnvironmentSnapshot {
+            r_version: self.r_version.clone(),
             r_path: self.r_path.clone(),
             working_dir: self.working_dir.to_string_lossy().into_owned(),
             temp_dir: self.temp_dir.to_string_lossy().into_owned(),

--- a/core/src/executor/r_executor_builder.rs
+++ b/core/src/executor/r_executor_builder.rs
@@ -89,9 +89,12 @@ impl RExecutorBuilder {
             self.command_runner
         };
 
+        let r_version = RExecutor::detect_r_version(&self.r_path);
+
         RExecutor {
             temp_dir: self.temp_dir,
             r_path: self.r_path,
+            r_version,
             working_dir: self.working_dir,
             timeline: self.timeline,
             command_runner,

--- a/core/src/executor/r_executor_tests.rs
+++ b/core/src/executor/r_executor_tests.rs
@@ -200,3 +200,37 @@ async fn streamed_chunks_exclude_internal_noise_lines() {
     assert!(chunks.iter().all(|c| !c.chunk.starts_with("REPROD_")));
     assert!(chunks.iter().any(|c| c.chunk.contains("Hello")));
 }
+
+#[test]
+fn test_parse_r_version_standard_output() {
+    // Standard R --version output
+    let output = "R version 4.3.1 (2023-06-16) -- \"Beagle Scouts\"
+Copyright (C) 2023 The R Foundation for Statistical Computing
+Platform: aarch64-apple-darwin20 (64-bit)";
+
+    let version = RExecutor::parse_r_version(output);
+    assert_eq!(version, Some("4.3.1".to_string()));
+}
+
+#[test]
+fn test_parse_r_version_rscript_output() {
+    // Rscript --version output (can vary by system)
+    let output = "R scripting front-end version 4.2.0 (2022-04-22)";
+
+    let version = RExecutor::parse_r_version(output);
+    assert_eq!(version, Some("4.2.0".to_string()));
+}
+
+#[test]
+fn test_parse_r_version_no_version() {
+    let output = "Some other output without version info";
+    let version = RExecutor::parse_r_version(output);
+    assert_eq!(version, None);
+}
+
+#[test]
+fn test_parse_r_version_empty() {
+    let output = "";
+    let version = RExecutor::parse_r_version(output);
+    assert_eq!(version, None);
+}

--- a/core/src/export/bundle.rs
+++ b/core/src/export/bundle.rs
@@ -37,7 +37,7 @@ impl ReproductionBundle {
         // Extract environment info from first event
         if let Some(first_event) = events.first() {
             metadata.environment = EnvironmentInfo {
-                r_version: None, // TODO: Extract from R execution if available
+                r_version: first_event.environment.r_version.clone(),
                 r_path: first_event.environment.r_path.clone(),
                 platform: Self::get_platform_string(),
                 working_dir: first_event.environment.working_dir.clone(),
@@ -298,6 +298,7 @@ mod tests {
                 execution_time_ms: 42,
             },
             environment: EnvironmentSnapshot {
+                r_version: None,
                 r_path: "Rscript".to_string(),
                 working_dir: "/tmp/test".to_string(),
                 temp_dir: "/tmp/reprod".to_string(),

--- a/core/src/export/rmarkdown.rs
+++ b/core/src/export/rmarkdown.rs
@@ -826,6 +826,7 @@ mod tests {
                 execution_time_ms: 42,
             },
             environment: EnvironmentSnapshot {
+                r_version: None,
                 r_path: "Rscript".to_string(),
                 working_dir: "/tmp/test".to_string(),
                 temp_dir: "/tmp/reprod".to_string(),

--- a/core/src/export/scripts.rs
+++ b/core/src/export/scripts.rs
@@ -351,6 +351,7 @@ mod tests {
                 execution_time_ms: 42,
             },
             environment: EnvironmentSnapshot {
+                r_version: None,
                 r_path: "Rscript".to_string(),
                 working_dir: "/tmp/test".to_string(),
                 temp_dir: "/tmp/reprod".to_string(),

--- a/core/src/export/writer.rs
+++ b/core/src/export/writer.rs
@@ -164,6 +164,7 @@ mod tests {
                 execution_time_ms: 42,
             },
             environment: EnvironmentSnapshot {
+                r_version: None,
                 r_path: "Rscript".to_string(),
                 working_dir: "/tmp/test".to_string(),
                 temp_dir: "/tmp/reprod".to_string(),

--- a/core/src/protocol.rs
+++ b/core/src/protocol.rs
@@ -169,6 +169,7 @@ pub struct ExecutionRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS)]
 #[ts(export, export_to = "../../client/src/types/generated/")]
 pub struct EnvironmentSnapshot {
+    pub r_version: Option<String>,
     pub r_path: String,
     pub working_dir: String,
     pub temp_dir: String,
@@ -370,6 +371,7 @@ mod tests {
                 execution_time_ms: 42,
             },
             environment: EnvironmentSnapshot {
+                r_version: None,
                 r_path: "Rscript".into(),
                 working_dir: "/tmp".into(),
                 temp_dir: "/tmp/reprod".into(),

--- a/core/src/timeline/json.rs
+++ b/core/src/timeline/json.rs
@@ -457,6 +457,7 @@ mod tests {
                 execution_time_ms: 100,
             },
             environment: EnvironmentSnapshot {
+                r_version: None,
                 r_path: "Rscript".into(),
                 working_dir: "/tmp".into(),
                 temp_dir: "/tmp/reprod".into(),

--- a/core/src/timeline/types.rs
+++ b/core/src/timeline/types.rs
@@ -144,6 +144,7 @@ mod tests {
                 execution_time_ms: 10,
             },
             environment: EnvironmentSnapshot {
+                r_version: None,
                 r_path: "Rscript".into(),
                 working_dir: "/tmp".into(),
                 temp_dir: "/tmp/reprod".into(),

--- a/core/tests/export_integration_test.rs
+++ b/core/tests/export_integration_test.rs
@@ -70,6 +70,7 @@ fn create_test_event(
             execution_time_ms: 42,
         },
         environment: EnvironmentSnapshot {
+            r_version: None,
             r_path: "Rscript".to_string(),
             working_dir: "/tmp/test-project".to_string(),
             temp_dir: "/tmp/reprod-test".to_string(),

--- a/core/tests/rmarkdown_integration_test.rs
+++ b/core/tests/rmarkdown_integration_test.rs
@@ -69,6 +69,7 @@ fn create_test_event(
             execution_time_ms: 42,
         },
         environment: EnvironmentSnapshot {
+            r_version: None,
             r_path: "Rscript".to_string(),
             working_dir: "/tmp/test-project".to_string(),
             temp_dir: "/tmp/reprod-test".to_string(),


### PR DESCRIPTION
## Summary

- Add `r_version: Option<String>` to `EnvironmentSnapshot` to capture the R version used during execution
- Implement `detect_r_version()` and `parse_r_version()` methods in `RExecutor` to extract version from R's output
- Update bundle export to use the captured R version from execution events
- Add unit tests for R version parsing logic

## Details

This PR enables reproducibility tracking by recording which R version was used during code execution. When `RExecutor` is created, it runs `R --version` and parses the version number (e.g., "4.3.1") from the output. This version is then included in the `EnvironmentSnapshot` of every execution event and used in reproduction bundle exports.

The implementation handles various output formats:
- Standard R: `R version 4.3.1 (2023-06-16)`
- Rscript: `R scripting front-end version 4.2.0`

## Test plan

- [x] All existing core tests pass (177+ tests)
- [x] New unit tests for `parse_r_version()` cover standard, Rscript, empty, and no-version outputs
- [x] `cargo clippy` passes
- [x] TypeScript bindings are updated

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)