### PR TITLE
Add unified pending edit flow

### DIFF
--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -10,6 +10,8 @@ import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { useEditorCells } from "@/hooks/useEditorCells";
 import { useEditorDecorations } from "@/hooks/useEditorDecorations";
 import { useEditorExecution } from "@/hooks/useEditorExecution";
+import type { AppliedCodeChange } from "@/core/state/slices/editorSlice";
+import { acceptPendingEdit, rejectPendingEdit } from "@/services/pendingEditService";
 import type { CodeBlock, CodeRange } from "@/types";
 import { clamp } from "@/utils/math";
 import type { EditorRef } from "./editorRef";
@@ -28,9 +30,13 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const setEditorRef = useStore((state) => state.setEditorRef);
 	const recordPatchMatchFailure = useStore((state) => state.recordPatchMatchFailure);
 	const recordPatchMatchSuccess = useStore((state) => state.recordPatchMatchSuccess);
+	const pendingEdit = useStore((state) => state.pendingEdits[editor.filepath]);
+	const clearPendingEdit = useStore((state) => state.clearPendingEdit);
+	const updatePendingEditStatus = useStore((state) => state.updatePendingEditStatus);
 	const editorMethodsRef = useRef<EditorRef | null>(null);
 	const monacoEditorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
 	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
+	const pendingEditWarningRef = useRef(false);
 
 	const cells = useEditorCells(editor.content, editor.filepath);
 	const { state, actions } = useEditorExecution({
@@ -46,8 +52,70 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 		executingCellIndex,
 	});
 
+	useEffect(() => {
+		pendingEditWarningRef.current = false;
+	}, [pendingEdit?.id]);
+
+	useEffect(() => {
+		if (!pendingEdit) return;
+		if (editor.content === pendingEdit.newContent) return;
+		setEditorContent(pendingEdit.newContent);
+	}, [editor.content, pendingEdit, setEditorContent]);
+
+	const handlePendingAccept = useCallback(async () => {
+		if (!pendingEdit) return;
+		if (editor.content !== pendingEdit.newContent) {
+			toast.showWarning("Editor content changed since the pending edit was created.");
+			return;
+		}
+		try {
+			await acceptPendingEdit(pendingEdit);
+			updatePendingEditStatus(pendingEdit.filePath, "accepted");
+			clearPendingEdit(pendingEdit.filePath);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Failed to accept pending edit";
+			toast.showError(message);
+		}
+	}, [clearPendingEdit, editor.content, pendingEdit, toast, updatePendingEditStatus]);
+
+	const handlePendingReject = useCallback(async () => {
+		if (!pendingEdit) return;
+		try {
+			await rejectPendingEdit(pendingEdit);
+			setEditorContent(pendingEdit.oldContent);
+			updatePendingEditStatus(pendingEdit.filePath, "rejected");
+			clearPendingEdit(pendingEdit.filePath);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Failed to reject pending edit";
+			toast.showError(message);
+		}
+	}, [clearPendingEdit, pendingEdit, setEditorContent, toast, updatePendingEditStatus]);
+
+	useEffect(() => {
+		if (!pendingEdit) return;
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Enter" && !event.shiftKey && !event.ctrlKey && !event.metaKey) {
+				event.preventDefault();
+				handlePendingAccept();
+				return;
+			}
+			if (event.key === "Escape") {
+				event.preventDefault();
+				handlePendingReject();
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => {
+			window.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [handlePendingAccept, handlePendingReject, pendingEdit]);
+
 	const handleEditorChange = (value: string | undefined): void => {
 		if (value !== undefined) {
+			if (pendingEdit && !pendingEditWarningRef.current) {
+				toast.showWarning("Resolve the pending edit before making additional changes.");
+				pendingEditWarningRef.current = true;
+			}
 			setEditorContent(value);
 		}
 	};
@@ -91,15 +159,15 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 
 	// Apply code changes from AI
 	const applyCodeChange = useCallback(
-		(codeBlock: CodeBlock): void => {
+		async (codeBlock: CodeBlock): Promise<AppliedCodeChange | null> => {
 			const monacoEditor = monacoEditorRef.current;
 			if (!monacoEditor) {
-				return;
+				return null;
 			}
 
 			const model = monacoEditor.getModel();
 			if (!model) {
-				return;
+				return null;
 			}
 
 			const clampLine = (line: number): number => clamp(line, 1, model.getLineCount());
@@ -111,10 +179,19 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 			};
 
 			const editorContent = monacoEditor.getValue();
+			const originalContent = editorContent;
 			const contextAlertMessage =
 				"Unable to locate the suggested context in the current editor. Try running the suggestion again after scrolling the intended section into view.";
 			let contextMatchingFailed = false;
 			let contextAlertPending = false;
+
+			const finalizeChange = (): AppliedCodeChange | null => {
+				const newContent = monacoEditor.getValue();
+				if (newContent === originalContent) {
+					return null;
+				}
+				return { oldContent: originalContent, newContent };
+			};
 
 			const resolveTargetRange = (): CodeRange | undefined => {
 				if (codeBlock.targetRange) {
@@ -286,53 +363,58 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 				case "replace-all": {
 					const structuredApplied = applyStructuredContext();
 					if (structuredApplied) {
-						break;
+						return finalizeChange();
 					}
 
 					const appliedRange = applyRangeChange(codeBlock.code, false);
 					if (appliedRange) {
-						break;
+						return finalizeChange();
 					}
 
-					// Show confirmation dialog asynchronously
 					const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
 					const confirmationMessage = contextMatchingFailed
 						? `Context matching failed, so this action will replace the entire ${target}. Proceed only if you understand the change.`
 						: `This AI suggestion will replace the entire ${target}. Proceed only if you understand the change.`;
-					showConfirm("Confirm Replace All", confirmationMessage).then((confirmed) => {
-						if (confirmed) {
-							monacoEditor.setValue(codeBlock.code);
-							setEditorContent(codeBlock.code);
-						}
-					});
-					break;
+					const confirmed = await showConfirm("Confirm Replace All", confirmationMessage);
+					if (confirmed) {
+						monacoEditor.setValue(codeBlock.code);
+						setEditorContent(codeBlock.code);
+						return finalizeChange();
+					}
+					return null;
 				}
 				case "replace-range": {
 					const structuredApplied = applyStructuredContext();
-					if (!structuredApplied) {
-						const applied = applyRangeChange(codeBlock.code, contextMatchingFailed);
-						if (!applied) {
-							// No explicit context; offer to replace the whole file as a fallback
-							const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
-							showConfirm(
-								"Confirm Replace All",
-								`Could not match the suggested context. Replace the entire ${target} with the suggested code?`,
-							).then((confirmed) => {
-								if (confirmed) {
-									monacoEditor.setValue(codeBlock.code);
-									setEditorContent(codeBlock.code);
-								}
-							});
-						}
+					if (structuredApplied) {
+						return finalizeChange();
 					}
-					break;
+
+					const applied = applyRangeChange(codeBlock.code, contextMatchingFailed);
+					if (applied) {
+						return finalizeChange();
+					}
+
+					const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
+					const confirmed = await showConfirm(
+						"Confirm Replace All",
+						`Could not match the suggested context. Replace the entire ${target} with the suggested code?`,
+					);
+					if (confirmed) {
+						monacoEditor.setValue(codeBlock.code);
+						setEditorContent(codeBlock.code);
+						return finalizeChange();
+					}
+					return null;
 				}
 				case "delete-range": {
 					const structuredApplied = applyStructuredContext();
 					if (!structuredApplied) {
-						applyRangeChange("", contextMatchingFailed);
+						const applied = applyRangeChange("", contextMatchingFailed);
+						if (!applied) {
+							return null;
+						}
 					}
-					break;
+					return finalizeChange();
 				}
 				case "insert": {
 					const position = monacoEditor.getPosition();
@@ -346,12 +428,14 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 							},
 							codeBlock.code,
 						);
+						return finalizeChange();
 					}
-					break;
+					return null;
 				}
 				case "create-file":
-					break;
+					return null;
 				default:
+					return null;
 			}
 		},
 		[setEditorContent, showConfirm, recordPatchMatchFailure, recordPatchMatchSuccess],
@@ -441,6 +525,21 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 						</button>
 					</div>
 				</div>
+				{pendingEdit && (
+					<div className="pending-edit-toolbar">
+						<div className="pending-edit-info">
+							Pending edit ({pendingEdit.source.type === "acp" ? "ACP" : "API Key"})
+						</div>
+						<div className="pending-edit-actions">
+							<button className="btn btn-primary" onClick={handlePendingAccept} type="button">
+								Accept (Enter)
+							</button>
+							<button className="btn" onClick={handlePendingReject} type="button">
+								Reject (Esc)
+							</button>
+						</div>
+					</div>
+				)}
 				<div className="panel-content">
 					<Editor
 						height="100%"

--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -1,7 +1,15 @@
 import Editor, { type Monaco } from "@monaco-editor/react";
 import type { editor as MonacoEditor } from "monaco-editor";
 import type { ForwardedRef } from "react";
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef } from "react";
+import {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useImperativeHandle,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { ConfirmDialog, IconPlay, IconPlayCircle, useToast } from "@/components/shared";
 import { useStore } from "@/core";
 import { computeTargetRange, findCodeInEditor, matchPatchChunk } from "@/core/ai/contextMatcher";
@@ -14,6 +22,7 @@ import type { AppliedCodeChange } from "@/core/state/slices/editorSlice";
 import { acceptPendingEdit, rejectPendingEdit } from "@/services/pendingEditService";
 import type { CodeBlock, CodeRange } from "@/types";
 import { clamp } from "@/utils/math";
+import { normalizeRelativePath } from "@/core/pathUtils";
 import type { EditorRef } from "./editorRef";
 
 function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Element {
@@ -30,13 +39,21 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const setEditorRef = useStore((state) => state.setEditorRef);
 	const recordPatchMatchFailure = useStore((state) => state.recordPatchMatchFailure);
 	const recordPatchMatchSuccess = useStore((state) => state.recordPatchMatchSuccess);
-	const pendingEdit = useStore((state) => state.pendingEdits[editor.filepath]);
+	const normalizedEditorPath = useMemo(
+		() => normalizeRelativePath(editor.filepath, { keepRootEmpty: true }),
+		[editor.filepath],
+	);
+	const pendingEdit = useStore((state) => state.pendingEdits[normalizedEditorPath]);
 	const clearPendingEdit = useStore((state) => state.clearPendingEdit);
 	const updatePendingEditStatus = useStore((state) => state.updatePendingEditStatus);
 	const editorMethodsRef = useRef<EditorRef | null>(null);
 	const monacoEditorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
 	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
 	const pendingEditWarningRef = useRef(false);
+	const [pendingNotice, setPendingNotice] = useState<{
+		type: "warning" | "error";
+		message: string;
+	} | null>(null);
 
 	const cells = useEditorCells(editor.content, editor.filepath);
 	const { state, actions } = useEditorExecution({
@@ -54,6 +71,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 
 	useEffect(() => {
 		pendingEditWarningRef.current = false;
+		setPendingNotice(null);
 	}, [pendingEdit?.id]);
 
 	useEffect(() => {
@@ -65,18 +83,27 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const handlePendingAccept = useCallback(async () => {
 		if (!pendingEdit) return;
 		if (editor.content !== pendingEdit.newContent) {
-			toast.showWarning("Editor content changed since the pending edit was created.");
+			setPendingNotice({
+				type: "warning",
+				message: "Editor content changed since the pending edit was created.",
+			});
 			return;
 		}
 		try {
 			await acceptPendingEdit(pendingEdit);
 			updatePendingEditStatus(pendingEdit.filePath, "accepted");
 			clearPendingEdit(pendingEdit.filePath);
+			setPendingNotice(null);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to accept pending edit";
-			toast.showError(message);
+			setPendingNotice({
+				type: "error",
+				message: message.includes("Pending edit not found")
+					? "Pending edit is no longer available. Re-run the change or reject it."
+					: message,
+			});
 		}
-	}, [clearPendingEdit, editor.content, pendingEdit, toast, updatePendingEditStatus]);
+	}, [clearPendingEdit, editor.content, pendingEdit, updatePendingEditStatus]);
 
 	const handlePendingReject = useCallback(async () => {
 		if (!pendingEdit) return;
@@ -85,11 +112,17 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 			setEditorContent(pendingEdit.oldContent);
 			updatePendingEditStatus(pendingEdit.filePath, "rejected");
 			clearPendingEdit(pendingEdit.filePath);
+			setPendingNotice(null);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Failed to reject pending edit";
-			toast.showError(message);
+			setPendingNotice({
+				type: "error",
+				message: message.includes("Pending edit not found")
+					? "Pending edit is no longer available. The buffer may already be resolved."
+					: message,
+			});
 		}
-	}, [clearPendingEdit, pendingEdit, setEditorContent, toast, updatePendingEditStatus]);
+	}, [clearPendingEdit, pendingEdit, setEditorContent, updatePendingEditStatus]);
 
 	useEffect(() => {
 		if (!pendingEdit) return;
@@ -113,7 +146,12 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const handleEditorChange = (value: string | undefined): void => {
 		if (value !== undefined) {
 			if (pendingEdit && !pendingEditWarningRef.current) {
-				toast.showWarning("Resolve the pending edit before making additional changes.");
+				if (!pendingNotice || pendingNotice.type !== "error") {
+					setPendingNotice({
+						type: "warning",
+						message: "Resolve the pending edit before making additional changes.",
+					});
+				}
 				pendingEditWarningRef.current = true;
 			}
 			setEditorContent(value);
@@ -530,6 +568,11 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 						<div className="pending-edit-info">
 							Pending edit ({pendingEdit.source.type === "acp" ? "ACP" : "API Key"})
 						</div>
+						{pendingNotice && (
+							<div className={`pending-edit-message ${pendingNotice.type}`}>
+								{pendingNotice.message}
+							</div>
+						)}
 						<div className="pending-edit-actions">
 							<button className="btn btn-primary" onClick={handlePendingAccept} type="button">
 								Accept (Enter)

--- a/client/src/core/ai/actions/ICodeAction.ts
+++ b/client/src/core/ai/actions/ICodeAction.ts
@@ -33,7 +33,9 @@ export interface ICodeAction {
  */
 export interface CodeActionContext {
 	/** Function to apply changes to the current editor */
-	applyToEditor?: (codeBlock: CodeBlock) => Promise<void>;
+	applyToEditor?: (
+		codeBlock: CodeBlock,
+	) => Promise<{ oldContent: string; newContent: string } | null>;
 
 	/** Function to apply changes to remote files */
 	applyToFile?: (codeBlock: CodeBlock) => Promise<void>;

--- a/client/src/core/state/slices/__tests__/pendingEditSlice.test.ts
+++ b/client/src/core/state/slices/__tests__/pendingEditSlice.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createStore } from "zustand/vanilla";
+import {
+	createPendingEditSlice,
+	type PendingEditState,
+} from "@/core/state/slices/pendingEditSlice";
+import type { PendingEdit } from "@/types/pendingEdit";
+
+const makeEdit = (filePath: string): PendingEdit => ({
+	id: "edit-1",
+	source: { type: "acp", sessionId: "s-1" },
+	filePath,
+	oldContent: "old",
+	newContent: "new",
+	unifiedDiff: "",
+	baseHash: "",
+	expectedSha: null,
+	status: "pending",
+	createdAt: 0,
+});
+
+function createTestStore() {
+	return createStore<PendingEditState>()((...args) => createPendingEditSlice(...args));
+}
+
+describe("pendingEditSlice", () => {
+	it("normalizes file paths on register", () => {
+		const store = createTestStore();
+		const edit = makeEdit("/foo//bar.R");
+
+		const registered = store.getState().registerPendingEdit(edit);
+		expect(registered).toBe(true);
+		expect(store.getState().pendingEdits["foo/bar.R"]).toBeTruthy();
+		expect(store.getState().pendingEdits["foo/bar.R"]?.filePath).toBe("foo/bar.R");
+	});
+
+	it("normalizes file paths on update and clear", () => {
+		const store = createTestStore();
+		const edit = makeEdit("foo/bar.R");
+
+		store.getState().registerPendingEdit(edit);
+		store.getState().updatePendingEditStatus("/foo/bar.R", "accepted");
+		expect(store.getState().pendingEdits["foo/bar.R"]?.status).toBe("accepted");
+
+		store.getState().clearPendingEdit("/foo/bar.R");
+		expect(store.getState().pendingEdits["foo/bar.R"]).toBeUndefined();
+	});
+});

--- a/client/src/core/state/slices/editorSlice.ts
+++ b/client/src/core/state/slices/editorSlice.ts
@@ -3,6 +3,11 @@ import type { StateCreator } from "zustand";
 import type { EditorRef } from "@/components/editor/editorRef";
 import type { CodeBlock } from "@/types";
 
+export interface AppliedCodeChange {
+	oldContent: string;
+	newContent: string;
+}
+
 export const DEFAULT_R_SCRIPT = `# Welcome to Re-prod ----
 # AI-Powered R Analysis IDE
 # Try Cmd/Ctrl+Enter to run current section
@@ -21,7 +26,7 @@ export interface EditorState {
 		};
 	};
 	monacoEditor: any | null;
-	applyCodeChange: ((codeBlock: CodeBlock) => void) | null;
+	applyCodeChange: ((codeBlock: CodeBlock) => Promise<AppliedCodeChange | null>) | null;
 	runCurrentCell: (() => void) | null;
 	runAll: (() => void) | null;
 	editorRef: RefObject<EditorRef> | null;
@@ -30,7 +35,9 @@ export interface EditorState {
 	setEditorCursorPosition: (position: { line: number; column: number }) => void;
 	setEditorIsDirty: (isDirty: boolean) => void;
 	setMonacoEditor: (editor: any) => void;
-	setApplyCodeChange: (handler: (codeBlock: CodeBlock) => void) => void;
+	setApplyCodeChange: (
+		handler: (codeBlock: CodeBlock) => Promise<AppliedCodeChange | null>,
+	) => void;
 	setRunCurrentCell: (handler: () => void) => void;
 	setRunAll: (handler: () => void) => void;
 	setEditorRef: (editorRef: RefObject<EditorRef> | null) => void;

--- a/client/src/core/state/slices/pendingEditSlice.ts
+++ b/client/src/core/state/slices/pendingEditSlice.ts
@@ -1,0 +1,47 @@
+import type { StateCreator } from "zustand";
+import type { PendingEdit, PendingEditStatus } from "@/types/pendingEdit";
+
+export interface PendingEditState {
+	pendingEdits: Record<string, PendingEdit>;
+	registerPendingEdit: (edit: PendingEdit) => boolean;
+	updatePendingEditStatus: (filePath: string, status: PendingEditStatus) => void;
+	clearPendingEdit: (filePath: string) => void;
+}
+
+export const createPendingEditSlice: StateCreator<PendingEditState> = (set, get) => ({
+	pendingEdits: {},
+	registerPendingEdit: (edit) => {
+		const { pendingEdits } = get();
+		if (pendingEdits[edit.filePath]) {
+			return false;
+		}
+		set({
+			pendingEdits: {
+				...pendingEdits,
+				[edit.filePath]: edit,
+			},
+		});
+		return true;
+	},
+	updatePendingEditStatus: (filePath, status) =>
+		set((state) => {
+			const existing = state.pendingEdits[filePath];
+			if (!existing) return state;
+			return {
+				pendingEdits: {
+					...state.pendingEdits,
+					[filePath]: {
+						...existing,
+						status,
+					},
+				},
+			};
+		}),
+	clearPendingEdit: (filePath) =>
+		set((state) => {
+			if (!state.pendingEdits[filePath]) return state;
+			const next = { ...state.pendingEdits };
+			delete next[filePath];
+			return { pendingEdits: next };
+		}),
+});

--- a/client/src/core/state/slices/pendingEditSlice.ts
+++ b/client/src/core/state/slices/pendingEditSlice.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from "zustand";
 import type { PendingEdit, PendingEditStatus } from "@/types/pendingEdit";
+import { normalizeRelativePath } from "@/core/pathUtils";
 
 export interface PendingEditState {
 	pendingEdits: Record<string, PendingEdit>;
@@ -12,36 +13,42 @@ export const createPendingEditSlice: StateCreator<PendingEditState> = (set, get)
 	pendingEdits: {},
 	registerPendingEdit: (edit) => {
 		const { pendingEdits } = get();
-		if (pendingEdits[edit.filePath]) {
+		const normalizedPath = normalizeRelativePath(edit.filePath, { keepRootEmpty: true });
+		if (pendingEdits[normalizedPath]) {
 			return false;
 		}
+		const normalizedEdit: PendingEdit = { ...edit, filePath: normalizedPath };
 		set({
 			pendingEdits: {
 				...pendingEdits,
-				[edit.filePath]: edit,
+				[normalizedPath]: normalizedEdit,
 			},
 		});
 		return true;
 	},
-	updatePendingEditStatus: (filePath, status) =>
+	updatePendingEditStatus: (filePath, status) => {
+		const normalizedPath = normalizeRelativePath(filePath, { keepRootEmpty: true });
 		set((state) => {
-			const existing = state.pendingEdits[filePath];
+			const existing = state.pendingEdits[normalizedPath];
 			if (!existing) return state;
 			return {
 				pendingEdits: {
 					...state.pendingEdits,
-					[filePath]: {
+					[normalizedPath]: {
 						...existing,
 						status,
 					},
 				},
 			};
-		}),
-	clearPendingEdit: (filePath) =>
+		});
+	},
+	clearPendingEdit: (filePath) => {
+		const normalizedPath = normalizeRelativePath(filePath, { keepRootEmpty: true });
 		set((state) => {
-			if (!state.pendingEdits[filePath]) return state;
+			if (!state.pendingEdits[normalizedPath]) return state;
 			const next = { ...state.pendingEdits };
-			delete next[filePath];
+			delete next[normalizedPath];
 			return { pendingEdits: next };
-		}),
+		});
+	},
 });

--- a/client/src/core/state/store.ts
+++ b/client/src/core/state/store.ts
@@ -4,6 +4,7 @@ import { type AIState, createAISlice } from "./slices/aiSlice";
 import { type ConnectionState, createConnectionSlice } from "./slices/connectionSlice";
 import { createEditorSlice, type EditorState } from "./slices/editorSlice";
 import { createExecutionSlice, type ExecutionState } from "./slices/executionSlice";
+import { createPendingEditSlice, type PendingEditState } from "./slices/pendingEditSlice";
 import { createPlotHistorySlice, type PlotHistorySlice } from "./slices/plotHistorySlice";
 import { createProjectSlice, type ProjectState } from "./slices/projectSlice";
 import { createSettingsSlice, type SettingsState } from "./slices/settingsSlice";
@@ -13,6 +14,7 @@ import { createViewSlice, type ViewState } from "./slices/viewSlice";
 export type StoreState = EditorState &
 	ExecutionState &
 	AIState &
+	PendingEditState &
 	SettingsState &
 	ConnectionState &
 	TimelineState &
@@ -26,6 +28,7 @@ export const useStore = create<StoreState>()(
 			...createEditorSlice(...args),
 			...createExecutionSlice(...args),
 			...createAISlice(...args),
+			...createPendingEditSlice(...args),
 			...createSettingsSlice(...args),
 			...createConnectionSlice(...args),
 			...createTimelineSlice(...args),

--- a/client/src/css/components/editor.css
+++ b/client/src/css/components/editor.css
@@ -37,6 +37,29 @@
 	color: var(--text-primary, #1f1f1f);
 }
 
+.pending-edit-message {
+	flex: 1;
+	min-width: 0;
+	padding: 4px 8px;
+	border-radius: 6px;
+	font-weight: 500;
+	color: #1f1f1f;
+	background: #fff7cc;
+	border: 1px solid #f5d573;
+}
+
+.pending-edit-message.warning {
+	color: #5c3b00;
+	background: #fff5cc;
+	border-color: #f2d07a;
+}
+
+.pending-edit-message.error {
+	color: #6b0f0f;
+	background: #ffe1e1;
+	border-color: #f1a6a6;
+}
+
 .pending-edit-actions {
 	display: flex;
 	gap: 8px;

--- a/client/src/css/components/editor.css
+++ b/client/src/css/components/editor.css
@@ -19,3 +19,25 @@
 .executing-cell-background {
 	background-color: rgba(47, 111, 237, 0.08);
 }
+
+.pending-edit-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 8px 12px;
+	border-top: 1px solid var(--border-color, #e0e0e0);
+	border-bottom: 1px solid var(--border-color, #e0e0e0);
+	background: rgba(255, 196, 0, 0.08);
+	font-size: 12px;
+}
+
+.pending-edit-info {
+	font-weight: 600;
+	color: var(--text-primary, #1f1f1f);
+}
+
+.pending-edit-actions {
+	display: flex;
+	gap: 8px;
+}

--- a/client/src/hooks/useAICodeApplication.ts
+++ b/client/src/hooks/useAICodeApplication.ts
@@ -38,7 +38,7 @@ export function useAICodeApplication(postAssistantMessage: PostAssistantMessage)
 				applyToEditor: applyCodeChange
 					? async (codeBlock: CodeBlock) => {
 							const snapshot = await applyCodeChange(codeBlock);
-							if (!snapshot) return;
+							if (!snapshot) return null;
 
 							const filePath = editorFilepath || "untitled";
 							const baseHash = await sha256Hex(snapshot.oldContent);
@@ -46,7 +46,6 @@ export function useAICodeApplication(postAssistantMessage: PostAssistantMessage)
 								id: crypto.randomUUID(),
 								source: {
 									type: "api-key",
-									messageId: codeBlock.messageId,
 									codeBlockId: codeBlock.id,
 								},
 								filePath,
@@ -64,6 +63,7 @@ export function useAICodeApplication(postAssistantMessage: PostAssistantMessage)
 								setEditorContent(snapshot.oldContent);
 								postAssistantMessage("A pending edit already exists for this file.");
 							}
+							return snapshot;
 						}
 					: undefined,
 				applyToFile: applyCodeChangeFile,

--- a/client/src/hooks/useAICodeApplication.ts
+++ b/client/src/hooks/useAICodeApplication.ts
@@ -2,7 +2,8 @@ import { useCallback } from "react";
 import { useStore } from "@/core";
 import { type CodeActionContext, CodeActionFactory } from "@/core/ai/actions";
 import { applyCodeChangeFile } from "@/services/fileService";
-import type { AIMessage, CodeBlock } from "@/types";
+import type { AIMessage, CodeBlock, PendingEdit } from "@/types";
+import { sha256Hex } from "@/utils/crypto";
 import { getErrorMessage } from "@/utils/error";
 
 type PostAssistantMessage = (content: string, extras?: Partial<AIMessage>) => void;
@@ -10,9 +11,18 @@ type PostAssistantMessage = (content: string, extras?: Partial<AIMessage>) => vo
 export function useAICodeApplication(postAssistantMessage: PostAssistantMessage) {
 	const applyCodeChange = useStore((state) => state.applyCodeChange);
 	const editorFilepath = useStore((state) => state.editor.filepath);
+	const pendingEdit = useStore((state) => state.pendingEdits[editorFilepath]);
+	const registerPendingEdit = useStore((state) => state.registerPendingEdit);
+	const setEditorContent = useStore((state) => state.setEditorContent);
 
 	const handleApplyCode = useCallback(
 		async (codeBlock: CodeBlock): Promise<void> => {
+			const targetFile = codeBlock.filepath ?? editorFilepath;
+			if (editorFilepath && pendingEdit && targetFile === editorFilepath) {
+				postAssistantMessage("Resolve the pending edit before applying new changes.");
+				return;
+			}
+
 			// Validate the action first
 			const validation = CodeActionFactory.validate(codeBlock);
 			if (!validation.valid) {
@@ -27,7 +37,33 @@ export function useAICodeApplication(postAssistantMessage: PostAssistantMessage)
 			const context: CodeActionContext = {
 				applyToEditor: applyCodeChange
 					? async (codeBlock: CodeBlock) => {
-							applyCodeChange(codeBlock);
+							const snapshot = await applyCodeChange(codeBlock);
+							if (!snapshot) return;
+
+							const filePath = editorFilepath || "untitled";
+							const baseHash = await sha256Hex(snapshot.oldContent);
+							const pendingEdit: PendingEdit = {
+								id: crypto.randomUUID(),
+								source: {
+									type: "api-key",
+									messageId: codeBlock.messageId,
+									codeBlockId: codeBlock.id,
+								},
+								filePath,
+								oldContent: snapshot.oldContent,
+								newContent: snapshot.newContent,
+								unifiedDiff: "",
+								baseHash,
+								expectedSha: null,
+								status: "pending",
+								createdAt: Date.now(),
+							};
+
+							const registered = registerPendingEdit(pendingEdit);
+							if (!registered) {
+								setEditorContent(snapshot.oldContent);
+								postAssistantMessage("A pending edit already exists for this file.");
+							}
 						}
 					: undefined,
 				applyToFile: applyCodeChangeFile,
@@ -43,7 +79,14 @@ export function useAICodeApplication(postAssistantMessage: PostAssistantMessage)
 				postAssistantMessage(`Failed to apply code change: ${message}`);
 			}
 		},
-		[applyCodeChange, editorFilepath, postAssistantMessage],
+		[
+			applyCodeChange,
+			editorFilepath,
+			pendingEdit,
+			postAssistantMessage,
+			registerPendingEdit,
+			setEditorContent,
+		],
 	);
 
 	return { handleApplyCode };

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -7,6 +7,7 @@ import { aiMessages } from "@/services/messageBuilders";
 import { socketService } from "@/services/socket";
 import type { AIMessage, AIMode } from "@/types";
 import type { AcpPromptMessage, AcpSessionUpdateEnvelope } from "@/types/generated";
+import type { PendingEdit } from "@/types";
 import { useAICodeApplication } from "./useAICodeApplication";
 import { useAIStreaming } from "./useAIStreaming";
 import { useAITimeout } from "./useAITimeout";
@@ -93,6 +94,8 @@ export function useAIConversation() {
 	);
 
 	const { handleApplyCode } = useAICodeApplication(postAssistantMessage);
+	const registerPendingEdit = useStore((state) => state.registerPendingEdit);
+	const setEditorContent = useStore((state) => state.setEditorContent);
 
 	const clearActiveRequest = useCallback((options: { dispose?: boolean } = {}) => {
 		if (!activeRequestRef.current) {
@@ -170,6 +173,37 @@ export function useAIConversation() {
 
 			// Handle ToolCallUpdate
 			if (typeof update === "object" && update !== null && "ToolCallUpdate" in update) {
+				const toolUpdate = update.ToolCallUpdate;
+				const output = toolUpdate.output;
+				if (
+					output &&
+					typeof output === "object" &&
+					"type" in output &&
+					(output as { type?: unknown }).type === "pending_edit"
+				) {
+					const editPayload = (output as { edit?: any }).edit;
+					if (editPayload && typeof editPayload === "object") {
+						const pendingEdit: PendingEdit = {
+							id: String(editPayload.id ?? ""),
+							source: { type: "acp", sessionId: payload.session_id },
+							filePath: String(editPayload.file_path ?? ""),
+							oldContent: String(editPayload.old_text ?? ""),
+							newContent: String(editPayload.new_text ?? ""),
+							unifiedDiff: String(editPayload.unified_diff ?? ""),
+							baseHash: String(editPayload.base_sha256 ?? ""),
+							expectedSha: editPayload.expected_sha256 ?? null,
+							status: "pending",
+							createdAt: Date.now(),
+						};
+
+						if (pendingEdit.filePath) {
+							const registered = registerPendingEdit(pendingEdit);
+							if (registered && pendingEdit.filePath === editorFilepath) {
+								setEditorContent(pendingEdit.newContent);
+							}
+						}
+					}
+				}
 				recordTool(streamingId, mapToolCallUpdate(update.ToolCallUpdate));
 				return;
 			}
@@ -187,6 +221,9 @@ export function useAIConversation() {
 			mapToolCall,
 			mapToolCallUpdate,
 			recordTool,
+			registerPendingEdit,
+			editorFilepath,
+			setEditorContent,
 			startStreamingMessage,
 			updatePlan,
 		],

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useStore } from "@/core";
 import { buildPromptWithContext, createRequestId } from "@/core/ai/promptUtils";
 import { getAcpSystemPrompts } from "@/core/ai/systemPrompts";
+import { normalizeRelativePath } from "@/core/pathUtils";
 import { getExternalAgentClient } from "@/services/externalAgentClient";
 import { aiMessages } from "@/services/messageBuilders";
 import { socketService } from "@/services/socket";
@@ -183,10 +184,16 @@ export function useAIConversation() {
 				) {
 					const editPayload = (output as { edit?: any }).edit;
 					if (editPayload && typeof editPayload === "object") {
+						const normalizedFilePath = normalizeRelativePath(String(editPayload.file_path ?? ""), {
+							keepRootEmpty: true,
+						});
+						const normalizedEditorPath = normalizeRelativePath(editorFilepath, {
+							keepRootEmpty: true,
+						});
 						const pendingEdit: PendingEdit = {
 							id: String(editPayload.id ?? ""),
 							source: { type: "acp", sessionId: payload.session_id },
-							filePath: String(editPayload.file_path ?? ""),
+							filePath: normalizedFilePath,
 							oldContent: String(editPayload.old_text ?? ""),
 							newContent: String(editPayload.new_text ?? ""),
 							unifiedDiff: String(editPayload.unified_diff ?? ""),
@@ -196,11 +203,9 @@ export function useAIConversation() {
 							createdAt: Date.now(),
 						};
 
-						if (pendingEdit.filePath) {
-							const registered = registerPendingEdit(pendingEdit);
-							if (registered && pendingEdit.filePath === editorFilepath) {
-								setEditorContent(pendingEdit.newContent);
-							}
+						const registered = registerPendingEdit(pendingEdit);
+						if (registered && pendingEdit.filePath === normalizedEditorPath) {
+							setEditorContent(pendingEdit.newContent);
 						}
 					}
 				}

--- a/client/src/services/pendingEditService.ts
+++ b/client/src/services/pendingEditService.ts
@@ -1,0 +1,47 @@
+import { IS_TAURI } from "@/constants/features";
+import { socketService } from "@/services/socket";
+import type { PendingEdit } from "@/types/pendingEdit";
+
+export async function acceptPendingEdit(edit: PendingEdit): Promise<void> {
+	if (edit.source.type !== "acp") {
+		return;
+	}
+
+	if (IS_TAURI) {
+		const { invoke } = await import("@tauri-apps/api/core");
+		await invoke("acp_accept_pending_edit", { editId: edit.id });
+		return;
+	}
+
+	const response = await socketService.request(
+		{ type: "acp_pending_edit_accept", edit_id: edit.id },
+		"acp_pending_edit_resolved",
+		(message) => message.edit_id === edit.id,
+	);
+
+	if (!response.success) {
+		throw new Error(response.error || "Failed to accept pending edit");
+	}
+}
+
+export async function rejectPendingEdit(edit: PendingEdit): Promise<void> {
+	if (edit.source.type !== "acp") {
+		return;
+	}
+
+	if (IS_TAURI) {
+		const { invoke } = await import("@tauri-apps/api/core");
+		await invoke("acp_reject_pending_edit", { editId: edit.id });
+		return;
+	}
+
+	const response = await socketService.request(
+		{ type: "acp_pending_edit_reject", edit_id: edit.id },
+		"acp_pending_edit_resolved",
+		(message) => message.edit_id === edit.id,
+	);
+
+	if (!response.success) {
+		throw new Error(response.error || "Failed to reject pending edit");
+	}
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -7,3 +7,4 @@ export * from "./timeline";
 export * from "./tools";
 export * from "./ui";
 export * from "./ws";
+export * from "./pendingEdit";

--- a/client/src/types/pendingEdit.ts
+++ b/client/src/types/pendingEdit.ts
@@ -1,0 +1,18 @@
+export type PendingEditSource =
+	| { type: "acp"; sessionId: string }
+	| { type: "api-key"; messageId?: string; codeBlockId: string };
+
+export type PendingEditStatus = "pending" | "accepted" | "rejected";
+
+export interface PendingEdit {
+	id: string;
+	source: PendingEditSource;
+	filePath: string;
+	oldContent: string;
+	newContent: string;
+	unifiedDiff: string;
+	baseHash: string;
+	expectedSha?: string | null;
+	status: PendingEditStatus;
+	createdAt: number;
+}

--- a/client/src/types/pendingEdit.ts
+++ b/client/src/types/pendingEdit.ts
@@ -1,6 +1,6 @@
 export type PendingEditSource =
 	| { type: "acp"; sessionId: string }
-	| { type: "api-key"; messageId?: string; codeBlockId: string };
+	| { type: "api-key"; codeBlockId: string };
 
 export type PendingEditStatus = "pending" | "accepted" | "rejected";
 

--- a/client/src/types/ws.ts
+++ b/client/src/types/ws.ts
@@ -142,7 +142,9 @@ export type ClientMessage =
 	| { type: "acp_session_create" }
 	| { type: "acp_session_prompt"; session_id: string; messages: AcpPromptMessage[] }
 	| { type: "acp_session_cancel"; session_id: string }
-	| { type: "acp_permission_decision"; decision: AcpPermissionDecision };
+	| { type: "acp_permission_decision"; decision: AcpPermissionDecision }
+	| { type: "acp_pending_edit_accept"; edit_id: string }
+	| { type: "acp_pending_edit_reject"; edit_id: string };
 
 type TimelineEventPush = Extract<TimelineMessage, { type: "timeline_event_added" }>;
 
@@ -218,6 +220,7 @@ export type ServerMessage =
 	| { type: "run_accepted"; run_id: string }
 	| { type: "run_started"; run: RunSummary }
 	| ({ type: "run_output" } & RunOutputChunk)
+	| { type: "acp_pending_edit_resolved"; edit_id: string; success: boolean; error?: string | null }
 	| { type: "run_finished"; run: RunSummary }
 	| { type: "acp_session_created"; session_id: string }
 	| ({ type: "acp://session-update" } & AcpSessionUpdateEnvelope)

--- a/client/src/utils/crypto.ts
+++ b/client/src/utils/crypto.ts
@@ -1,0 +1,7 @@
+export async function sha256Hex(input: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const data = encoder.encode(input);
+	const hash = await crypto.subtle.digest("SHA-256", data);
+	const bytes = Array.from(new Uint8Array(hash));
+	return bytes.map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/core/src/acp/client.rs
+++ b/core/src/acp/client.rs
@@ -28,6 +28,7 @@ use uuid::Uuid;
 
 use super::{
     connection::map_permission_request,
+    pending_edit::{PendingEdit, PendingEditStore},
     types::{AcpPermissionDecisionScope, AcpPermissionRequestPayload},
 };
 
@@ -48,11 +49,14 @@ pub struct ReprodAcpClient {
     decision_meta: Arc<Mutex<HashMap<String, AcpPermissionDecisionScope>>>,
     session_trust: Arc<Mutex<HashMap<String, TrustDecision>>>,
     read_snapshots: Arc<Mutex<HashMap<String, String>>>,
+    pending_edits: Arc<Mutex<PendingEditStore>>,
 }
 
 impl ReprodAcpClient {
     pub fn new(
         workspace_root: PathBuf,
+        edit_service: Arc<EditService>,
+        pending_edits: Arc<Mutex<PendingEditStore>>,
         session_update_tx: UnboundedSender<SessionNotification>,
         permission_request_tx: UnboundedSender<AcpPermissionRequestPayload>,
         pending_permissions: Arc<Mutex<HashMap<String, oneshot::Sender<RequestPermissionOutcome>>>>,
@@ -62,7 +66,6 @@ impl ReprodAcpClient {
         let trust_store = Arc::new(Mutex::new(
             load_trust_store(&trust_path).unwrap_or_default(),
         ));
-        let edit_service = Arc::new(EditService::new(workspace_root.clone()));
         Self {
             workspace_root,
             edit_service,
@@ -74,6 +77,7 @@ impl ReprodAcpClient {
             decision_meta,
             session_trust: Arc::new(Mutex::new(HashMap::new())),
             read_snapshots: Arc::new(Mutex::new(HashMap::new())),
+            pending_edits,
         }
     }
 
@@ -277,6 +281,34 @@ impl ReprodAcpClient {
         ));
     }
 
+    fn emit_pending_edit_update(&self, session_id: &str, path: &Path, edit: &PendingEdit) {
+        let tool_call_id = ToolCallId::new(format!("fs-pending-{}", edit.id));
+        let location = ToolCallLocation::new(path.to_string_lossy().to_string());
+        let tool_call = ToolCall::new(tool_call_id.clone(), "Pending edit")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::InProgress)
+            .locations(vec![location]);
+        let _ = self.session_update_tx.send(SessionNotification::new(
+            session_id.to_string(),
+            SessionUpdate::ToolCall(tool_call),
+        ));
+
+        let output = serde_json::json!({
+            "type": "pending_edit",
+            "edit": edit,
+        });
+        let update = ToolCallUpdate::new(
+            tool_call_id,
+            ToolCallUpdateFields::new()
+                .status(ToolCallStatus::Completed)
+                .raw_output(output),
+        );
+        let _ = self.session_update_tx.send(SessionNotification::new(
+            session_id.to_string(),
+            SessionUpdate::ToolCallUpdate(update),
+        ));
+    }
+
     fn emit_edit_tool_error(&self, session_id: &str, path: &Path, message: &str) {
         let tool_call_id = ToolCallId::new(format!("fs-edit-{}", Uuid::new_v4()));
         let location = ToolCallLocation::new(path.to_string_lossy().to_string());
@@ -337,11 +369,12 @@ impl Client for ReprodAcpClient {
             .map_err(|err| agent_client_protocol::Error::internal_error().data(err.to_string()))?;
         let relative = workspace_relative_path(&self.workspace_root, &resolved)
             .map_err(|err| agent_client_protocol::Error::internal_error().data(err.to_string()))?;
+        let session_id = args.session_id.to_string();
 
         let expected_sha = match Self::expected_sha_from_meta(&args.meta) {
             Some(value) => Some(value),
             None => {
-                let key = self.snapshot_key(&args.session_id.to_string(), &resolved);
+                let key = self.snapshot_key(&session_id, &resolved);
                 self.read_snapshots.lock().await.get(&key).cloned()
             }
         };
@@ -354,25 +387,60 @@ impl Client for ReprodAcpClient {
             edits: None,
         };
 
-        let result = match self.edit_service.edit_text_file(edit_request).await {
+        let overlay_text = self
+            .pending_edits
+            .lock()
+            .await
+            .overlay_for(&session_id, &relative)
+            .map(|overlay| overlay.text);
+
+        let result = match self
+            .edit_service
+            .preview_text_file(edit_request, overlay_text)
+            .await
+        {
             Ok(result) => result,
             Err(err) => {
-                self.emit_edit_tool_error(
-                    &args.session_id.to_string(),
-                    &resolved,
-                    &err.to_string(),
-                );
+                self.emit_edit_tool_error(&session_id, &resolved, &err.to_string());
                 return Err(agent_client_protocol::Error::into_internal_error(err));
             }
         };
 
-        self.emit_edit_tool_update(&args.session_id.to_string(), &resolved, &result);
-
         if matches!(result.status, EditStatus::Conflict) {
+            self.emit_edit_tool_error(
+                &session_id,
+                &resolved,
+                "Conflict detected: file changed since last read. Reload and retry.",
+            );
             return Err(agent_client_protocol::Error::internal_error()
                 .data("Conflict detected: file changed since last read. Reload and retry."));
         }
 
+        let pending_edit = PendingEdit {
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.clone(),
+            tool_call_id: Uuid::new_v4().to_string(),
+            file_path: relative.clone(),
+            old_text: result.old_text.clone(),
+            new_text: result.new_text.clone(),
+            unified_diff: result.unified_diff.clone(),
+            base_sha256: result.old_sha256.clone(),
+            expected_sha256: expected_sha,
+        };
+
+        let mut store = self.pending_edits.lock().await;
+        if store.has_pending_for_file(&session_id, &relative) {
+            self.emit_edit_tool_error(&session_id, &resolved, "Pending edit already exists.");
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("Pending edit already exists for this file."));
+        }
+        if let Err(err) = store.register_pending_edit(pending_edit.clone(), &result) {
+            self.emit_edit_tool_error(&session_id, &resolved, &err);
+            return Err(agent_client_protocol::Error::internal_error().data(err));
+        }
+        drop(store);
+
+        self.emit_pending_edit_update(&session_id, &resolved, &pending_edit);
         Ok(WriteTextFileResponse::new())
     }
 
@@ -384,18 +452,29 @@ impl Client for ReprodAcpClient {
             .map_err(|err| agent_client_protocol::Error::internal_error().data(err.to_string()))?;
         let relative = workspace_relative_path(&self.workspace_root, &resolved)
             .map_err(|err| agent_client_protocol::Error::internal_error().data(err.to_string()))?;
-        let result = self
-            .edit_service
-            .read_text_file(&relative)
+        let session_id = args.session_id.to_string();
+        let overlay = self
+            .pending_edits
+            .lock()
             .await
-            .map_err(agent_client_protocol::Error::into_internal_error)?;
+            .overlay_for(&session_id, &relative);
 
-        let content = result.text.clone();
-        let snapshot_key = self.snapshot_key(&args.session_id.to_string(), &resolved);
+        let (content, sha256) = if let Some(overlay) = overlay {
+            (overlay.text, overlay.sha256)
+        } else {
+            let result = self
+                .edit_service
+                .read_text_file(&relative)
+                .await
+                .map_err(agent_client_protocol::Error::into_internal_error)?;
+            (result.text, result.sha256)
+        };
+
+        let snapshot_key = self.snapshot_key(&session_id, &resolved);
         self.read_snapshots
             .lock()
             .await
-            .insert(snapshot_key, result.sha256);
+            .insert(snapshot_key, sha256);
 
         let (start_line, limit) = match (args.line, args.limit) {
             (None, None) => return Ok(ReadTextFileResponse::new(content)),
@@ -532,8 +611,10 @@ fn select_timeout_outcome(options: &[PermissionOption]) -> RequestPermissionOutc
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::acp::pending_edit::PendingEditStore;
     use crate::acp::test_support::ENV_LOCK;
     use crate::config::APP_DIR_ENV;
+    use crate::edit::EditService;
     use agent_client_protocol::{
         PermissionOption, PermissionOptionId, PermissionOptionKind, SelectedPermissionOutcome,
         SessionId, ToolCallId, ToolCallUpdate, ToolCallUpdateFields,
@@ -578,8 +659,12 @@ mod tests {
                 let pending = Arc::new(Mutex::new(HashMap::new()));
                 let decision_meta: Arc<Mutex<HashMap<String, AcpPermissionDecisionScope>>> =
                     Arc::new(Mutex::new(HashMap::new()));
+                let edit_service = Arc::new(EditService::new(workspace.clone()));
+                let pending_edits = Arc::new(Mutex::new(PendingEditStore::default()));
                 let client = ReprodAcpClient::new(
                     workspace,
+                    edit_service,
+                    pending_edits,
                     session_tx,
                     permission_tx,
                     pending.clone(),
@@ -637,8 +722,17 @@ mod tests {
         let pending = Arc::new(Mutex::new(HashMap::new()));
         let decision_meta: Arc<Mutex<HashMap<String, AcpPermissionDecisionScope>>> =
             Arc::new(Mutex::new(HashMap::new()));
-        let client =
-            ReprodAcpClient::new(workspace, session_tx, permission_tx, pending, decision_meta);
+        let edit_service = Arc::new(EditService::new(workspace.clone()));
+        let pending_edits = Arc::new(Mutex::new(PendingEditStore::default()));
+        let client = ReprodAcpClient::new(
+            workspace,
+            edit_service,
+            pending_edits,
+            session_tx,
+            permission_tx,
+            pending,
+            decision_meta,
+        );
 
         let req = RequestPermissionRequest::new(
             SessionId::new("s-test"),
@@ -694,8 +788,12 @@ mod tests {
         let pending = Arc::new(Mutex::new(HashMap::new()));
         let decision_meta: Arc<Mutex<HashMap<String, AcpPermissionDecisionScope>>> =
             Arc::new(Mutex::new(HashMap::new()));
+        let edit_service = Arc::new(EditService::new(workspace.clone()));
+        let pending_edits = Arc::new(Mutex::new(PendingEditStore::default()));
         let client = ReprodAcpClient::new(
             workspace.clone(),
+            edit_service,
+            pending_edits,
             session_tx,
             permission_tx,
             pending.clone(),

--- a/core/src/acp/client.rs
+++ b/core/src/acp/client.rs
@@ -382,7 +382,7 @@ impl Client for ReprodAcpClient {
         let edit_request = EditTextFileRequest {
             path: relative.clone(),
             operation: EditOperation::Replace,
-            expected_sha256: expected_sha,
+            expected_sha256: expected_sha.clone(),
             new_text: Some(args.content.clone()),
             edits: None,
         };

--- a/core/src/acp/client.rs
+++ b/core/src/acp/client.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     config::app_config_dir,
-    edit::{EditOperation, EditService, EditStatus, EditTextFileRequest, EditTextFileResult},
+    edit::{EditOperation, EditService, EditStatus, EditTextFileRequest},
 };
 use agent_client_protocol::{
     Client, PermissionOption, PermissionOptionKind, ReadTextFileRequest, ReadTextFileResponse,
@@ -253,32 +253,6 @@ impl ReprodAcpClient {
 
         let _ = self.pending_permissions.lock().await.remove(&request_id);
         outcome
-    }
-
-    fn emit_edit_tool_update(&self, session_id: &str, path: &Path, result: &EditTextFileResult) {
-        let tool_call_id = ToolCallId::new(format!("fs-edit-{}", Uuid::new_v4()));
-        let location = ToolCallLocation::new(path.to_string_lossy().to_string());
-        let tool_call = ToolCall::new(tool_call_id.clone(), "Edit file")
-            .kind(ToolKind::Edit)
-            .status(ToolCallStatus::InProgress)
-            .locations(vec![location]);
-        let _ = self.session_update_tx.send(SessionNotification::new(
-            session_id.to_string(),
-            SessionUpdate::ToolCall(tool_call),
-        ));
-
-        let output = serde_json::to_value(result)
-            .unwrap_or(Value::String("Failed to serialize edit result".to_string()));
-        let update = ToolCallUpdate::new(
-            tool_call_id,
-            ToolCallUpdateFields::new()
-                .status(ToolCallStatus::Completed)
-                .raw_output(output),
-        );
-        let _ = self.session_update_tx.send(SessionNotification::new(
-            session_id.to_string(),
-            SessionUpdate::ToolCallUpdate(update),
-        ));
     }
 
     fn emit_pending_edit_update(&self, session_id: &str, path: &Path, edit: &PendingEdit) {
@@ -872,4 +846,48 @@ mod tests {
         let canon_root = dunce::canonicalize(&workspace).unwrap();
         assert!(resolved.starts_with(&canon_root));
     }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn write_text_file_creates_pending_overlay_and_blocks_second() {
+    let workspace = std::env::temp_dir().join(format!("acp-pending-{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&workspace).unwrap();
+    let file_path = workspace.join("sample.R");
+    std::fs::write(&file_path, "old").unwrap();
+
+    let (session_tx, _session_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (permission_tx, _permission_rx) = tokio::sync::mpsc::unbounded_channel();
+    let pending = Arc::new(Mutex::new(HashMap::new()));
+    let decision_meta: Arc<Mutex<HashMap<String, AcpPermissionDecisionScope>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    let edit_service = Arc::new(EditService::new(workspace.clone()));
+    let pending_edits = Arc::new(Mutex::new(PendingEditStore::default()));
+    let client = ReprodAcpClient::new(
+        workspace,
+        edit_service,
+        pending_edits,
+        session_tx,
+        permission_tx,
+        pending,
+        decision_meta,
+    );
+
+    let session_id = "s-pending";
+    let read_req = ReadTextFileRequest::new(session_id, file_path.clone());
+    let read_resp = client.read_text_file(read_req).await.unwrap();
+    assert_eq!(read_resp.content, "old");
+
+    let write_req = WriteTextFileRequest::new(session_id, file_path.clone(), "new-content");
+    client.write_text_file(write_req).await.unwrap();
+
+    let disk_contents = std::fs::read_to_string(&file_path).unwrap();
+    assert_eq!(disk_contents, "old");
+
+    let read_req = ReadTextFileRequest::new(session_id, file_path.clone());
+    let read_resp = client.read_text_file(read_req).await.unwrap();
+    assert_eq!(read_resp.content, "new-content");
+
+    let write_req = WriteTextFileRequest::new(session_id, file_path.clone(), "another");
+    let second = client.write_text_file(write_req).await;
+    assert!(second.is_err());
 }

--- a/core/src/acp/connection.rs
+++ b/core/src/acp/connection.rs
@@ -22,11 +22,13 @@ use tracing::{error, info};
 
 use super::{
     client::ReprodAcpClient,
+    pending_edit::PendingEditStore,
     types::{
         AcpPermissionDecision, AcpPermissionDecisionScope, AcpPermissionOption,
         AcpPermissionRequestPayload,
     },
 };
+use crate::edit::EditService;
 
 enum AcpRequest {
     CreateSession {
@@ -59,6 +61,8 @@ pub struct PermissionDecisionMessage {
 impl AcpConnection {
     pub async fn initialize<R, W>(
         workspace_root: std::path::PathBuf,
+        edit_service: Arc<EditService>,
+        pending_edits: Arc<Mutex<PendingEditStore>>,
         outgoing: W,
         incoming: R,
     ) -> Result<(
@@ -82,6 +86,8 @@ impl AcpConnection {
 
         let handler = ReprodAcpClient::new(
             workspace_root,
+            edit_service,
+            pending_edits,
             notif_tx,
             permission_request_tx,
             pending_permissions.clone(),

--- a/core/src/acp/gateway.rs
+++ b/core/src/acp/gateway.rs
@@ -388,6 +388,160 @@ fn stringify_chunk(chunk: &ContentChunk) -> String {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::pending_edit::PendingEdit;
+    use crate::edit::sha256_hex;
+    use tokio::fs;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn accept_pending_edit_persists_and_clears() {
+        let workspace = std::env::temp_dir().join(format!("acp-accept-{}", Uuid::new_v4()));
+        fs::create_dir_all(&workspace).await.unwrap();
+        let file_path = workspace.join("sample.R");
+        fs::write(&file_path, "old").await.unwrap();
+
+        let gateway = AcpGateway::new(workspace.clone());
+        let request = EditTextFileRequest {
+            path: "sample.R".to_string(),
+            operation: EditOperation::Replace,
+            expected_sha256: None,
+            new_text: Some("new".to_string()),
+            edits: None,
+        };
+        let result = gateway
+            .edit_service
+            .preview_text_file(request, None)
+            .await
+            .unwrap();
+
+        let pending = PendingEdit {
+            id: "edit-1".to_string(),
+            session_id: "s1".to_string(),
+            tool_call_id: "tool-1".to_string(),
+            file_path: "sample.R".to_string(),
+            old_text: result.old_text.clone(),
+            new_text: result.new_text.clone(),
+            unified_diff: result.unified_diff.clone(),
+            base_sha256: result.old_sha256.clone(),
+            expected_sha256: None,
+        };
+
+        {
+            let mut store = gateway.pending_edits.lock().await;
+            store
+                .register_pending_edit(pending.clone(), &result)
+                .unwrap();
+        }
+
+        gateway.accept_pending_edit(&pending.id).await.unwrap();
+        let disk_contents = fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(disk_contents, "new");
+
+        let store = gateway.pending_edits.lock().await;
+        assert!(store.get_edit(&pending.id).is_none());
+    }
+
+    #[tokio::test]
+    async fn reject_pending_edit_keeps_disk_unchanged() {
+        let workspace = std::env::temp_dir().join(format!("acp-reject-{}", Uuid::new_v4()));
+        fs::create_dir_all(&workspace).await.unwrap();
+        let file_path = workspace.join("sample.R");
+        fs::write(&file_path, "old").await.unwrap();
+
+        let gateway = AcpGateway::new(workspace.clone());
+        let request = EditTextFileRequest {
+            path: "sample.R".to_string(),
+            operation: EditOperation::Replace,
+            expected_sha256: None,
+            new_text: Some("new".to_string()),
+            edits: None,
+        };
+        let result = gateway
+            .edit_service
+            .preview_text_file(request, None)
+            .await
+            .unwrap();
+
+        let pending = PendingEdit {
+            id: "edit-2".to_string(),
+            session_id: "s2".to_string(),
+            tool_call_id: "tool-2".to_string(),
+            file_path: "sample.R".to_string(),
+            old_text: result.old_text.clone(),
+            new_text: result.new_text.clone(),
+            unified_diff: result.unified_diff.clone(),
+            base_sha256: result.old_sha256.clone(),
+            expected_sha256: None,
+        };
+
+        {
+            let mut store = gateway.pending_edits.lock().await;
+            store
+                .register_pending_edit(pending.clone(), &result)
+                .unwrap();
+        }
+
+        gateway.reject_pending_edit(&pending.id).await.unwrap();
+        let disk_contents = fs::read_to_string(&file_path).await.unwrap();
+        assert_eq!(disk_contents, "old");
+    }
+
+    #[tokio::test]
+    async fn accept_pending_edit_rejects_base_mismatch() {
+        let workspace = std::env::temp_dir().join(format!("acp-mismatch-{}", Uuid::new_v4()));
+        fs::create_dir_all(&workspace).await.unwrap();
+        let file_path = workspace.join("sample.R");
+        fs::write(&file_path, "old").await.unwrap();
+
+        let gateway = AcpGateway::new(workspace.clone());
+        let base_hash = sha256_hex("old");
+        let pending = PendingEdit {
+            id: "edit-3".to_string(),
+            session_id: "s3".to_string(),
+            tool_call_id: "tool-3".to_string(),
+            file_path: "sample.R".to_string(),
+            old_text: "old".to_string(),
+            new_text: "new".to_string(),
+            unified_diff: String::new(),
+            base_sha256: base_hash,
+            expected_sha256: None,
+        };
+
+        let preview = gateway
+            .edit_service
+            .preview_text_file(
+                EditTextFileRequest {
+                    path: "sample.R".to_string(),
+                    operation: EditOperation::Replace,
+                    expected_sha256: None,
+                    new_text: Some("new".to_string()),
+                    edits: None,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        {
+            let mut store = gateway.pending_edits.lock().await;
+            store
+                .register_pending_edit(pending.clone(), &preview)
+                .unwrap();
+        }
+
+        fs::write(&file_path, "changed").await.unwrap();
+
+        let result = gateway.accept_pending_edit(&pending.id).await;
+        assert!(result.is_err());
+
+        let store = gateway.pending_edits.lock().await;
+        assert!(store.get_edit(&pending.id).is_some());
+    }
+}
+
 fn tool_output_from(raw_output: Option<&Value>, content: &[ToolCallContent]) -> Option<Value> {
     if let Some(output) = raw_output {
         return Some(output.clone());

--- a/core/src/acp/gateway.rs
+++ b/core/src/acp/gateway.rs
@@ -11,6 +11,7 @@ use tracing::{info, warn};
 
 use super::{
     connection::{AcpConnection, PermissionDecisionMessage},
+    pending_edit::PendingEditStore,
     process::{spawn_agent, AcpChild, ProcessConfig, SpawnedPipes},
     session::AcpSessionManager,
     types::{
@@ -18,6 +19,7 @@ use super::{
         AcpPlanStepStatus, AcpSessionUpdate, AcpSessionUpdateEnvelope,
     },
 };
+use crate::edit::{EditOperation, EditService, EditStatus, EditTextFileRequest};
 
 const BROADCAST_BUFFER: usize = 128;
 
@@ -27,6 +29,8 @@ pub struct AcpGateway {
     conn: Option<AcpConnection>,
     workspace_root: PathBuf,
     sessions: AcpSessionManager,
+    edit_service: std::sync::Arc<EditService>,
+    pending_edits: std::sync::Arc<tokio::sync::Mutex<PendingEditStore>>,
     updates_tx: broadcast::Sender<AcpSessionUpdateEnvelope>,
     permission_tx: broadcast::Sender<AcpPermissionRequestPayload>,
 }
@@ -35,11 +39,16 @@ impl AcpGateway {
     pub fn new(workspace_root: PathBuf) -> Self {
         let (updates_tx, _) = broadcast::channel(BROADCAST_BUFFER);
         let (permission_tx, _) = broadcast::channel(BROADCAST_BUFFER);
+        let edit_service = std::sync::Arc::new(EditService::new(workspace_root.clone()));
+        let pending_edits =
+            std::sync::Arc::new(tokio::sync::Mutex::new(PendingEditStore::default()));
         Self {
             child: None,
             conn: None,
             workspace_root,
             sessions: AcpSessionManager::new(),
+            edit_service,
+            pending_edits,
             updates_tx,
             permission_tx,
         }
@@ -78,15 +87,22 @@ impl AcpGateway {
         } = spawn_agent(config).await?;
         child.notify_ready().await?;
 
-        let (connection, updates, permission_requests) =
-            match AcpConnection::initialize(self.workspace_root.clone(), writer, reader).await {
-                Ok(result) => result,
-                Err(err) => {
-                    warn!(error = %err, "ACP initialize failed; shutting down agent");
-                    child.shutdown().await;
-                    return Err(err);
-                }
-            };
+        let (connection, updates, permission_requests) = match AcpConnection::initialize(
+            self.workspace_root.clone(),
+            self.edit_service.clone(),
+            self.pending_edits.clone(),
+            writer,
+            reader,
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(err) => {
+                warn!(error = %err, "ACP initialize failed; shutting down agent");
+                child.shutdown().await;
+                return Err(err);
+            }
+        };
         self.forward_updates(updates);
         self.forward_permission_requests(permission_requests);
 
@@ -161,6 +177,49 @@ impl AcpGateway {
             update: AcpSessionUpdate::Done,
         };
         let _ = self.updates_tx.send(payload);
+        Ok(())
+    }
+
+    pub async fn accept_pending_edit(&self, edit_id: &str) -> Result<()> {
+        let edit = {
+            let store = self.pending_edits.lock().await;
+            store
+                .get_edit(edit_id)
+                .ok_or_else(|| anyhow!("Pending edit not found"))?
+        };
+
+        let current = self.edit_service.read_text_file(&edit.file_path).await?;
+        if current.sha256 != edit.base_sha256 {
+            return Err(anyhow!(
+                "Pending edit base mismatch: file changed since edit was created"
+            ));
+        }
+
+        let request = EditTextFileRequest {
+            path: edit.file_path.clone(),
+            operation: EditOperation::Replace,
+            expected_sha256: edit
+                .expected_sha256
+                .clone()
+                .or_else(|| Some(edit.base_sha256.clone())),
+            new_text: Some(edit.new_text.clone()),
+            edits: None,
+        };
+        let result = self.edit_service.edit_text_file(request).await?;
+        if matches!(result.status, EditStatus::Conflict) {
+            return Err(anyhow!("Conflict detected while applying pending edit"));
+        }
+
+        let mut store = self.pending_edits.lock().await;
+        store.remove_edit(edit_id);
+        Ok(())
+    }
+
+    pub async fn reject_pending_edit(&self, edit_id: &str) -> Result<()> {
+        let mut store = self.pending_edits.lock().await;
+        if store.remove_edit(edit_id).is_none() {
+            return Err(anyhow!("Pending edit not found"));
+        }
         Ok(())
     }
 

--- a/core/src/acp/mod.rs
+++ b/core/src/acp/mod.rs
@@ -5,6 +5,7 @@ pub mod connection;
 pub mod detection;
 mod download;
 pub mod gateway;
+pub mod pending_edit;
 pub mod process;
 pub mod runtime;
 pub mod session;

--- a/core/src/acp/pending_edit.rs
+++ b/core/src/acp/pending_edit.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::edit::EditTextFileResult;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct PendingEdit {
+    pub id: String,
+    pub session_id: String,
+    pub tool_call_id: String,
+    pub file_path: String,
+    pub old_text: String,
+    pub new_text: String,
+    pub unified_diff: String,
+    pub base_sha256: String,
+    pub expected_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingOverlay {
+    pub text: String,
+    pub sha256: String,
+}
+
+#[derive(Default)]
+pub struct PendingEditStore {
+    edits_by_id: HashMap<String, PendingEdit>,
+    edit_by_file: HashMap<String, String>,
+    overlays: HashMap<String, PendingOverlay>,
+}
+
+impl PendingEditStore {
+    pub fn overlay_for(&self, session_id: &str, file_path: &str) -> Option<PendingOverlay> {
+        let key = overlay_key(session_id, file_path);
+        self.overlays.get(&key).cloned()
+    }
+
+    pub fn has_pending_for_file(&self, session_id: &str, file_path: &str) -> bool {
+        let key = file_key(session_id, file_path);
+        self.edit_by_file.contains_key(&key)
+    }
+
+    pub fn register_pending_edit(
+        &mut self,
+        edit: PendingEdit,
+        result: &EditTextFileResult,
+    ) -> Result<(), String> {
+        let key = file_key(&edit.session_id, &edit.file_path);
+        if self.edit_by_file.contains_key(&key) {
+            return Err("Pending edit already exists for this file".to_string());
+        }
+
+        let overlay_key = overlay_key(&edit.session_id, &edit.file_path);
+        self.overlays.insert(
+            overlay_key,
+            PendingOverlay {
+                text: edit.new_text.clone(),
+                sha256: result.new_sha256.clone(),
+            },
+        );
+        self.edit_by_file.insert(key, edit.id.clone());
+        self.edits_by_id.insert(edit.id.clone(), edit);
+        Ok(())
+    }
+
+    pub fn get_edit(&self, edit_id: &str) -> Option<PendingEdit> {
+        self.edits_by_id.get(edit_id).cloned()
+    }
+
+    pub fn remove_edit(&mut self, edit_id: &str) -> Option<PendingEdit> {
+        let edit = self.edits_by_id.remove(edit_id)?;
+        let file_key = file_key(&edit.session_id, &edit.file_path);
+        self.edit_by_file.remove(&file_key);
+        let overlay_key = overlay_key(&edit.session_id, &edit.file_path);
+        self.overlays.remove(&overlay_key);
+        Some(edit)
+    }
+
+    pub fn clear_overlay(&mut self, session_id: &str, file_path: &str) {
+        let key = overlay_key(session_id, file_path);
+        self.overlays.remove(&key);
+    }
+}
+
+fn file_key(session_id: &str, file_path: &str) -> String {
+    format!("{session_id}:{file_path}")
+}
+
+fn overlay_key(session_id: &str, file_path: &str) -> String {
+    format!("{session_id}:{file_path}")
+}

--- a/core/src/edit.rs
+++ b/core/src/edit.rs
@@ -189,6 +189,88 @@ impl EditService {
         })
     }
 
+    pub async fn preview_text_file(
+        &self,
+        request: EditTextFileRequest,
+        base_text: Option<String>,
+    ) -> Result<EditTextFileResult, ReprodError> {
+        let resolved = self.validate_path(&request.path)?;
+        let (old_text, old_sha256) = match base_text {
+            Some(text) => {
+                let hash = sha256_hex(&text);
+                (text, hash)
+            }
+            None => read_existing(&resolved).await?,
+        };
+
+        if let Some(expected) = request.expected_sha256.as_ref() {
+            if &old_sha256 != expected {
+                let new_text = derive_new_text(&old_text, &request)?;
+                let unified_diff = unified_diff(&request.path, &old_text, &new_text);
+                let new_sha256 = sha256_hex(&new_text);
+                let structured_edits = match request.operation {
+                    EditOperation::ApplyEdits => request.edits.clone().unwrap_or_default(),
+                    _ => vec![TextEdit {
+                        range: full_range(&old_text),
+                        text: new_text.clone(),
+                    }],
+                };
+                return Ok(EditTextFileResult {
+                    status: EditStatus::Conflict,
+                    path: request.path,
+                    old_text: old_text.clone(),
+                    new_text,
+                    old_sha256: old_sha256.clone(),
+                    new_sha256,
+                    structured_edits,
+                    unified_diff,
+                    conflict: Some(EditConflict {
+                        current_sha256: old_sha256,
+                        current_text: old_text,
+                    }),
+                });
+            }
+        }
+
+        let new_text = derive_new_text(&old_text, &request)?;
+        if new_text.len() > MAX_FILE_SIZE as usize {
+            return Err(ReprodError::SecurityError(format!(
+                "Content size {} exceeds maximum allowed size of {} bytes",
+                new_text.len(),
+                MAX_FILE_SIZE
+            )));
+        }
+
+        let status = if new_text == old_text {
+            EditStatus::NoOp
+        } else {
+            EditStatus::Applied
+        };
+
+        let structured_edits = match request.operation {
+            EditOperation::ApplyEdits => request.edits.unwrap_or_default(),
+            _ => vec![TextEdit {
+                range: full_range(&old_text),
+                text: new_text.clone(),
+            }],
+        };
+
+        let unified_diff = unified_diff(&request.path, &old_text, &new_text);
+        let new_sha256 = sha256_hex(&new_text);
+
+        Ok(EditTextFileResult {
+            status,
+            path: request.path,
+            old_text,
+            new_text,
+            old_sha256,
+            new_sha256,
+            structured_edits,
+            unified_diff,
+            conflict: None,
+        })
+    }
+
     fn validate_path(&self, relative_path: &str) -> Result<PathBuf, ReprodError> {
         let path_obj = Path::new(relative_path);
         if path_obj.is_absolute() {
@@ -386,7 +468,7 @@ fn unified_diff(path: &str, old_text: &str, new_text: &str) -> String {
         .to_string()
 }
 
-fn sha256_hex(text: &str) -> String {
+pub fn sha256_hex(text: &str) -> String {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(text.as_bytes());

--- a/core/src/edit.rs
+++ b/core/src/edit.rs
@@ -124,19 +124,18 @@ impl EditService {
                 let unified_diff = unified_diff(&request.path, &old_text, &new_text);
                 let new_sha256 = sha256_hex(&new_text);
                 let old_sha256_snapshot = old_sha256.clone();
-                let new_text_snapshot = new_text.clone();
                 let structured_edits = match request.operation {
                     EditOperation::ApplyEdits => request.edits.clone().unwrap_or_default(),
                     _ => vec![TextEdit {
                         range: full_range(&old_text),
-                        text: new_text_snapshot.clone(),
+                        text: new_text.clone(),
                     }],
                 };
                 return Ok(EditTextFileResult {
                     status: EditStatus::Conflict,
                     path: request.path,
                     old_text: old_text.clone(),
-                    new_text: new_text_snapshot,
+                    new_text,
                     old_sha256: old_sha256.clone(),
                     new_sha256,
                     structured_edits,

--- a/core/src/edit.rs
+++ b/core/src/edit.rs
@@ -128,14 +128,14 @@ impl EditService {
                     EditOperation::ApplyEdits => request.edits.clone().unwrap_or_default(),
                     _ => vec![TextEdit {
                         range: full_range(&old_text),
-                        text: new_text.clone(),
+                        text: new_text_snapshot.clone(),
                     }],
                 };
                 return Ok(EditTextFileResult {
                     status: EditStatus::Conflict,
                     path: request.path,
                     old_text: old_text.clone(),
-                    new_text,
+                    new_text: new_text_snapshot,
                     old_sha256: old_sha256.clone(),
                     new_sha256,
                     structured_edits,

--- a/core/src/executor/r_executor.rs
+++ b/core/src/executor/r_executor.rs
@@ -156,6 +156,7 @@ impl RExecutor {
                     if is_internal_line(&line) {
                         return;
                     }
+                    let line_text = line;
                     let chunk = RunOutputChunk {
                         run_id: run_id.clone().unwrap_or_default(),
                         stream: if is_stdout {
@@ -163,17 +164,17 @@ impl RExecutor {
                         } else {
                             RunStream::Stderr
                         },
-                        chunk: line.clone(),
+                        chunk: line_text.clone(),
                         at_ms,
                     };
                     if let Some(tx) = output_tx.as_ref() {
                         let _ = tx.send(chunk.clone());
                     }
                     if is_stdout {
-                        streamed_stdout.push(line.clone());
+                        streamed_stdout.push(line_text);
                         streamed_chunks.push(chunk);
                     } else {
-                        streamed_stderr.push(line.clone());
+                        streamed_stderr.push(line_text);
                         streamed_chunks.push(chunk);
                     }
                 },

--- a/desktop/src/acp/commands.rs
+++ b/desktop/src/acp/commands.rs
@@ -167,3 +167,21 @@ pub async fn acp_set_agent_config(
         active_agent_command: cfg.active_agent_command,
     })
 }
+
+#[tauri::command]
+pub async fn acp_accept_pending_edit(state: AcpState<'_>, edit_id: String) -> Result<(), String> {
+    let manager = state.lock().await;
+    manager
+        .accept_pending_edit(&edit_id)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn acp_reject_pending_edit(state: AcpState<'_>, edit_id: String) -> Result<(), String> {
+    let manager = state.lock().await;
+    manager
+        .reject_pending_edit(&edit_id)
+        .await
+        .map_err(|err| err.to_string())
+}

--- a/desktop/src/acp/mod.rs
+++ b/desktop/src/acp/mod.rs
@@ -88,6 +88,14 @@ impl AcpManager {
         self.gateway.subscribe_permission_requests()
     }
 
+    pub async fn accept_pending_edit(&self, edit_id: &str) -> Result<()> {
+        self.gateway.accept_pending_edit(edit_id).await
+    }
+
+    pub async fn reject_pending_edit(&self, edit_id: &str) -> Result<()> {
+        self.gateway.reject_pending_edit(edit_id).await
+    }
+
     pub async fn shutdown(&mut self) {
         if let Some(handles) = self.forwarders.take() {
             handles.updates.abort();

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -64,6 +64,8 @@ async fn main() {
             acp::commands::acp_detect_agents,
             acp::commands::acp_get_agent_config,
             acp::commands::acp_set_agent_config,
+            acp::commands::acp_accept_pending_edit,
+            acp::commands::acp_reject_pending_edit,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/server/src/acp.rs
+++ b/server/src/acp.rs
@@ -114,6 +114,22 @@ impl AcpService {
         Ok(())
     }
 
+    pub async fn accept_pending_edit(&self, edit_id: &str) -> Result<()> {
+        self.rate_limit("pending_edit_accept").await?;
+        self.ensure_agent_running().await?;
+        let gateway = self.gateway.lock().await;
+        gateway.accept_pending_edit(edit_id).await?;
+        Ok(())
+    }
+
+    pub async fn reject_pending_edit(&self, edit_id: &str) -> Result<()> {
+        self.rate_limit("pending_edit_reject").await?;
+        self.ensure_agent_running().await?;
+        let gateway = self.gateway.lock().await;
+        gateway.reject_pending_edit(edit_id).await?;
+        Ok(())
+    }
+
     pub async fn subscribe_session_updates(&self) -> broadcast::Receiver<AcpSessionUpdateEnvelope> {
         let gateway = self.gateway.lock().await;
         gateway.subscribe_session_updates()

--- a/server/src/handlers/acp_handler.rs
+++ b/server/src/handlers/acp_handler.rs
@@ -68,3 +68,39 @@ pub async fn handle_acp_permission_decision(
         Err(error) => error_response(error.to_string()),
     }
 }
+
+pub async fn handle_acp_pending_edit_accept(
+    runtime: &Arc<ProjectRuntime>,
+    edit_id: &str,
+) -> Vec<WSResponse> {
+    match runtime.acp.accept_pending_edit(edit_id).await {
+        Ok(()) => single_response(WSResponse::AcpPendingEditResolved {
+            edit_id: edit_id.to_string(),
+            success: true,
+            error: None,
+        }),
+        Err(error) => single_response(WSResponse::AcpPendingEditResolved {
+            edit_id: edit_id.to_string(),
+            success: false,
+            error: Some(error.to_string()),
+        }),
+    }
+}
+
+pub async fn handle_acp_pending_edit_reject(
+    runtime: &Arc<ProjectRuntime>,
+    edit_id: &str,
+) -> Vec<WSResponse> {
+    match runtime.acp.reject_pending_edit(edit_id).await {
+        Ok(()) => single_response(WSResponse::AcpPendingEditResolved {
+            edit_id: edit_id.to_string(),
+            success: true,
+            error: None,
+        }),
+        Err(error) => single_response(WSResponse::AcpPendingEditResolved {
+            edit_id: edit_id.to_string(),
+            success: false,
+            error: Some(error.to_string()),
+        }),
+    }
+}

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -182,6 +182,10 @@ pub(super) enum WSRequest {
     AcpSessionCancel { session_id: String },
     #[serde(rename = "acp_permission_decision")]
     AcpPermissionDecision { decision: AcpPermissionDecision },
+    #[serde(rename = "acp_pending_edit_accept")]
+    AcpPendingEditAccept { edit_id: String },
+    #[serde(rename = "acp_pending_edit_reject")]
+    AcpPendingEditReject { edit_id: String },
 }
 
 #[derive(serde::Serialize)]
@@ -267,6 +271,13 @@ pub(super) enum WSResponse {
     },
     #[serde(rename = "project_state_saved")]
     ProjectStateSaved { project_id: String },
+    #[serde(rename = "acp_pending_edit_resolved")]
+    AcpPendingEditResolved {
+        edit_id: String,
+        success: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
     #[serde(rename = "plot_history_state")]
     PlotHistoryState {
         #[serde(rename = "activePlotId")]

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -37,8 +37,8 @@ pub use common::AppState;
 
 use crate::projects::RuntimeBroadcastEvent;
 use acp_handler::{
-    handle_acp_permission_decision, handle_acp_session_cancel, handle_acp_session_create,
-    handle_acp_session_prompt,
+    handle_acp_pending_edit_accept, handle_acp_pending_edit_reject, handle_acp_permission_decision,
+    handle_acp_session_cancel, handle_acp_session_create, handle_acp_session_prompt,
 };
 use ai_handler::handle_ai_message;
 use common::{error_response, WSRequest, WSResponse};
@@ -303,6 +303,12 @@ async fn handle_ws_request(
         }
         WSRequest::AcpPermissionDecision { decision } => {
             handle_acp_permission_decision(runtime, decision).await
+        }
+        WSRequest::AcpPendingEditAccept { edit_id } => {
+            handle_acp_pending_edit_accept(runtime, &edit_id).await
+        }
+        WSRequest::AcpPendingEditReject { edit_id } => {
+            handle_acp_pending_edit_reject(runtime, &edit_id).await
         }
         _ => Vec::new(),
     }


### PR DESCRIPTION
## Description

- Add unified pending edit flow for ACP and related services
- Introduce pending edit state management, hooks, and editor UI wiring
- Normalize pending edit path handling and add tests

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `bash .husky/pre-push`

## Screenshots (if applicable)

- N/A

## Related Issues

Closes #323
