### PR TITLE
Stabilize basic Playwright run and add AIPanel test

### DIFF
--- a/client/src/components/ai-panel/__tests__/AIPanel.test.tsx
+++ b/client/src/components/ai-panel/__tests__/AIPanel.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useStore } from "@/core";
+import { useSettingsStore } from "@/core/state/slices/settingsStore";
+import { AIPanel } from "../AIPanel";
+
+vi.mock("@/hooks/useAIConversation", () => ({
+	useAIConversation: () => ({
+		aiState: {
+			input: "",
+			messages: [],
+			isLoading: false,
+		},
+		aiActions: {
+			setInput: vi.fn(),
+			ask: vi.fn(),
+			stop: vi.fn(),
+			applyCode: vi.fn(),
+		},
+		promptHistory: {
+			navigateUp: vi.fn(),
+			navigateDown: vi.fn(),
+			resetNavigation: vi.fn(),
+		},
+	}),
+}));
+
+vi.mock("../ProviderSwitcher", () => ({
+	ProviderSwitcher: () => <div data-testid="provider-switcher" />,
+}));
+
+vi.mock("../StreamingMessage", () => ({
+	StreamingMessage: () => <div data-testid="streaming-message" />,
+}));
+
+describe("AIPanel provider indicator", () => {
+	beforeEach(() => {
+		useStore.setState({
+			activeMode: "api",
+			activeAgent: null,
+			detectedAgents: [],
+		});
+		useSettingsStore.setState({
+			activeProvider: "openai",
+			providers: [
+				{
+					name: "openai",
+					displayName: "OpenAI",
+					models: [],
+					activeModel: "gpt-4o",
+					isConfigured: true,
+					metadata: {
+						name: "openai",
+						displayName: "OpenAI",
+						icon: {
+							path: "/icons/providers/OpenAI-black-monoblossom.svg",
+							alt: "OpenAI",
+							format: "svg",
+						},
+					},
+				},
+			],
+		});
+	});
+
+	it("shows the active API provider icon and label", () => {
+		render(<AIPanel hasConfiguredProvider />);
+
+		expect(screen.getByAltText("OpenAI")).toBeInTheDocument();
+		expect(screen.getByText("OpenAI")).toBeInTheDocument();
+	});
+
+	it("shows the active external agent icon and label", () => {
+		useStore.setState({
+			activeMode: "external_agent",
+			activeAgent: "gemini",
+			detectedAgents: [
+				{
+					id: "gemini",
+					name: "Gemini CLI",
+					command: "gemini",
+					available: true,
+					path: null,
+				},
+			],
+		});
+
+		render(<AIPanel hasConfiguredProvider />);
+
+		expect(screen.getByAltText("Google Gemini")).toBeInTheDocument();
+		expect(screen.getByText("Gemini")).toBeInTheDocument();
+	});
+});

--- a/desktop/e2e/shared/helpers.ts
+++ b/desktop/e2e/shared/helpers.ts
@@ -55,6 +55,11 @@ export async function waitForConsoleOutput(
 ) {
 	const timeout = options.timeout || 30000;
 
+	const consoleTab = page.locator('button:has-text("Console")');
+	if (await consoleTab.isVisible()) {
+		await consoleTab.click();
+	}
+
 	await page.waitForFunction(
 		({ selector, text }) => {
 			const outputs = document.querySelectorAll(selector);

--- a/desktop/e2e/tests/r-execution.spec.ts
+++ b/desktop/e2e/tests/r-execution.spec.ts
@@ -11,8 +11,8 @@ test.describe("R execution flow", () => {
 		const editor = page.locator(selectors.editor);
 		await editor.waitFor({ timeout: 30000 });
 
-		// Execute simple R code
-		await executeRCode(page, "1 + 1");
+		// Execute simple R code (explicit print ensures output in non-interactive runs)
+		await executeRCode(page, "print(1 + 1)");
 
 		// Wait for output to appear
 		await waitForConsoleOutput(page, "[1] 2", { timeout: 30000 });
@@ -31,7 +31,7 @@ test.describe("R execution flow", () => {
 		// Execute multiple lines
 		const code = `x <- 5
 y <- 10
-x + y`;
+print(x + y)`;
 
 		await executeRCode(page, code);
 


### PR DESCRIPTION
## Description

- Stabilize Playwright R execution tests by ensuring Console tab is active and using explicit print output.
- Add component test for AI provider indicator in the AIPanel.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `pnpm --filter @reprod/e2e test tests/r-execution.spec.ts`
- `pnpm --filter client test -- --run src/components/ai-panel/__tests__/AIPanel.test.tsx`

## Screenshots (if applicable)

- N/A

## Related Issues

- N/A
