### PR TITLE
Show ACP thought and tool updates

### DIFF
--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -79,6 +79,7 @@ export function useAIConversation() {
 	});
 	const acpSessionIdRef = useRef<string | null>(null);
 	const acpStreamsRef = useRef<Map<string, string>>(new Map());
+	const acpLastChunkKindRef = useRef<Map<string, "message" | "thought" | "tool">>(new Map());
 	const acpConfigured = activeMode === "external_agent" && Boolean(activeAgent);
 	const externalAgentClient = acpConfigured ? getExternalAgentClient() : null;
 
@@ -118,16 +119,63 @@ export function useAIConversation() {
 		};
 	}, [clearActiveRequest, clearTimeoutRef]);
 
-	const extractAcpText = useCallback(
-		(update: AcpSessionUpdateEnvelope["update"]): string | null => {
+	const extractAcpChunk = useCallback(
+		(
+			update: AcpSessionUpdateEnvelope["update"],
+		): { kind: "message" | "thought"; text: string } | null => {
 			if (typeof update !== "object" || update === null) return null;
-			if (!("AgentMessageChunk" in update)) return null;
-			const value = update.AgentMessageChunk;
+			if (!("AgentMessageChunk" in update) && !("AgentThoughtChunk" in update)) return null;
+			const kind = "AgentThoughtChunk" in update ? "thought" : "message";
+			const value =
+				"AgentThoughtChunk" in update ? update.AgentThoughtChunk : update.AgentMessageChunk;
 			if (typeof value === "object" && "text" in value) {
 				const candidate = (value as { text?: unknown }).text;
-				return typeof candidate === "string" ? candidate : null;
+				if (typeof candidate === "string") {
+					return { kind, text: candidate };
+				}
+				return null;
 			}
 			return null;
+		},
+		[],
+	);
+
+	const appendAcpChunk = useCallback(
+		(streamingId: string, kind: "message" | "thought" | "tool", text: string) => {
+			if (!text) return;
+			const lastKind = acpLastChunkKindRef.current.get(streamingId);
+			let prefix = "";
+
+			if (kind === "thought") {
+				if (lastKind !== "thought") {
+					prefix = `${lastKind ? "\n\n" : ""}[Thought]\n`;
+				}
+			} else if (kind === "tool") {
+				if (lastKind !== "tool") {
+					prefix = `${lastKind ? "\n\n" : ""}[Tool]\n`;
+				}
+			} else if (lastKind && lastKind !== "message") {
+				prefix = "\n\n";
+			}
+
+			acpLastChunkKindRef.current.set(streamingId, kind);
+			appendChunk(streamingId, `${prefix}${text}`);
+		},
+		[appendChunk],
+	);
+
+	const summarizeAcpToolCall = useCallback((toolCall: { title: string; status: string }) => {
+		const status = toolCall.status?.trim();
+		return status ? `${toolCall.title} (${status})` : toolCall.title;
+	}, []);
+
+	const summarizeAcpToolUpdate = useCallback(
+		(toolUpdate: { status: string | null; content: string | null }) => {
+			if (toolUpdate.content && toolUpdate.content.trim()) {
+				return toolUpdate.content;
+			}
+			const status = toolUpdate.status ?? "running";
+			return `Status: ${status}`;
 		},
 		[],
 	);
@@ -140,6 +188,7 @@ export function useAIConversation() {
 			);
 			const finalContent = message?.content ?? "";
 			finalize(streamingId, finalContent);
+			acpLastChunkKindRef.current.delete(streamingId);
 			clearActiveRequest();
 		},
 		[clearActiveRequest, finalize],
@@ -170,6 +219,7 @@ export function useAIConversation() {
 
 			// Handle ToolCall
 			if (typeof update === "object" && update !== null && "ToolCall" in update) {
+				appendAcpChunk(streamingId, "tool", summarizeAcpToolCall(update.ToolCall));
 				recordTool(streamingId, mapToolCall(update.ToolCall));
 				return;
 			}
@@ -177,6 +227,7 @@ export function useAIConversation() {
 			// Handle ToolCallUpdate
 			if (typeof update === "object" && update !== null && "ToolCallUpdate" in update) {
 				const toolUpdate = update.ToolCallUpdate;
+				appendAcpChunk(streamingId, "tool", summarizeAcpToolUpdate(toolUpdate));
 				const output = toolUpdate.output;
 				if (
 					output &&
@@ -222,18 +273,20 @@ export function useAIConversation() {
 			}
 
 			// Handle text chunks
-			const text = extractAcpText(update);
-			if (!text) return;
-			appendChunk(streamingId, text);
+			const chunk = extractAcpChunk(update);
+			if (!chunk) return;
+			appendAcpChunk(streamingId, chunk.kind, chunk.text);
 		},
 		[
-			appendChunk,
-			extractAcpText,
+			appendAcpChunk,
+			extractAcpChunk,
 			finalizeAcpStream,
 			mapPlanSteps,
 			mapToolCall,
 			mapToolCallUpdate,
 			recordTool,
+			summarizeAcpToolCall,
+			summarizeAcpToolUpdate,
 			registerPendingEdit,
 			editorFilepath,
 			setEditorContent,
@@ -280,6 +333,7 @@ export function useAIConversation() {
 		const acpStreamId = acpStreamsRef.current.get(acpSessionIdRef.current);
 		if (acpStreamId) {
 			completeStreamingMessage(acpStreamId);
+			acpLastChunkKindRef.current.delete(acpStreamId);
 		}
 	}, [completeStreamingMessage, externalAgentClient]);
 
@@ -289,6 +343,7 @@ export function useAIConversation() {
 		const streamingId = activeRequestRef.current?.id;
 		if (streamingId) {
 			completeStreamingMessage(streamingId);
+			acpLastChunkKindRef.current.delete(streamingId);
 			clearActiveRequest();
 		} else if (acpConfigured && acpSessionIdRef.current) {
 			void cancelAcpSession();


### PR DESCRIPTION
## Description

- Surface ACP AgentThoughtChunk and tool events in streaming assistant message with labeled sections.
- Keep ToolCallLog updates intact while improving real-time visibility.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `.husky/pre-push`
- `pnpm -r lint`
- `pnpm --filter client build`
- `cargo check --workspace`
- `cargo test --workspace --lib --all-features`
- `cd core && cargo test --test export_integration_test -- --nocapture`
- `cd core && cargo test --test timeline_integration_test -- --nocapture`
- `cd core && cargo test --test rmarkdown_integration_test -- --nocapture`
- `cd core && cargo test --test tool_manifests_test -- --nocapture`
- `cd core && cargo test --test viral_phylogenomics_workflow_test -- --nocapture`
- `pnpm --filter client test -- --run`

## Screenshots (if applicable)

- N/A

## Related Issues

- Closes #344
