### PR TITLE
Add pending edit diff review UI

### DIFF
--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -28,11 +28,7 @@ import {
 import type { CodeBlock, CodeRange } from "@/types";
 import type { PendingEditReviewMap, PendingEditReviewStatus } from "@/types/pendingEdit";
 import { clamp } from "@/utils/math";
-import {
-	applyPendingEditChanges,
-	buildDiffChanges,
-	buildDiffHunks,
-} from "@/utils/pendingEditDiff";
+import { applyPendingEditChanges, buildDiffChanges, buildDiffHunks } from "@/utils/pendingEditDiff";
 import { PendingEditDiffView } from "./PendingEditDiffView";
 import type { EditorRef } from "./editorRef";
 
@@ -73,23 +69,25 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const pendingEditDiff = useMemo(() => {
 		if (!pendingEdit || !monacoInstance) return null;
 		const language = monacoEditorRef.current?.getModel()?.getLanguageId();
+		if (typeof document === "undefined") {
+			return null;
+		}
 		const original = monacoInstance.editor.createModel(pendingEdit.oldContent, language);
 		const modified = monacoInstance.editor.createModel(pendingEdit.newContent, language);
+		const diffContainer = document.createElement("div");
+		const diffEditor = monacoInstance.editor.createDiffEditor(diffContainer, {
+			readOnly: true,
+		});
 		try {
-			const result = monacoInstance.editor.computeDiff(original, modified, {
-				ignoreTrimWhitespace: false,
-				maxComputationTime: 2000,
-			});
-			const diffChanges = buildDiffChanges(
-				pendingEdit.oldContent,
-				pendingEdit.newContent,
-				result.changes ?? [],
-			);
+			diffEditor.setModel({ original, modified });
+			const changes = diffEditor.getLineChanges() ?? [];
+			const diffChanges = buildDiffChanges(pendingEdit.oldContent, pendingEdit.newContent, changes);
 			return {
 				changes: diffChanges,
 				hunks: buildDiffHunks(diffChanges),
 			};
 		} finally {
+			diffEditor.dispose();
 			original.dispose();
 			modified.dispose();
 		}
@@ -712,11 +710,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 								<button className="btn" onClick={handlePendingRejectAll} type="button">
 									Reject All
 								</button>
-								<button
-									className="btn btn-primary"
-									onClick={handlePendingAccept}
-									type="button"
-								>
+								<button className="btn btn-primary" onClick={handlePendingAccept} type="button">
 									Apply (Enter)
 								</button>
 								<button className="btn" onClick={handlePendingReject} type="button">

--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -14,15 +14,26 @@ import { ConfirmDialog, IconPlay, IconPlayCircle, useToast } from "@/components/
 import { useStore } from "@/core";
 import { computeTargetRange, findCodeInEditor, matchPatchChunk } from "@/core/ai/contextMatcher";
 import { commandRegistry } from "@/core/commands/registry";
+import type { AppliedCodeChange } from "@/core/state/slices/editorSlice";
+import { normalizeRelativePath } from "@/core/pathUtils";
 import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { useEditorCells } from "@/hooks/useEditorCells";
 import { useEditorDecorations } from "@/hooks/useEditorDecorations";
 import { useEditorExecution } from "@/hooks/useEditorExecution";
-import type { AppliedCodeChange } from "@/core/state/slices/editorSlice";
-import { acceptPendingEdit, rejectPendingEdit } from "@/services/pendingEditService";
+import {
+	acceptPendingEdit,
+	rejectPendingEdit,
+	updatePendingEdit,
+} from "@/services/pendingEditService";
 import type { CodeBlock, CodeRange } from "@/types";
+import type { PendingEditReviewMap, PendingEditReviewStatus } from "@/types/pendingEdit";
 import { clamp } from "@/utils/math";
-import { normalizeRelativePath } from "@/core/pathUtils";
+import {
+	applyPendingEditChanges,
+	buildDiffChanges,
+	buildDiffHunks,
+} from "@/utils/pendingEditDiff";
+import { PendingEditDiffView } from "./PendingEditDiffView";
 import type { EditorRef } from "./editorRef";
 
 function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Element {
@@ -46,14 +57,70 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const pendingEdit = useStore((state) => state.pendingEdits[normalizedEditorPath]);
 	const clearPendingEdit = useStore((state) => state.clearPendingEdit);
 	const updatePendingEditStatus = useStore((state) => state.updatePendingEditStatus);
+	const updatePendingEditReview = useStore((state) => state.updatePendingEditReview);
+	const setPendingEditReviewMap = useStore((state) => state.setPendingEditReviewMap);
 	const editorMethodsRef = useRef<EditorRef | null>(null);
 	const monacoEditorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
 	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
 	const pendingEditWarningRef = useRef(false);
+	const skipPendingNoticeRef = useRef(false);
+	const [monacoInstance, setMonacoInstance] = useState<Monaco | null>(null);
 	const [pendingNotice, setPendingNotice] = useState<{
 		type: "warning" | "error";
 		message: string;
 	} | null>(null);
+	const pendingEditReviewMap = pendingEdit?.reviewedChanges ?? {};
+	const pendingEditDiff = useMemo(() => {
+		if (!pendingEdit || !monacoInstance) return null;
+		const language = monacoEditorRef.current?.getModel()?.getLanguageId();
+		const original = monacoInstance.editor.createModel(pendingEdit.oldContent, language);
+		const modified = monacoInstance.editor.createModel(pendingEdit.newContent, language);
+		try {
+			const result = monacoInstance.editor.computeDiff(original, modified, {
+				ignoreTrimWhitespace: false,
+				maxComputationTime: 2000,
+			});
+			const diffChanges = buildDiffChanges(
+				pendingEdit.oldContent,
+				pendingEdit.newContent,
+				result.changes ?? [],
+			);
+			return {
+				changes: diffChanges,
+				hunks: buildDiffHunks(diffChanges),
+			};
+		} finally {
+			original.dispose();
+			modified.dispose();
+		}
+	}, [monacoInstance, pendingEdit]);
+	const reviewedContent = useMemo(() => {
+		if (!pendingEdit || !pendingEditDiff) return null;
+		return applyPendingEditChanges(
+			pendingEdit.oldContent,
+			pendingEditDiff.changes,
+			pendingEditReviewMap,
+		);
+	}, [pendingEdit, pendingEditDiff, pendingEditReviewMap]);
+	const pendingEditSummary = useMemo(() => {
+		if (!pendingEditDiff) {
+			return { total: 0, keep: 0, reject: 0, pending: 0 };
+		}
+		let keep = 0;
+		let reject = 0;
+		let pending = 0;
+		for (const change of pendingEditDiff.changes) {
+			const status = pendingEditReviewMap[change.id];
+			if (status === "keep") {
+				keep += 1;
+			} else if (status === "reject") {
+				reject += 1;
+			} else {
+				pending += 1;
+			}
+		}
+		return { total: pendingEditDiff.changes.length, keep, reject, pending };
+	}, [pendingEditDiff, pendingEditReviewMap]);
 
 	const cells = useEditorCells(editor.content, editor.filepath);
 	const { state, actions } = useEditorExecution({
@@ -76,20 +143,41 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 
 	useEffect(() => {
 		if (!pendingEdit) return;
-		if (editor.content === pendingEdit.newContent) return;
-		setEditorContent(pendingEdit.newContent);
-	}, [editor.content, pendingEdit, setEditorContent]);
+		if (reviewedContent === null) return;
+		if (editor.content === reviewedContent) return;
+		skipPendingNoticeRef.current = true;
+		setEditorContent(reviewedContent);
+	}, [editor.content, pendingEdit, reviewedContent, setEditorContent]);
+
+	useEffect(() => {
+		if (!pendingEdit || !pendingEditDiff) return;
+		const nextMap: PendingEditReviewMap = { ...pendingEditReviewMap };
+		let updated = false;
+		for (const change of pendingEditDiff.changes) {
+			if (!(change.id in nextMap)) {
+				nextMap[change.id] = "keep";
+				updated = true;
+			}
+		}
+		if (updated) {
+			setPendingEditReviewMap(pendingEdit.filePath, nextMap);
+		}
+	}, [pendingEdit, pendingEditDiff, pendingEditReviewMap, setPendingEditReviewMap]);
 
 	const handlePendingAccept = useCallback(async () => {
 		if (!pendingEdit) return;
-		if (editor.content !== pendingEdit.newContent) {
+		const resolvedContent = reviewedContent ?? pendingEdit.newContent;
+		if (editor.content !== resolvedContent) {
 			setPendingNotice({
 				type: "warning",
-				message: "Editor content changed since the pending edit was created.",
+				message: "Editor content changed since the pending edit review.",
 			});
 			return;
 		}
 		try {
+			if (pendingEdit.source.type === "acp" && resolvedContent !== pendingEdit.newContent) {
+				await updatePendingEdit(pendingEdit, resolvedContent);
+			}
 			await acceptPendingEdit(pendingEdit);
 			updatePendingEditStatus(pendingEdit.filePath, "accepted");
 			clearPendingEdit(pendingEdit.filePath);
@@ -103,7 +191,14 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 					: message,
 			});
 		}
-	}, [clearPendingEdit, editor.content, pendingEdit, updatePendingEditStatus]);
+	}, [
+		clearPendingEdit,
+		editor.content,
+		pendingEdit,
+		reviewedContent,
+		updatePendingEdit,
+		updatePendingEditStatus,
+	]);
 
 	const handlePendingReject = useCallback(async () => {
 		if (!pendingEdit) return;
@@ -123,6 +218,32 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 			});
 		}
 	}, [clearPendingEdit, pendingEdit, setEditorContent, updatePendingEditStatus]);
+
+	const handlePendingReviewChange = useCallback(
+		(changeId: string, status: PendingEditReviewStatus) => {
+			if (!pendingEdit) return;
+			updatePendingEditReview(pendingEdit.filePath, changeId, status);
+		},
+		[pendingEdit, updatePendingEditReview],
+	);
+
+	const handlePendingKeepAll = useCallback(() => {
+		if (!pendingEdit || !pendingEditDiff) return;
+		const nextMap: PendingEditReviewMap = {};
+		for (const change of pendingEditDiff.changes) {
+			nextMap[change.id] = "keep";
+		}
+		setPendingEditReviewMap(pendingEdit.filePath, nextMap);
+	}, [pendingEdit, pendingEditDiff, setPendingEditReviewMap]);
+
+	const handlePendingRejectAll = useCallback(() => {
+		if (!pendingEdit || !pendingEditDiff) return;
+		const nextMap: PendingEditReviewMap = {};
+		for (const change of pendingEditDiff.changes) {
+			nextMap[change.id] = "reject";
+		}
+		setPendingEditReviewMap(pendingEdit.filePath, nextMap);
+	}, [pendingEdit, pendingEditDiff, setPendingEditReviewMap]);
 
 	useEffect(() => {
 		if (!pendingEdit) return;
@@ -145,6 +266,11 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 
 	const handleEditorChange = (value: string | undefined): void => {
 		if (value !== undefined) {
+			if (pendingEdit && skipPendingNoticeRef.current) {
+				skipPendingNoticeRef.current = false;
+				setEditorContent(value);
+				return;
+			}
 			if (pendingEdit && !pendingEditWarningRef.current) {
 				if (!pendingNotice || pendingNotice.type !== "error") {
 					setPendingNotice({
@@ -501,6 +627,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	): void => {
 		monacoEditorRef.current = monacoEditor;
 		setMonacoEditor(monacoEditor);
+		setMonacoInstance(monaco);
 
 		// Track cursor position
 		monacoEditor.onDidChangeCursorPosition((e) => {
@@ -564,23 +691,51 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 					</div>
 				</div>
 				{pendingEdit && (
-					<div className="pending-edit-toolbar">
-						<div className="pending-edit-info">
-							Pending edit ({pendingEdit.source.type === "acp" ? "ACP" : "API Key"})
+					<div className="pending-edit-review">
+						<div className="pending-edit-review-toolbar">
+							<div className="pending-edit-review-summary">
+								Pending edit ({pendingEdit.source.type === "acp" ? "ACP" : "API Key"})
+							</div>
+							<div className="pending-edit-review-meta">
+								{pendingEditSummary.total} hunks · {pendingEditSummary.keep} keep ·{" "}
+								{pendingEditSummary.reject} reject · {pendingEditSummary.pending} pending
+							</div>
+							{pendingNotice && (
+								<div className={`pending-edit-message ${pendingNotice.type}`}>
+									{pendingNotice.message}
+								</div>
+							)}
+							<div className="pending-edit-review-actions">
+								<button className="btn" onClick={handlePendingKeepAll} type="button">
+									Keep All
+								</button>
+								<button className="btn" onClick={handlePendingRejectAll} type="button">
+									Reject All
+								</button>
+								<button
+									className="btn btn-primary"
+									onClick={handlePendingAccept}
+									type="button"
+								>
+									Apply (Enter)
+								</button>
+								<button className="btn" onClick={handlePendingReject} type="button">
+									Discard (Esc)
+								</button>
+							</div>
 						</div>
-						{pendingNotice && (
-							<div className={`pending-edit-message ${pendingNotice.type}`}>
-								{pendingNotice.message}
+						{pendingEditDiff && pendingEditDiff.hunks.length > 0 ? (
+							<PendingEditDiffView
+								hunks={pendingEditDiff.hunks}
+								reviewMap={pendingEditReviewMap}
+								onReviewChange={handlePendingReviewChange}
+								onNavigateToLine={navigateToLine}
+							/>
+						) : (
+							<div className="pending-edit-message warning">
+								No pending changes detected in the diff view.
 							</div>
 						)}
-						<div className="pending-edit-actions">
-							<button className="btn btn-primary" onClick={handlePendingAccept} type="button">
-								Accept (Enter)
-							</button>
-							<button className="btn" onClick={handlePendingReject} type="button">
-								Reject (Esc)
-							</button>
-						</div>
 					</div>
 				)}
 				<div className="panel-content">
@@ -601,6 +756,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 							tabSize: 2,
 							automaticLayout: true,
 							padding: { top: 8, bottom: 8 },
+							readOnly: Boolean(pendingEdit),
 							scrollbar: {
 								useShadows: false,
 								verticalScrollbarSize: 12,

--- a/client/src/components/editor/PendingEditDiffView.tsx
+++ b/client/src/components/editor/PendingEditDiffView.tsx
@@ -61,10 +61,7 @@ export function PendingEditDiffView({
 						</div>
 						<div className="pending-edit-lines">
 							{hunk.lines.map((line, index) => (
-								<div
-									className={`pending-edit-line ${line.type}`}
-									key={`${hunk.id}-${index}`}
-								>
+								<div className={`pending-edit-line ${line.type}`} key={`${hunk.id}-${index}`}>
 									<span className="line-number old">{line.oldLine ?? ""}</span>
 									<span className="line-number new">{line.newLine ?? ""}</span>
 									<span className="line-content">{line.content}</span>

--- a/client/src/components/editor/PendingEditDiffView.tsx
+++ b/client/src/components/editor/PendingEditDiffView.tsx
@@ -1,0 +1,79 @@
+import type { PendingEditReviewMap } from "@/types/pendingEdit";
+import type { DiffHunk } from "@/utils/pendingEditDiff";
+
+interface Props {
+	hunks: DiffHunk[];
+	reviewMap: PendingEditReviewMap;
+	onReviewChange: (changeId: string, status: PendingEditReviewMap[string]) => void;
+	onNavigateToLine: (lineNumber: number) => void;
+}
+
+export function PendingEditDiffView({
+	hunks,
+	reviewMap,
+	onReviewChange,
+	onNavigateToLine,
+}: Props): JSX.Element {
+	return (
+		<div className="pending-edit-diff">
+			{hunks.map((hunk) => {
+				const status = reviewMap[hunk.id];
+				const headerLine =
+					hunk.change.originalStartLine > 0
+						? hunk.change.originalStartLine
+						: hunk.change.modifiedStartLine;
+
+				return (
+					<div className="pending-edit-hunk" key={hunk.id}>
+						<button
+							className="pending-edit-hunk-header"
+							onClick={() => onNavigateToLine(headerLine)}
+							type="button"
+						>
+							<span className="pending-edit-hunk-title">Hunk {hunk.index + 1}</span>
+							<span className="pending-edit-hunk-range">
+								-{hunk.change.originalStartLine},{hunk.change.oldLines.length} +
+								{hunk.change.modifiedStartLine},{hunk.change.newLines.length}
+							</span>
+							{status ? (
+								<span className={`pending-edit-hunk-status ${status}`}>
+									{status === "keep" ? "Keep" : "Reject"}
+								</span>
+							) : (
+								<span className="pending-edit-hunk-status pending">Pending</span>
+							)}
+						</button>
+						<div className="pending-edit-hunk-actions">
+							<button
+								className={`btn ${status === "keep" ? "btn-primary" : ""}`}
+								onClick={() => onReviewChange(hunk.id, "keep")}
+								type="button"
+							>
+								Keep
+							</button>
+							<button
+								className={`btn ${status === "reject" ? "btn-primary" : ""}`}
+								onClick={() => onReviewChange(hunk.id, "reject")}
+								type="button"
+							>
+								Reject
+							</button>
+						</div>
+						<div className="pending-edit-lines">
+							{hunk.lines.map((line, index) => (
+								<div
+									className={`pending-edit-line ${line.type}`}
+									key={`${hunk.id}-${index}`}
+								>
+									<span className="line-number old">{line.oldLine ?? ""}</span>
+									<span className="line-number new">{line.newLine ?? ""}</span>
+									<span className="line-content">{line.content}</span>
+								</div>
+							))}
+						</div>
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/client/src/core/state/slices/__tests__/pendingEditSlice.test.ts
+++ b/client/src/core/state/slices/__tests__/pendingEditSlice.test.ts
@@ -45,4 +45,28 @@ describe("pendingEditSlice", () => {
 		store.getState().clearPendingEdit("/foo/bar.R");
 		expect(store.getState().pendingEdits["foo/bar.R"]).toBeUndefined();
 	});
+
+	it("tracks per-change reviews", () => {
+		const store = createTestStore();
+		const edit = makeEdit("foo/bar.R");
+
+		store.getState().registerPendingEdit(edit);
+		store.getState().updatePendingEditReview("foo/bar.R", "change-1", "reject");
+
+		expect(store.getState().pendingEdits["foo/bar.R"]?.reviewedChanges).toEqual({
+			"change-1": "reject",
+		});
+	});
+
+	it("replaces review map", () => {
+		const store = createTestStore();
+		const edit = makeEdit("foo/bar.R");
+
+		store.getState().registerPendingEdit(edit);
+		store.getState().setPendingEditReviewMap("foo/bar.R", { "change-2": "keep" });
+
+		expect(store.getState().pendingEdits["foo/bar.R"]?.reviewedChanges).toEqual({
+			"change-2": "keep",
+		});
+	});
 });

--- a/client/src/core/state/slices/pendingEditSlice.ts
+++ b/client/src/core/state/slices/pendingEditSlice.ts
@@ -1,11 +1,22 @@
 import type { StateCreator } from "zustand";
-import type { PendingEdit, PendingEditStatus } from "@/types/pendingEdit";
+import type {
+	PendingEdit,
+	PendingEditReviewMap,
+	PendingEditReviewStatus,
+	PendingEditStatus,
+} from "@/types/pendingEdit";
 import { normalizeRelativePath } from "@/core/pathUtils";
 
 export interface PendingEditState {
 	pendingEdits: Record<string, PendingEdit>;
 	registerPendingEdit: (edit: PendingEdit) => boolean;
 	updatePendingEditStatus: (filePath: string, status: PendingEditStatus) => void;
+	updatePendingEditReview: (
+		filePath: string,
+		changeId: string,
+		status: PendingEditReviewStatus,
+	) => void;
+	setPendingEditReviewMap: (filePath: string, reviewMap: PendingEditReviewMap) => void;
 	clearPendingEdit: (filePath: string) => void;
 }
 
@@ -17,7 +28,11 @@ export const createPendingEditSlice: StateCreator<PendingEditState> = (set, get)
 		if (pendingEdits[normalizedPath]) {
 			return false;
 		}
-		const normalizedEdit: PendingEdit = { ...edit, filePath: normalizedPath };
+		const normalizedEdit: PendingEdit = {
+			...edit,
+			filePath: normalizedPath,
+			reviewedChanges: edit.reviewedChanges ?? {},
+		};
 		set({
 			pendingEdits: {
 				...pendingEdits,
@@ -37,6 +52,41 @@ export const createPendingEditSlice: StateCreator<PendingEditState> = (set, get)
 					[normalizedPath]: {
 						...existing,
 						status,
+					},
+				},
+			};
+		});
+	},
+	updatePendingEditReview: (filePath, changeId, status) => {
+		const normalizedPath = normalizeRelativePath(filePath, { keepRootEmpty: true });
+		set((state) => {
+			const existing = state.pendingEdits[normalizedPath];
+			if (!existing) return state;
+			return {
+				pendingEdits: {
+					...state.pendingEdits,
+					[normalizedPath]: {
+						...existing,
+						reviewedChanges: {
+							...(existing.reviewedChanges ?? {}),
+							[changeId]: status,
+						},
+					},
+				},
+			};
+		});
+	},
+	setPendingEditReviewMap: (filePath, reviewMap) => {
+		const normalizedPath = normalizeRelativePath(filePath, { keepRootEmpty: true });
+		set((state) => {
+			const existing = state.pendingEdits[normalizedPath];
+			if (!existing) return state;
+			return {
+				pendingEdits: {
+					...state.pendingEdits,
+					[normalizedPath]: {
+						...existing,
+						reviewedChanges: { ...reviewMap },
 					},
 				},
 			};

--- a/client/src/css/components/editor.css
+++ b/client/src/css/components/editor.css
@@ -64,3 +64,140 @@
 	display: flex;
 	gap: 8px;
 }
+
+.pending-edit-review {
+	display: flex;
+	flex-direction: column;
+	border-top: 1px solid var(--border-color, #e0e0e0);
+	border-bottom: 1px solid var(--border-color, #e0e0e0);
+	background: var(--bg-secondary, #f5f5f5);
+}
+
+.pending-edit-review-toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 12px;
+	padding: 8px 12px;
+}
+
+.pending-edit-review-summary {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--text-primary, #1f1f1f);
+}
+
+.pending-edit-review-meta {
+	font-size: 11px;
+	color: var(--text-muted, #666666);
+}
+
+.pending-edit-review-actions {
+	display: flex;
+	gap: 8px;
+	margin-left: auto;
+}
+
+.pending-edit-diff {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 8px 12px 12px;
+}
+
+.pending-edit-hunk {
+	border: 1px solid var(--border-color, #e0e0e0);
+	border-radius: 6px;
+	background: var(--bg-primary, #ffffff);
+	overflow: hidden;
+}
+
+.pending-edit-hunk-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	padding: 6px 10px;
+	border: none;
+	background: var(--bg-tertiary, #f0f0f0);
+	font-size: 11px;
+	color: var(--text-secondary, #444444);
+	cursor: pointer;
+}
+
+.pending-edit-hunk-title {
+	font-weight: 600;
+	color: var(--text-primary, #1f1f1f);
+}
+
+.pending-edit-hunk-range {
+	font-family: "Monaco", "Menlo", "Consolas", monospace;
+	font-size: 10px;
+}
+
+.pending-edit-hunk-status {
+	margin-left: auto;
+	padding: 2px 6px;
+	border-radius: 999px;
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	background: var(--bg-secondary, #f5f5f5);
+	color: var(--text-muted, #666666);
+}
+
+.pending-edit-hunk-status.keep {
+	background: rgba(34, 197, 94, 0.12);
+	color: var(--success-color, #16a34a);
+}
+
+.pending-edit-hunk-status.reject {
+	background: rgba(239, 68, 68, 0.12);
+	color: var(--error-color, #dc2626);
+}
+
+.pending-edit-hunk-actions {
+	display: flex;
+	gap: 8px;
+	padding: 6px 10px;
+	border-bottom: 1px solid var(--border-color, #e0e0e0);
+	background: var(--bg-primary, #ffffff);
+}
+
+.pending-edit-hunk-actions .btn {
+	padding: 4px 8px;
+	font-size: 11px;
+}
+
+.pending-edit-lines {
+	font-family: "Monaco", "Menlo", "Consolas", monospace;
+	font-size: 11px;
+}
+
+.pending-edit-line {
+	display: grid;
+	grid-template-columns: 36px 36px 1fr;
+	gap: 8px;
+	padding: 2px 10px;
+	border-top: 1px solid var(--border-color, #e0e0e0);
+	align-items: baseline;
+}
+
+.pending-edit-line.add {
+	background: rgba(34, 197, 94, 0.08);
+}
+
+.pending-edit-line.remove {
+	background: rgba(239, 68, 68, 0.08);
+}
+
+.line-number {
+	text-align: right;
+	color: var(--text-muted, #666666);
+}
+
+.line-content {
+	white-space: pre-wrap;
+	word-break: break-word;
+}

--- a/client/src/services/pendingEditService.ts
+++ b/client/src/services/pendingEditService.ts
@@ -45,3 +45,25 @@ export async function rejectPendingEdit(edit: PendingEdit): Promise<void> {
 		throw new Error(response.error || "Failed to reject pending edit");
 	}
 }
+
+export async function updatePendingEdit(edit: PendingEdit, newContent: string): Promise<void> {
+	if (edit.source.type !== "acp") {
+		return;
+	}
+
+	if (IS_TAURI) {
+		const { invoke } = await import("@tauri-apps/api/core");
+		await invoke("acp_update_pending_edit", { editId: edit.id, newText: newContent });
+		return;
+	}
+
+	const response = await socketService.request(
+		{ type: "acp_pending_edit_update", edit_id: edit.id, new_text: newContent },
+		"acp_pending_edit_updated",
+		(message) => message.edit_id === edit.id,
+	);
+
+	if (!response.success) {
+		throw new Error(response.error || "Failed to update pending edit");
+	}
+}

--- a/client/src/types/pendingEdit.ts
+++ b/client/src/types/pendingEdit.ts
@@ -4,6 +4,9 @@ export type PendingEditSource =
 
 export type PendingEditStatus = "pending" | "accepted" | "rejected";
 
+export type PendingEditReviewStatus = "keep" | "reject";
+export type PendingEditReviewMap = Record<string, PendingEditReviewStatus>;
+
 export interface PendingEdit {
 	id: string;
 	source: PendingEditSource;
@@ -15,4 +18,5 @@ export interface PendingEdit {
 	expectedSha?: string | null;
 	status: PendingEditStatus;
 	createdAt: number;
+	reviewedChanges?: PendingEditReviewMap;
 }

--- a/client/src/types/ws.ts
+++ b/client/src/types/ws.ts
@@ -144,7 +144,8 @@ export type ClientMessage =
 	| { type: "acp_session_cancel"; session_id: string }
 	| { type: "acp_permission_decision"; decision: AcpPermissionDecision }
 	| { type: "acp_pending_edit_accept"; edit_id: string }
-	| { type: "acp_pending_edit_reject"; edit_id: string };
+	| { type: "acp_pending_edit_reject"; edit_id: string }
+	| { type: "acp_pending_edit_update"; edit_id: string; new_text: string };
 
 type TimelineEventPush = Extract<TimelineMessage, { type: "timeline_event_added" }>;
 
@@ -221,6 +222,7 @@ export type ServerMessage =
 	| { type: "run_started"; run: RunSummary }
 	| ({ type: "run_output" } & RunOutputChunk)
 	| { type: "acp_pending_edit_resolved"; edit_id: string; success: boolean; error?: string | null }
+	| { type: "acp_pending_edit_updated"; edit_id: string; success: boolean; error?: string | null }
 	| { type: "run_finished"; run: RunSummary }
 	| { type: "acp_session_created"; session_id: string }
 	| ({ type: "acp://session-update" } & AcpSessionUpdateEnvelope)

--- a/client/src/utils/__tests__/pendingEditDiff.test.ts
+++ b/client/src/utils/__tests__/pendingEditDiff.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { DiffChange } from "@/utils/pendingEditDiff";
+import { applyPendingEditChanges } from "@/utils/pendingEditDiff";
+
+const makeChange = (overrides: Partial<DiffChange>): DiffChange => ({
+	id: overrides.id ?? "change-1",
+	type: overrides.type ?? "modify",
+	originalStartLine: overrides.originalStartLine ?? 1,
+	originalEndLine: overrides.originalEndLine ?? 1,
+	modifiedStartLine: overrides.modifiedStartLine ?? 1,
+	modifiedEndLine: overrides.modifiedEndLine ?? 1,
+	oldLines: overrides.oldLines ?? [],
+	newLines: overrides.newLines ?? [],
+});
+
+describe("applyPendingEditChanges", () => {
+	it("keeps changes by default", () => {
+		const oldContent = "alpha\nbeta\ngamma";
+		const changes = [
+			makeChange({
+				id: "c1",
+				originalStartLine: 2,
+				originalEndLine: 2,
+				modifiedStartLine: 2,
+				modifiedEndLine: 2,
+				oldLines: ["beta"],
+				newLines: ["beta-next"],
+			}),
+		];
+
+		const result = applyPendingEditChanges(oldContent, changes, {});
+		expect(result).toBe("alpha\nbeta-next\ngamma");
+	});
+
+	it("rejects a modified hunk", () => {
+		const oldContent = "alpha\nbeta\ngamma";
+		const changes = [
+			makeChange({
+				id: "c1",
+				originalStartLine: 2,
+				originalEndLine: 2,
+				modifiedStartLine: 2,
+				modifiedEndLine: 2,
+				oldLines: ["beta"],
+				newLines: ["beta-next"],
+			}),
+		];
+
+		const result = applyPendingEditChanges(oldContent, changes, { c1: "reject" });
+		expect(result).toBe("alpha\nbeta\ngamma");
+	});
+
+	it("handles insertions and deletions", () => {
+		const oldContent = "alpha\nbeta\ngamma";
+		const changes = [
+			makeChange({
+				id: "c1",
+				type: "add",
+				originalStartLine: 2,
+				originalEndLine: 1,
+				modifiedStartLine: 2,
+				modifiedEndLine: 2,
+				oldLines: [],
+				newLines: ["inserted"],
+			}),
+			makeChange({
+				id: "c2",
+				type: "remove",
+				originalStartLine: 3,
+				originalEndLine: 3,
+				modifiedStartLine: 4,
+				modifiedEndLine: 3,
+				oldLines: ["gamma"],
+				newLines: [],
+			}),
+		];
+
+		const result = applyPendingEditChanges(oldContent, changes, { c1: "keep", c2: "keep" });
+		expect(result).toBe("alpha\ninserted\nbeta");
+	});
+
+	it("keeps rejected insertions in place", () => {
+		const oldContent = "alpha\nbeta";
+		const changes = [
+			makeChange({
+				id: "c1",
+				type: "add",
+				originalStartLine: 2,
+				originalEndLine: 1,
+				modifiedStartLine: 2,
+				modifiedEndLine: 2,
+				oldLines: [],
+				newLines: ["inserted"],
+			}),
+		];
+
+		const result = applyPendingEditChanges(oldContent, changes, { c1: "reject" });
+		expect(result).toBe("alpha\nbeta");
+	});
+});

--- a/client/src/utils/pendingEditDiff.ts
+++ b/client/src/utils/pendingEditDiff.ts
@@ -65,11 +65,7 @@ export const buildDiffChanges = (
 		const oldLinesSlice = sliceLines(oldLines, originalStartLine, originalEndLine);
 		const newLinesSlice = sliceLines(newLines, modifiedStartLine, modifiedEndLine);
 		const type =
-			oldLinesSlice.length === 0
-				? "add"
-				: newLinesSlice.length === 0
-					? "remove"
-					: "modify";
+			oldLinesSlice.length === 0 ? "add" : newLinesSlice.length === 0 ? "remove" : "modify";
 
 		return {
 			id: buildChangeId(change, index),

--- a/client/src/utils/pendingEditDiff.ts
+++ b/client/src/utils/pendingEditDiff.ts
@@ -1,0 +1,152 @@
+import type { PendingEditReviewMap } from "@/types/pendingEdit";
+
+export interface DiffChangeRange {
+	originalStartLineNumber: number;
+	originalEndLineNumber: number;
+	modifiedStartLineNumber: number;
+	modifiedEndLineNumber: number;
+}
+
+export interface DiffChange {
+	id: string;
+	type: "add" | "remove" | "modify";
+	originalStartLine: number;
+	originalEndLine: number;
+	modifiedStartLine: number;
+	modifiedEndLine: number;
+	oldLines: string[];
+	newLines: string[];
+}
+
+export interface DiffLine {
+	type: "context" | "add" | "remove";
+	content: string;
+	oldLine?: number;
+	newLine?: number;
+}
+
+export interface DiffHunk {
+	id: string;
+	index: number;
+	change: DiffChange;
+	lines: DiffLine[];
+}
+
+const splitLines = (content: string): string[] => {
+	if (content === "") {
+		return [""];
+	}
+	return content.split(/\r?\n/);
+};
+
+const sliceLines = (lines: string[], start: number, end: number): string[] => {
+	if (start <= 0 || end <= 0 || start > end) {
+		return [];
+	}
+	return lines.slice(start - 1, end);
+};
+
+export const buildChangeId = (range: DiffChangeRange, index: number): string =>
+	`change-${range.originalStartLineNumber}-${range.originalEndLineNumber}-${range.modifiedStartLineNumber}-${range.modifiedEndLineNumber}-${index}`;
+
+export const buildDiffChanges = (
+	oldContent: string,
+	newContent: string,
+	changes: DiffChangeRange[],
+): DiffChange[] => {
+	const oldLines = splitLines(oldContent);
+	const newLines = splitLines(newContent);
+
+	return changes.map((change, index) => {
+		const originalStartLine = change.originalStartLineNumber;
+		const originalEndLine = change.originalEndLineNumber;
+		const modifiedStartLine = change.modifiedStartLineNumber;
+		const modifiedEndLine = change.modifiedEndLineNumber;
+		const oldLinesSlice = sliceLines(oldLines, originalStartLine, originalEndLine);
+		const newLinesSlice = sliceLines(newLines, modifiedStartLine, modifiedEndLine);
+		const type =
+			oldLinesSlice.length === 0
+				? "add"
+				: newLinesSlice.length === 0
+					? "remove"
+					: "modify";
+
+		return {
+			id: buildChangeId(change, index),
+			type,
+			originalStartLine,
+			originalEndLine,
+			modifiedStartLine,
+			modifiedEndLine,
+			oldLines: oldLinesSlice,
+			newLines: newLinesSlice,
+		};
+	});
+};
+
+export const buildDiffHunks = (changes: DiffChange[]): DiffHunk[] => {
+	return changes.map((change, index) => {
+		const lines: DiffLine[] = [];
+		let oldLine = change.originalStartLine;
+		let newLine = change.modifiedStartLine;
+
+		for (const line of change.oldLines) {
+			lines.push({
+				type: "remove",
+				content: line,
+				oldLine,
+			});
+			oldLine += 1;
+		}
+
+		for (const line of change.newLines) {
+			lines.push({
+				type: "add",
+				content: line,
+				newLine,
+			});
+			newLine += 1;
+		}
+
+		return {
+			id: change.id,
+			index,
+			change,
+			lines,
+		};
+	});
+};
+
+export const applyPendingEditChanges = (
+	oldContent: string,
+	changes: DiffChange[],
+	reviewMap: PendingEditReviewMap,
+): string => {
+	const oldLines = splitLines(oldContent);
+	const result: string[] = [];
+	let cursor = 1;
+
+	for (const change of changes) {
+		const startLine = Math.max(change.originalStartLine, 1);
+		const endLine = Math.max(change.originalEndLine, 0);
+
+		if (cursor <= startLine - 1) {
+			result.push(...oldLines.slice(cursor - 1, startLine - 1));
+		}
+
+		const decision = reviewMap[change.id] ?? "keep";
+		if (decision === "keep") {
+			result.push(...change.newLines);
+		} else {
+			result.push(...change.oldLines);
+		}
+
+		cursor = Math.max(endLine + 1, cursor);
+	}
+
+	if (cursor <= oldLines.length) {
+		result.push(...oldLines.slice(cursor - 1));
+	}
+
+	return result.join("\n");
+};

--- a/core/src/acp/gateway.rs
+++ b/core/src/acp/gateway.rs
@@ -215,6 +215,14 @@ impl AcpGateway {
         Ok(())
     }
 
+    pub async fn update_pending_edit(&self, edit_id: &str, new_text: &str) -> Result<()> {
+        let mut store = self.pending_edits.lock().await;
+        store
+            .update_edit_text(edit_id, new_text.to_string())
+            .map_err(|error| anyhow!(error))?;
+        Ok(())
+    }
+
     pub async fn reject_pending_edit(&self, edit_id: &str) -> Result<()> {
         let mut store = self.pending_edits.lock().await;
         if store.remove_edit(edit_id).is_none() {
@@ -487,6 +495,61 @@ mod tests {
         gateway.reject_pending_edit(&pending.id).await.unwrap();
         let disk_contents = fs::read_to_string(&file_path).await.unwrap();
         assert_eq!(disk_contents, "old");
+    }
+
+    #[tokio::test]
+    async fn update_pending_edit_refreshes_overlay() {
+        let workspace = std::env::temp_dir().join(format!("acp-update-{}", Uuid::new_v4()));
+        fs::create_dir_all(&workspace).await.unwrap();
+        let file_path = workspace.join("sample.R");
+        fs::write(&file_path, "old").await.unwrap();
+
+        let gateway = AcpGateway::new(workspace.clone());
+        let request = EditTextFileRequest {
+            path: "sample.R".to_string(),
+            operation: EditOperation::Replace,
+            expected_sha256: None,
+            new_text: Some("new".to_string()),
+            edits: None,
+        };
+        let result = gateway
+            .edit_service
+            .preview_text_file(request, None)
+            .await
+            .unwrap();
+
+        let pending = PendingEdit {
+            id: "edit-update".to_string(),
+            session_id: "s-update".to_string(),
+            tool_call_id: "tool-update".to_string(),
+            file_path: "sample.R".to_string(),
+            old_text: result.old_text.clone(),
+            new_text: result.new_text.clone(),
+            unified_diff: result.unified_diff.clone(),
+            base_sha256: result.old_sha256.clone(),
+            expected_sha256: None,
+        };
+
+        {
+            let mut store = gateway.pending_edits.lock().await;
+            store
+                .register_pending_edit(pending.clone(), &result)
+                .unwrap();
+        }
+
+        gateway
+            .update_pending_edit(&pending.id, "new-updated")
+            .await
+            .unwrap();
+
+        let store = gateway.pending_edits.lock().await;
+        let updated = store.get_edit(&pending.id).unwrap();
+        assert_eq!(updated.new_text, "new-updated");
+        let overlay = store
+            .overlay_for(&pending.session_id, &pending.file_path)
+            .unwrap();
+        assert_eq!(overlay.text, "new-updated");
+        assert_eq!(overlay.sha256, sha256_hex("new-updated"));
     }
 
     #[tokio::test]

--- a/core/src/acp/pending_edit.rs
+++ b/core/src/acp/pending_edit.rs
@@ -70,7 +70,11 @@ impl PendingEditStore {
         self.edits_by_id.get(edit_id).cloned()
     }
 
-    pub fn update_edit_text(&mut self, edit_id: &str, new_text: String) -> Result<PendingEdit, String> {
+    pub fn update_edit_text(
+        &mut self,
+        edit_id: &str,
+        new_text: String,
+    ) -> Result<PendingEdit, String> {
         let edit = self
             .edits_by_id
             .get_mut(edit_id)

--- a/core/src/acp/pending_edit.rs
+++ b/core/src/acp/pending_edit.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use similar::TextDiff;
 
-use crate::edit::EditTextFileResult;
+use crate::edit::{sha256_hex, EditTextFileResult};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -69,6 +70,27 @@ impl PendingEditStore {
         self.edits_by_id.get(edit_id).cloned()
     }
 
+    pub fn update_edit_text(&mut self, edit_id: &str, new_text: String) -> Result<PendingEdit, String> {
+        let edit = self
+            .edits_by_id
+            .get_mut(edit_id)
+            .ok_or_else(|| "Pending edit not found".to_string())?;
+
+        edit.new_text = new_text.clone();
+        edit.unified_diff = unified_diff(&edit.file_path, &edit.old_text, &new_text);
+
+        let overlay_key = overlay_key(&edit.session_id, &edit.file_path);
+        self.overlays.insert(
+            overlay_key,
+            PendingOverlay {
+                text: new_text,
+                sha256: sha256_hex(&edit.new_text),
+            },
+        );
+
+        Ok(edit.clone())
+    }
+
     pub fn remove_edit(&mut self, edit_id: &str) -> Option<PendingEdit> {
         let edit = self.edits_by_id.remove(edit_id)?;
         let file_key = file_key(&edit.session_id, &edit.file_path);
@@ -90,4 +112,11 @@ fn file_key(session_id: &str, file_path: &str) -> String {
 
 fn overlay_key(session_id: &str, file_path: &str) -> String {
     format!("{session_id}:{file_path}")
+}
+
+fn unified_diff(path: &str, old_text: &str, new_text: &str) -> String {
+    TextDiff::from_lines(old_text, new_text)
+        .unified_diff()
+        .header(&format!("a/{}", path), &format!("b/{}", path))
+        .to_string()
 }

--- a/desktop/src/acp/commands.rs
+++ b/desktop/src/acp/commands.rs
@@ -185,3 +185,17 @@ pub async fn acp_reject_pending_edit(state: AcpState<'_>, edit_id: String) -> Re
         .await
         .map_err(|err| err.to_string())
 }
+
+#[tauri::command]
+pub async fn acp_update_pending_edit(
+    state: AcpState<'_>,
+    edit_id: String,
+    new_text: String,
+) -> Result<(), String> {
+    let manager = state.lock().await;
+    manager
+        .update_pending_edit(&edit_id, &new_text)
+        .await
+        .map_err(|err| err.to_string())
+}
+

--- a/desktop/src/acp/mod.rs
+++ b/desktop/src/acp/mod.rs
@@ -96,6 +96,11 @@ impl AcpManager {
         self.gateway.reject_pending_edit(edit_id).await
     }
 
+    pub async fn update_pending_edit(&self, edit_id: &str, new_text: &str) -> Result<()> {
+        self.gateway.update_pending_edit(edit_id, new_text).await
+    }
+
+
     pub async fn shutdown(&mut self) {
         if let Some(handles) = self.forwarders.take() {
             handles.updates.abort();

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -66,6 +66,7 @@ async fn main() {
             acp::commands::acp_set_agent_config,
             acp::commands::acp_accept_pending_edit,
             acp::commands::acp_reject_pending_edit,
+            acp::commands::acp_update_pending_edit,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/server/src/acp.rs
+++ b/server/src/acp.rs
@@ -130,6 +130,14 @@ impl AcpService {
         Ok(())
     }
 
+    pub async fn update_pending_edit(&self, edit_id: &str, new_text: &str) -> Result<()> {
+        self.rate_limit("pending_edit_update").await?;
+        self.ensure_agent_running().await?;
+        let gateway = self.gateway.lock().await;
+        gateway.update_pending_edit(edit_id, new_text).await?;
+        Ok(())
+    }
+
     pub async fn subscribe_session_updates(&self) -> broadcast::Receiver<AcpSessionUpdateEnvelope> {
         let gateway = self.gateway.lock().await;
         gateway.subscribe_session_updates()

--- a/server/src/handlers/acp_handler.rs
+++ b/server/src/handlers/acp_handler.rs
@@ -104,3 +104,23 @@ pub async fn handle_acp_pending_edit_reject(
         }),
     }
 }
+
+pub async fn handle_acp_pending_edit_update(
+    runtime: &Arc<ProjectRuntime>,
+    edit_id: &str,
+    new_text: &str,
+) -> Vec<WSResponse> {
+    match runtime.acp.update_pending_edit(edit_id, new_text).await {
+        Ok(()) => single_response(WSResponse::AcpPendingEditUpdated {
+            edit_id: edit_id.to_string(),
+            success: true,
+            error: None,
+        }),
+        Err(error) => single_response(WSResponse::AcpPendingEditUpdated {
+            edit_id: edit_id.to_string(),
+            success: false,
+            error: Some(error.to_string()),
+        }),
+    }
+}
+

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -186,6 +186,8 @@ pub(super) enum WSRequest {
     AcpPendingEditAccept { edit_id: String },
     #[serde(rename = "acp_pending_edit_reject")]
     AcpPendingEditReject { edit_id: String },
+    #[serde(rename = "acp_pending_edit_update")]
+    AcpPendingEditUpdate { edit_id: String, new_text: String },
 }
 
 #[derive(serde::Serialize)]
@@ -273,6 +275,13 @@ pub(super) enum WSResponse {
     ProjectStateSaved { project_id: String },
     #[serde(rename = "acp_pending_edit_resolved")]
     AcpPendingEditResolved {
+        edit_id: String,
+        success: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    #[serde(rename = "acp_pending_edit_updated")]
+    AcpPendingEditUpdated {
         edit_id: String,
         success: bool,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -37,8 +37,9 @@ pub use common::AppState;
 
 use crate::projects::RuntimeBroadcastEvent;
 use acp_handler::{
-    handle_acp_pending_edit_accept, handle_acp_pending_edit_reject, handle_acp_permission_decision,
-    handle_acp_session_cancel, handle_acp_session_create, handle_acp_session_prompt,
+    handle_acp_pending_edit_accept, handle_acp_pending_edit_reject, handle_acp_pending_edit_update,
+    handle_acp_permission_decision, handle_acp_session_cancel, handle_acp_session_create,
+    handle_acp_session_prompt,
 };
 use ai_handler::handle_ai_message;
 use common::{error_response, WSRequest, WSResponse};
@@ -309,6 +310,9 @@ async fn handle_ws_request(
         }
         WSRequest::AcpPendingEditReject { edit_id } => {
             handle_acp_pending_edit_reject(runtime, &edit_id).await
+        }
+        WSRequest::AcpPendingEditUpdate { edit_id, new_text } => {
+            handle_acp_pending_edit_update(runtime, &edit_id, &new_text).await
         }
         _ => Vec::new(),
     }


### PR DESCRIPTION
## Description

- Add editor-pane pending edit diff review with per-hunk keep/reject controls.
- Apply reviewed changes to the editor buffer and enforce read-only review mode until resolved.
- Support ACP pending edit updates so partial accepts persist before final accept.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `.husky/pre-push`
- `pnpm -r lint`
- `pnpm --filter client build`
- `pnpm --filter client test -- --run`
- `cargo check --workspace`
- `cargo test --workspace --lib --all-features`
- `cargo test --test export_integration_test -- --nocapture`
- `cargo test --test timeline_integration_test -- --nocapture`
- `cargo test --test rmarkdown_integration_test -- --nocapture`
- `cargo test --test tool_manifests_test -- --nocapture`
- `cargo test --test viral_phylogenomics_workflow_test -- --nocapture`

## Screenshots (if applicable)

N/A

## Related Issues

Closes #319
