### PR TITLE
Add diff marker constants and helper functions

### DIFF
--- a/client/src/constants/diff.ts
+++ b/client/src/constants/diff.ts
@@ -1,0 +1,42 @@
+/**
+ * Diff format markers used in unified diff parsing
+ */
+
+/** Marker for removed lines in diff format */
+export const DIFF_MARKER_REMOVE = "-";
+
+/** Marker for added lines in diff format */
+export const DIFF_MARKER_ADD = "+";
+
+/** Marker for context (unchanged) lines in diff format */
+export const DIFF_MARKER_CONTEXT = " ";
+
+/** Marker for file header in diff format */
+export const DIFF_MARKER_FILE_OLD = "---";
+
+/** Marker for file header in diff format */
+export const DIFF_MARKER_FILE_NEW = "+++";
+
+/** Marker for hunk header in diff format */
+export const DIFF_MARKER_HUNK = "@@";
+
+/**
+ * Helper to check if a line is a removal
+ */
+export function isDiffRemoval(line: string): boolean {
+	return line.startsWith(DIFF_MARKER_REMOVE) && !line.startsWith(DIFF_MARKER_FILE_OLD);
+}
+
+/**
+ * Helper to check if a line is an addition
+ */
+export function isDiffAddition(line: string): boolean {
+	return line.startsWith(DIFF_MARKER_ADD) && !line.startsWith(DIFF_MARKER_FILE_NEW);
+}
+
+/**
+ * Helper to check if a line is context
+ */
+export function isDiffContext(line: string): boolean {
+	return line.startsWith(DIFF_MARKER_CONTEXT);
+}

--- a/client/src/core/ai/codeBlockUtils.ts
+++ b/client/src/core/ai/codeBlockUtils.ts
@@ -1,3 +1,11 @@
+import {
+	DIFF_MARKER_FILE_NEW,
+	DIFF_MARKER_FILE_OLD,
+	DIFF_MARKER_HUNK,
+	isDiffAddition,
+	isDiffContext,
+	isDiffRemoval,
+} from "@/constants/diff";
 import type { CodeBlock, CodeChangeAction, CodeRange, SimpleCodeChange } from "@/types";
 import { CodeActionFactory } from "./actions";
 import type { PatchHunk } from "./patchParser";
@@ -28,7 +36,7 @@ const makeCodeRange = (raw?: Partial<CodeRange>): CodeRange | undefined => {
 
 const parsePatchSnippet = (value: string): { originalCode: string; newCode: string } | null => {
 	const lines = value.split(/\r?\n/);
-	const hasDiffMarkers = lines.some((line) => line.startsWith("+") || line.startsWith("-"));
+	const hasDiffMarkers = lines.some((line) => isDiffAddition(line) || isDiffRemoval(line));
 	if (!hasDiffMarkers) {
 		return null;
 	}
@@ -37,21 +45,25 @@ const parsePatchSnippet = (value: string): { originalCode: string; newCode: stri
 	const newLines: string[] = [];
 
 	for (const line of lines) {
-		if (line.startsWith("@@") || line.startsWith("---") || line.startsWith("+++")) {
+		if (
+			line.startsWith(DIFF_MARKER_HUNK) ||
+			line.startsWith(DIFF_MARKER_FILE_OLD) ||
+			line.startsWith(DIFF_MARKER_FILE_NEW)
+		) {
 			continue;
 		}
 
-		if (line.startsWith("-")) {
+		if (isDiffRemoval(line)) {
 			originalLines.push(line.slice(1));
 			continue;
 		}
 
-		if (line.startsWith("+")) {
+		if (isDiffAddition(line)) {
 			newLines.push(line.slice(1));
 			continue;
 		}
 
-		if (line.startsWith(" ")) {
+		if (isDiffContext(line)) {
 			const context = line.slice(1);
 			originalLines.push(context);
 			newLines.push(context);

--- a/client/src/core/ai/patchParser.ts
+++ b/client/src/core/ai/patchParser.ts
@@ -1,3 +1,5 @@
+import { DIFF_MARKER_HUNK, isDiffAddition, isDiffContext, isDiffRemoval } from "@/constants/diff";
+
 export type PatchChunk = {
 	context?: string;
 	oldLines: string[];
@@ -58,7 +60,7 @@ export function parsePatchFormat(text: string): PatchHunk[] {
 				continue;
 			}
 
-			if (line.startsWith("@@")) {
+			if (line.startsWith(DIFF_MARKER_HUNK)) {
 				currentChunk = {
 					context: line,
 					oldLines: [],
@@ -73,17 +75,17 @@ export function parsePatchFormat(text: string): PatchHunk[] {
 				continue;
 			}
 
-			if (line.startsWith("-")) {
+			if (isDiffRemoval(line)) {
 				chunk.oldLines.push(line.slice(1));
 				continue;
 			}
 
-			if (line.startsWith("+")) {
+			if (isDiffAddition(line)) {
 				chunk.newLines.push(line.slice(1));
 				continue;
 			}
 
-			if (line.startsWith(" ")) {
+			if (isDiffContext(line)) {
 				const context = line.slice(1);
 				chunk.oldLines.push(context);
 				chunk.newLines.push(context);

--- a/client/src/core/ai/simpleChangeParser.ts
+++ b/client/src/core/ai/simpleChangeParser.ts
@@ -1,3 +1,4 @@
+import { isDiffAddition, isDiffContext, isDiffRemoval } from "@/constants/diff";
 import type { SimpleCodeChange } from "@/types";
 
 const CODE_FENCE_REGEX = /```[a-zA-Z0-9_-]*\n([\s\S]*?)```/g;
@@ -23,14 +24,14 @@ const parseDiffBlock = (block: string): SimpleCodeChange | null => {
 	const lines = normalizeBlock(block);
 	const diffLineIndexes = lines
 		.map((line, index) => ({ index, line }))
-		.filter(({ line }) => line.startsWith("-") || line.startsWith("+"));
+		.filter(({ line }) => isDiffRemoval(line) || isDiffAddition(line));
 
 	if (!diffLineIndexes.length) {
 		return null;
 	}
 
-	const hasAdditions = diffLineIndexes.some(({ line }) => line.startsWith("+"));
-	const hasRemovals = diffLineIndexes.some(({ line }) => line.startsWith("-"));
+	const hasAdditions = diffLineIndexes.some(({ line }) => isDiffAddition(line));
+	const hasRemovals = diffLineIndexes.some(({ line }) => isDiffRemoval(line));
 
 	if (!hasAdditions || !hasRemovals) {
 		return null;
@@ -47,17 +48,17 @@ const parseDiffBlock = (block: string): SimpleCodeChange | null => {
 
 	for (let idx = firstDiff; idx <= lastDiff; idx++) {
 		const line = lines[idx];
-		if (line.startsWith("-")) {
+		if (isDiffRemoval(line)) {
 			oldLines.push(line.slice(1));
 			continue;
 		}
-		if (line.startsWith("+")) {
+		if (isDiffAddition(line)) {
 			newLines.push(line.slice(1));
 			continue;
 		}
 		// Treat neutral lines (including blanks) within the diff span as shared context
-		oldLines.push(line.startsWith(" ") ? line.slice(1) : line);
-		newLines.push(line.startsWith(" ") ? line.slice(1) : line);
+		oldLines.push(isDiffContext(line) ? line.slice(1) : line);
+		newLines.push(isDiffContext(line) ? line.slice(1) : line);
 	}
 
 	if (!oldLines.length && !newLines.length) {


### PR DESCRIPTION
### Motivation

- Replace repeated hardcoded diff markers (`"-"`, `"+"`, `" "`, `"@@"`, `"---"`, `"+++"`) with named constants for clarity and maintainability.
- Centralize common diff checks to reduce duplication and make intent explicit when parsing unified diffs.
- Improve readability of diff parsing logic across AI-related utilities that handle unified diff text.

### Description

- Add `client/src/constants/diff.ts` exporting diff marker constants and helper predicates `isDiffRemoval`, `isDiffAddition`, and `isDiffContext` with JSDoc comments.
- Update `client/src/core/ai/simpleChangeParser.ts` to import and use the helper predicates instead of raw `startsWith` checks.
- Update `client/src/core/ai/codeBlockUtils.ts` to use the constants and helpers for detecting hunk/file headers and line types.
- Update `client/src/core/ai/patchParser.ts` to use the shared `DIFF_MARKER_HUNK` constant and the helper predicates for consistent parsing.

### Testing

- Ran linter and TypeScript checks with `pnpm -r lint`, which passed successfully.
- Built the frontend with `pnpm --filter client build`, which completed (Vite emitted chunk-size warnings only).
- Ran frontend unit tests with `pnpm --filter client test -- --run`, which passed all client tests.
- Ran Rust checks and test suites: `cargo test --workspace --lib --all-features` and several integration tests passed, while `cargo check --workspace` and some integration tests (`timeline_integration_test`, `viral_phylogenomics_workflow_test`) failed in this environment due to missing system dependencies / test environment requirements (e.g., `glib-2.0` and R-related files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a436f26bc8327a78f45e228198562)

Closes #334 