### PR TITLE
Fix ACP pending edit diff path matching

### DIFF
--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -14,8 +14,9 @@ import { ConfirmDialog, IconPlay, IconPlayCircle, useToast } from "@/components/
 import { useStore } from "@/core";
 import { computeTargetRange, findCodeInEditor, matchPatchChunk } from "@/core/ai/contextMatcher";
 import { commandRegistry } from "@/core/commands/registry";
+import { useFileSystemStore } from "@/core/fileSystemStore";
 import type { AppliedCodeChange } from "@/core/state/slices/editorSlice";
-import { normalizeRelativePath } from "@/core/pathUtils";
+import { normalizeWorkspaceRelativePath } from "@/core/pathUtils";
 import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { useEditorCells } from "@/hooks/useEditorCells";
 import { useEditorDecorations } from "@/hooks/useEditorDecorations";
@@ -37,6 +38,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const editor = useStore((state) => state.editor);
 	const execution = useStore((state) => state.execution);
 	const settings = useStore((state) => state.settings);
+	const workspaceRoot = useFileSystemStore((state) => state.workspaceRoot);
 	const setEditorContent = useStore((state) => state.setEditorContent);
 	const setEditorCursorPosition = useStore((state) => state.setEditorCursorPosition);
 	const setApplyCodeChange = useStore((state) => state.setApplyCodeChange);
@@ -47,8 +49,8 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const recordPatchMatchFailure = useStore((state) => state.recordPatchMatchFailure);
 	const recordPatchMatchSuccess = useStore((state) => state.recordPatchMatchSuccess);
 	const normalizedEditorPath = useMemo(
-		() => normalizeRelativePath(editor.filepath, { keepRootEmpty: true }),
-		[editor.filepath],
+		() => normalizeWorkspaceRelativePath(editor.filepath, workspaceRoot, { keepRootEmpty: true }),
+		[editor.filepath, workspaceRoot],
 	);
 	const pendingEdit = useStore((state) => state.pendingEdits[normalizedEditorPath]);
 	const clearPendingEdit = useStore((state) => state.clearPendingEdit);

--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -45,6 +45,12 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 		hunks: DiffHunk[];
 	};
 
+	const getHunkHeaderLine = useCallback((hunk: DiffHunk): number => {
+		return hunk.change.originalStartLine > 0
+			? hunk.change.originalStartLine
+			: hunk.change.modifiedStartLine;
+	}, []);
+
 	const toast = useToast();
 	const editor = useStore((state) => state.editor);
 	const execution = useStore((state) => state.execution);
@@ -252,10 +258,35 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 
 	const handlePendingReviewChange = useCallback(
 		(changeId: string, status: PendingEditReviewStatus) => {
-			if (!pendingEdit) return;
+			if (!pendingEdit || !pendingEditDiff) return;
 			updatePendingEditReview(pendingEdit.filePath, changeId, status);
+			const nextReviewMap: PendingEditReviewMap = {
+				...pendingEditReviewMap,
+				[changeId]: status,
+			};
+			const currentIndex = pendingEditDiff.hunks.findIndex((hunk) => hunk.id === changeId);
+			const startIndex = currentIndex >= 0 ? currentIndex + 1 : 0;
+			const nextPending =
+				pendingEditDiff.hunks.slice(startIndex).find((hunk) => !nextReviewMap[hunk.id]) ??
+				pendingEditDiff.hunks.find((hunk) => !nextReviewMap[hunk.id]);
+
+			if (nextPending) {
+				const targetLine = getHunkHeaderLine(nextPending);
+				if (typeof requestAnimationFrame === "function") {
+					requestAnimationFrame(() => navigateToLine(targetLine));
+				} else {
+					navigateToLine(targetLine);
+				}
+			}
 		},
-		[pendingEdit, updatePendingEditReview],
+		[
+			getHunkHeaderLine,
+			navigateToLine,
+			pendingEdit,
+			pendingEditDiff,
+			pendingEditReviewMap,
+			updatePendingEditReview,
+		],
 	);
 
 	const handlePendingKeepAll = useCallback(() => {

--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -29,11 +29,22 @@ import {
 import type { CodeBlock, CodeRange } from "@/types";
 import type { PendingEditReviewMap, PendingEditReviewStatus } from "@/types/pendingEdit";
 import { clamp } from "@/utils/math";
-import { applyPendingEditChanges, buildDiffChanges, buildDiffHunks } from "@/utils/pendingEditDiff";
+import {
+	applyPendingEditChanges,
+	buildDiffChanges,
+	buildDiffHunks,
+	type DiffChange,
+	type DiffHunk,
+} from "@/utils/pendingEditDiff";
 import { PendingEditDiffView } from "./PendingEditDiffView";
 import type { EditorRef } from "./editorRef";
 
 function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Element {
+	type PendingEditDiff = {
+		changes: DiffChange[];
+		hunks: DiffHunk[];
+	};
+
 	const toast = useToast();
 	const editor = useStore((state) => state.editor);
 	const execution = useStore((state) => state.execution);
@@ -68,32 +79,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 		message: string;
 	} | null>(null);
 	const pendingEditReviewMap = pendingEdit?.reviewedChanges ?? {};
-	const pendingEditDiff = useMemo(() => {
-		if (!pendingEdit || !monacoInstance) return null;
-		const language = monacoEditorRef.current?.getModel()?.getLanguageId();
-		if (typeof document === "undefined") {
-			return null;
-		}
-		const original = monacoInstance.editor.createModel(pendingEdit.oldContent, language);
-		const modified = monacoInstance.editor.createModel(pendingEdit.newContent, language);
-		const diffContainer = document.createElement("div");
-		const diffEditor = monacoInstance.editor.createDiffEditor(diffContainer, {
-			readOnly: true,
-		});
-		try {
-			diffEditor.setModel({ original, modified });
-			const changes = diffEditor.getLineChanges() ?? [];
-			const diffChanges = buildDiffChanges(pendingEdit.oldContent, pendingEdit.newContent, changes);
-			return {
-				changes: diffChanges,
-				hunks: buildDiffHunks(diffChanges),
-			};
-		} finally {
-			diffEditor.dispose();
-			original.dispose();
-			modified.dispose();
-		}
-	}, [monacoInstance, pendingEdit]);
+	const [pendingEditDiff, setPendingEditDiff] = useState<PendingEditDiff | null>(null);
 	const reviewedContent = useMemo(() => {
 		if (!pendingEdit || !pendingEditDiff) return null;
 		return applyPendingEditChanges(
@@ -121,6 +107,51 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 		}
 		return { total: pendingEditDiff.changes.length, keep, reject, pending };
 	}, [pendingEditDiff, pendingEditReviewMap]);
+
+	useEffect(() => {
+		if (!pendingEdit || !monacoInstance) {
+			setPendingEditDiff(null);
+			return;
+		}
+		if (typeof document === "undefined") {
+			setPendingEditDiff(null);
+			return;
+		}
+
+		setPendingEditDiff(null);
+
+		const language = monacoEditorRef.current?.getModel()?.getLanguageId();
+		const original = monacoInstance.editor.createModel(pendingEdit.oldContent, language);
+		const modified = monacoInstance.editor.createModel(pendingEdit.newContent, language);
+		const diffContainer = document.createElement("div");
+		const diffEditor = monacoInstance.editor.createDiffEditor(diffContainer, {
+			readOnly: true,
+		});
+		let disposed = false;
+
+		const updateDiff = (): void => {
+			if (disposed) return;
+			const changes = diffEditor.getLineChanges();
+			if (!changes) return;
+			const diffChanges = buildDiffChanges(pendingEdit.oldContent, pendingEdit.newContent, changes);
+			setPendingEditDiff({
+				changes: diffChanges,
+				hunks: buildDiffHunks(diffChanges),
+			});
+		};
+
+		const subscription = diffEditor.onDidUpdateDiff(updateDiff);
+		diffEditor.setModel({ original, modified });
+		updateDiff();
+
+		return () => {
+			disposed = true;
+			subscription.dispose();
+			diffEditor.dispose();
+			original.dispose();
+			modified.dispose();
+		};
+	}, [monacoInstance, pendingEdit]);
 
 	const cells = useEditorCells(editor.content, editor.filepath);
 	const { state, actions } = useEditorExecution({
@@ -720,17 +751,21 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 								</button>
 							</div>
 						</div>
-						{pendingEditDiff && pendingEditDiff.hunks.length > 0 ? (
-							<PendingEditDiffView
-								hunks={pendingEditDiff.hunks}
-								reviewMap={pendingEditReviewMap}
-								onReviewChange={handlePendingReviewChange}
-								onNavigateToLine={navigateToLine}
-							/>
+						{pendingEditDiff ? (
+							pendingEditDiff.hunks.length > 0 ? (
+								<PendingEditDiffView
+									hunks={pendingEditDiff.hunks}
+									reviewMap={pendingEditReviewMap}
+									onReviewChange={handlePendingReviewChange}
+									onNavigateToLine={navigateToLine}
+								/>
+							) : (
+								<div className="pending-edit-message warning">
+									No pending changes detected in the diff view.
+								</div>
+							)
 						) : (
-							<div className="pending-edit-message warning">
-								No pending changes detected in the diff view.
-							</div>
+							<div className="pending-edit-message warning">Preparing diff preview...</div>
 						)}
 					</div>
 				)}

--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -256,6 +256,23 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 		}
 	}, [clearPendingEdit, pendingEdit, setEditorContent, updatePendingEditStatus]);
 
+	const navigateToLine = useCallback((lineNumber: number): void => {
+		const monacoEditor = monacoEditorRef.current;
+		if (!monacoEditor) {
+			return;
+		}
+
+		const model = monacoEditor.getModel();
+		if (!model) {
+			return;
+		}
+
+		const clampLine = clamp(lineNumber, 1, model.getLineCount());
+		monacoEditor.revealLine(clampLine);
+		monacoEditor.setPosition({ lineNumber: clampLine, column: 1 });
+		monacoEditor.focus();
+	}, []);
+
 	const handlePendingReviewChange = useCallback(
 		(changeId: string, status: PendingEditReviewStatus) => {
 			if (!pendingEdit || !pendingEditDiff) return;
@@ -345,23 +362,6 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 			setEditorContent(value);
 		}
 	};
-
-	const navigateToLine = useCallback((lineNumber: number): void => {
-		const monacoEditor = monacoEditorRef.current;
-		if (!monacoEditor) {
-			return;
-		}
-
-		const model = monacoEditor.getModel();
-		if (!model) {
-			return;
-		}
-
-		const clampLine = clamp(lineNumber, 1, model.getLineCount());
-		monacoEditor.revealLine(clampLine);
-		monacoEditor.setPosition({ lineNumber: clampLine, column: 1 });
-		monacoEditor.focus();
-	}, []);
 
 	const focusEditor = useCallback((): void => {
 		const monacoEditor = monacoEditorRef.current;

--- a/client/src/core/__tests__/pathUtils.test.ts
+++ b/client/src/core/__tests__/pathUtils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { normalizeWorkspaceRelativePath, ROOT_PATH } from "@/core/pathUtils";
+
+describe("normalizeWorkspaceRelativePath", () => {
+	it("normalizes absolute paths relative to the workspace root", () => {
+		expect(
+			normalizeWorkspaceRelativePath("/Users/me/project/src/file.ts", "/Users/me/project"),
+		).toBe("src/file.ts");
+	});
+
+	it("keeps relative paths unchanged when they are already relative", () => {
+		expect(normalizeWorkspaceRelativePath("src/file.ts", "/Users/me/project")).toBe("src/file.ts");
+	});
+
+	it("returns the root placeholder when pointing at the workspace root", () => {
+		expect(normalizeWorkspaceRelativePath("/Users/me/project", "/Users/me/project")).toBe(
+			ROOT_PATH,
+		);
+		expect(
+			normalizeWorkspaceRelativePath("/Users/me/project", "/Users/me/project", {
+				keepRootEmpty: true,
+			}),
+		).toBe("");
+	});
+
+	it("handles Windows-style paths", () => {
+		expect(normalizeWorkspaceRelativePath("C:\\repo\\proj\\src\\file.ts", "C:\\repo\\proj")).toBe(
+			"src/file.ts",
+		);
+	});
+});

--- a/client/src/core/pathUtils.ts
+++ b/client/src/core/pathUtils.ts
@@ -18,6 +18,28 @@ export const normalizeRelativePath = (
 	return normalized;
 };
 
+export const normalizeWorkspaceRelativePath = (
+	path: string,
+	workspaceRoot: string,
+	options?: { keepRootEmpty?: boolean },
+): string => {
+	if (!path) {
+		return normalizeRelativePath(path, options);
+	}
+	const normalizedRoot = normalizeSeparators(workspaceRoot).replace(/\/+$/, "");
+	const normalizedPath = normalizeSeparators(path);
+	if (normalizedRoot) {
+		if (normalizedPath === normalizedRoot) {
+			return options?.keepRootEmpty ? "" : ROOT_PATH;
+		}
+		if (normalizedPath.startsWith(`${normalizedRoot}/`)) {
+			const relative = normalizedPath.slice(normalizedRoot.length + 1);
+			return normalizeRelativePath(relative, options);
+		}
+	}
+	return normalizeRelativePath(path, options);
+};
+
 export const normalizePathInput = (path: string): string => {
 	const normalized = normalizeRelativePath(path, { keepRootEmpty: true });
 	return normalized || ROOT_PATH;

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useStore } from "@/core";
+import { useFileSystemStore } from "@/core/fileSystemStore";
 import { buildPromptWithContext, createRequestId } from "@/core/ai/promptUtils";
 import { getAcpSystemPrompts } from "@/core/ai/systemPrompts";
-import { normalizeRelativePath } from "@/core/pathUtils";
+import { normalizeWorkspaceRelativePath } from "@/core/pathUtils";
 import { getExternalAgentClient } from "@/services/externalAgentClient";
 import { aiMessages } from "@/services/messageBuilders";
 import { socketService } from "@/services/socket";
@@ -54,6 +55,7 @@ export function useAIConversation() {
 	const editorContent = useStore((state) => state.editor.content);
 	const editorFilepath = useStore((state) => state.editor.filepath);
 	const consoleHistory = useStore((state) => state.execution.results);
+	const workspaceRoot = useFileSystemStore((state) => state.workspaceRoot);
 
 	const { clearTimeoutRef, startTimeout } = useAITimeout();
 	const { registerStreamingHandlers } = useAIStreaming();
@@ -184,12 +186,18 @@ export function useAIConversation() {
 				) {
 					const editPayload = (output as { edit?: any }).edit;
 					if (editPayload && typeof editPayload === "object") {
-						const normalizedFilePath = normalizeRelativePath(String(editPayload.file_path ?? ""), {
-							keepRootEmpty: true,
-						});
-						const normalizedEditorPath = normalizeRelativePath(editorFilepath, {
-							keepRootEmpty: true,
-						});
+						const normalizedFilePath = normalizeWorkspaceRelativePath(
+							String(editPayload.file_path ?? ""),
+							workspaceRoot,
+							{ keepRootEmpty: true },
+						);
+						const normalizedEditorPath = normalizeWorkspaceRelativePath(
+							editorFilepath,
+							workspaceRoot,
+							{
+								keepRootEmpty: true,
+							},
+						);
 						const pendingEdit: PendingEdit = {
 							id: String(editPayload.id ?? ""),
 							source: { type: "acp", sessionId: payload.session_id },
@@ -230,6 +238,7 @@ export function useAIConversation() {
 			editorFilepath,
 			setEditorContent,
 			startStreamingMessage,
+			workspaceRoot,
 			updatePlan,
 		],
 	);


### PR DESCRIPTION
## Description

- Normalize ACP pending edit paths against the workspace root so diff review shows when ACP sends absolute paths.
- Align pending edit lookup to the same normalization as ACP registration.
- Wait for Monaco diff computation before rendering hunks, and show a "Preparing diff preview..." placeholder while loading.
- Jump to the next pending hunk after Keep/Reject to streamline review.
- Add unit coverage for workspace-aware path normalization.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`) (script not available)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `pnpm -r lint`
- `pnpm --filter client build`
- `pnpm --filter client test -- --run`
- `cargo check --workspace`
- `cargo test --workspace --lib --all-features`
- `cd core && cargo test --test export_integration_test -- --nocapture`
- `cd core && cargo test --test timeline_integration_test -- --nocapture`
- `cd core && cargo test --test rmarkdown_integration_test -- --nocapture`
- `cd core && cargo test --test tool_manifests_test -- --nocapture`
- `cd core && cargo test --test viral_phylogenomics_workflow_test -- --nocapture`

## Screenshots (if applicable)

- N/A

## Related Issues

Closes #N/A
