### PR TITLE
Add clickable read file indicators

### DIFF
--- a/client/src/components/ai-panel/FileAccessIndicator.css
+++ b/client/src/components/ai-panel/FileAccessIndicator.css
@@ -1,0 +1,42 @@
+.file-access-indicator {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	margin: 8px 0;
+	padding: 8px 12px;
+	background: var(--bg-secondary);
+	border-radius: 6px;
+	border-left: 3px solid var(--accent-blue);
+}
+
+.file-access-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.file-access-icon {
+	flex-shrink: 0;
+	font-size: 14px;
+}
+
+.file-access-path {
+	font-family: monospace;
+	color: var(--text-primary);
+	word-break: break-all;
+}
+
+.file-access-button {
+	background: transparent;
+	border: none;
+	padding: 0;
+	text-align: left;
+	cursor: pointer;
+}
+
+.file-access-button:hover,
+.file-access-button:focus-visible {
+	text-decoration: underline;
+}

--- a/client/src/components/ai-panel/FileAccessIndicator.tsx
+++ b/client/src/components/ai-panel/FileAccessIndicator.tsx
@@ -1,0 +1,27 @@
+import "./FileAccessIndicator.css";
+
+interface Props {
+	filePaths: string[];
+	onOpenPath?: (path: string) => void;
+}
+
+export function FileAccessIndicator({ filePaths, onOpenPath }: Props): JSX.Element {
+	return (
+		<div className="file-access-indicator">
+			{filePaths.map((path) => (
+				<div key={path} className="file-access-item">
+					<span className="file-access-icon" aria-hidden="true">
+						🔍
+					</span>
+					<button
+						type="button"
+						className="file-access-button file-access-path"
+						onClick={() => onOpenPath?.(path)}
+					>
+						{path}
+					</button>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/client/src/components/ai-panel/Markdown.css
+++ b/client/src/components/ai-panel/Markdown.css
@@ -15,6 +15,11 @@
 	margin-bottom: 0 !important;
 }
 
+/* Ensure content doesn't get clipped in message-streaming-text container */
+.message-streaming-text .markdown-body {
+	padding-top: 6px;
+}
+
 /* Headings */
 .markdown-body h1,
 .markdown-body h2,
@@ -70,14 +75,14 @@
 
 /* Code blocks */
 .markdown-body pre {
-	padding: 16px;
+	padding: 8px;
 	overflow: auto;
 	font-size: 85%;
 	line-height: 1.45;
 	background-color: var(--code-block-bg, #f6f8fa);
 	border-radius: 6px;
 	margin-top: 0;
-	margin-bottom: 16px;
+	margin-bottom: 8px;
 }
 
 .markdown-body pre code {
@@ -105,7 +110,7 @@
 }
 
 .markdown-body li > p {
-	margin-top: 16px;
+	margin-top: 8px;
 }
 
 .markdown-body li + li {
@@ -128,7 +133,7 @@
 	color: var(--text-secondary, #656d76);
 	border-left: 0.25em solid var(--border-accent, #d0d7de);
 	margin-top: 0;
-	margin-bottom: 16px;
+	margin-bottom: 8px;
 }
 
 .markdown-body blockquote > :first-child {
@@ -148,7 +153,7 @@
 	max-width: 100%;
 	overflow: auto;
 	margin-top: 0;
-	margin-bottom: 16px;
+	margin-bottom: 8px;
 }
 
 .markdown-body table th {
@@ -215,7 +220,7 @@
 /* Paragraphs */
 .markdown-body p {
 	margin-top: 0;
-	margin-bottom: 16px;
+	margin-bottom: 8px;
 }
 
 /* Images */

--- a/client/src/components/ai-panel/StreamingMessage.tsx
+++ b/client/src/components/ai-panel/StreamingMessage.tsx
@@ -1,11 +1,15 @@
+import { useCallback, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
-import { BrailleSpinner } from "@/components/shared";
-import type { AIMessage, CodeBlock } from "@/types";
+import { useStore } from "@/core";
+import { BrailleSpinner, useToast } from "@/components/shared";
+import { fileSystem } from "@/services/fileSystem";
+import type { AIMessage, CodeBlock, ToolCallLog as ToolCallLogEntry } from "@/types";
 import { classNames } from "@/utils/classNames";
 import { AIPlanCard } from "./AIPlanCard";
 import { CodeBlockWithApply } from "./CodeBlockWithApply";
+import { FileAccessIndicator } from "./FileAccessIndicator";
 import { ToolCallLog } from "./ToolCallLog";
 import "github-markdown-css/github-markdown.css";
 import "./Markdown.css";
@@ -21,7 +25,54 @@ function stripPatchBlocks(content: string): string {
 	return content.replace(/\*\*\* Begin Patch[\s\S]*?\*\*\* End Patch/g, "").trim();
 }
 
+const READ_TOOL_NAMES = new Set(["read", "read file", "read_file", "read_text_file"]);
+
+const isReadTool = (name?: string): boolean => {
+	if (!name) return false;
+	const normalized = name.trim().toLowerCase();
+	if (READ_TOOL_NAMES.has(normalized)) return true;
+	return normalized.includes("read") && normalized.includes("file");
+};
+
+const extractReadPathFromInput = (input?: Record<string, unknown>): string | null => {
+	if (!input) return null;
+	const candidate = input.path ?? input.file_path ?? input.filePath;
+	if (typeof candidate === "string" && candidate.trim()) {
+		return candidate.trim();
+	}
+	return null;
+};
+
+const extractReadFilePaths = (logs?: ToolCallLogEntry[]): string[] => {
+	if (!logs || logs.length === 0) return [];
+	const seen = new Set<string>();
+	const result: string[] = [];
+
+	for (const log of logs) {
+		if (log.status !== "done") continue;
+		if (!isReadTool(log.name)) continue;
+
+		const path =
+			extractReadPathFromInput(log.input) ??
+			(log.locations && log.locations.length > 0 ? log.locations[0] : null);
+
+		if (typeof path === "string" && path.trim()) {
+			const trimmed = path.trim();
+			if (!seen.has(trimmed)) {
+				seen.add(trimmed);
+				result.push(trimmed);
+			}
+		}
+	}
+
+	return result;
+};
+
 export function StreamingMessage({ message, onApplyCode }: Props): JSX.Element {
+	const setEditorContent = useStore((state) => state.setEditorContent);
+	const setEditorFilepath = useStore((state) => state.setEditorFilepath);
+	const setEditorIsDirty = useStore((state) => state.setEditorIsDirty);
+	const toast = useToast();
 	const isAssistant = message.role === "assistant";
 	const isStreaming = Boolean(message.streamingId && !message.isComplete);
 	const hasPlan = Boolean(message.planSteps && message.planSteps.length > 0);
@@ -31,6 +82,21 @@ export function StreamingMessage({ message, onApplyCode }: Props): JSX.Element {
 
 	// Strip patch blocks from content to avoid duplicate display
 	const displayContent = message.content ? stripPatchBlocks(message.content) : "";
+	const readFilePaths = useMemo(() => extractReadFilePaths(message.toolLogs), [message.toolLogs]);
+	const handleOpenPath = useCallback(
+		async (path: string) => {
+			try {
+				const content = await fileSystem.readFile(path);
+				setEditorContent(content);
+				setEditorFilepath(path);
+				setEditorIsDirty(false);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : "Unknown error";
+				toast.showError(`Failed to open file: ${message}`);
+			}
+		},
+		[setEditorContent, setEditorFilepath, setEditorIsDirty, toast],
+	);
 
 	// Custom components for react-markdown
 	const markdownComponents: Components = {
@@ -118,6 +184,10 @@ export function StreamingMessage({ message, onApplyCode }: Props): JSX.Element {
 
 			{isAssistant && (
 				<>
+					{readFilePaths.length > 0 && (
+						<FileAccessIndicator filePaths={readFilePaths} onOpenPath={handleOpenPath} />
+					)}
+
 					{hasPlan && <AIPlanCard steps={message.planSteps} />}
 
 					{hasTools && <ToolCallLog logs={message.toolLogs} />}

--- a/client/src/components/ai-panel/__tests__/StreamingMessage.test.tsx
+++ b/client/src/components/ai-panel/__tests__/StreamingMessage.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useStore } from "@/core";
+import type { AIMessage } from "@/types";
+import { StreamingMessage } from "../StreamingMessage";
+
+const { readFileMock } = vi.hoisted(() => ({
+	readFileMock: vi.fn().mockResolvedValue("file contents"),
+}));
+
+vi.mock("@/services/fileSystem", () => ({
+	fileSystem: {
+		readFile: readFileMock,
+	},
+}));
+
+vi.mock("@/components/shared", async () => {
+	const actual = await vi.importActual<typeof import("@/components/shared")>("@/components/shared");
+	return {
+		...actual,
+		useToast: () => ({
+			showToast: vi.fn(),
+			showInfo: vi.fn(),
+			showSuccess: vi.fn(),
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+		}),
+	};
+});
+
+const renderMessage = (overrides: Partial<AIMessage> = {}) => {
+	const message: AIMessage = {
+		id: "msg-1",
+		role: "assistant",
+		content: "",
+		timestamp: Date.now(),
+		...overrides,
+	};
+
+	return render(<StreamingMessage message={message} onApplyCode={async () => undefined} />);
+};
+
+beforeEach(() => {
+	readFileMock.mockClear();
+	useStore.setState((state) => ({
+		editor: {
+			...state.editor,
+			content: "",
+			filepath: "",
+			isDirty: false,
+		},
+	}));
+});
+
+describe("StreamingMessage read file indicator", () => {
+	it("renders completed read tool paths", () => {
+		renderMessage({
+			toolLogs: [
+				{
+					id: "tool-1",
+					name: "read_text_file",
+					status: "done",
+					input: { path: "analysis.R" },
+				},
+			],
+		});
+
+		expect(screen.getByRole("button", { name: "analysis.R" })).toBeInTheDocument();
+	});
+
+	it("opens the file in the editor when a path is clicked", async () => {
+		renderMessage({
+			toolLogs: [
+				{
+					id: "tool-2",
+					name: "read_text_file",
+					status: "done",
+					input: { path: "analysis.R" },
+				},
+			],
+		});
+
+		await userEvent.click(screen.getByRole("button", { name: "analysis.R" }));
+
+		await waitFor(() => {
+			expect(readFileMock).toHaveBeenCalledWith("analysis.R");
+		});
+
+		const state = useStore.getState().editor;
+		expect(state.filepath).toBe("analysis.R");
+		expect(state.content).toBe("file contents");
+		expect(state.isDirty).toBe(false);
+	});
+});


### PR DESCRIPTION
## Description

Add a read-file indicator in AI streaming messages and make the file paths clickable to open in the editor.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `pnpm --filter client test`
- `pnpm -r lint`
- `pnpm --filter client build`
- `cargo check --workspace`
- `cargo test --workspace --lib --all-features`
- `cd core && cargo test --test export_integration_test -- --nocapture`
- `cd core && cargo test --test timeline_integration_test -- --nocapture`
- `cd core && cargo test --test rmarkdown_integration_test -- --nocapture`
- `cd core && cargo test --test tool_manifests_test -- --nocapture`
- `cd core && cargo test --test viral_phylogenomics_workflow_test -- --nocapture`
- `pnpm --filter client test -- --run`

## Screenshots (if applicable)

N/A

## Related Issues

Closes #343
