### PR TITLE
Consolidate placeholder pattern validation logic (#329)

### DIFF
--- a/client/src/constants/placeholders.ts
+++ b/client/src/constants/placeholders.ts
@@ -1,0 +1,12 @@
+/**
+ * Placeholder patterns used to detect invalid or placeholder file paths
+ * in AI code actions.
+ *
+ * These patterns indicate that a file path is a placeholder and should not
+ * be treated as a valid file path.
+ */
+export const EDITOR_BUFFER_PLACEHOLDER_PATTERNS = [
+	"<current editor buffer>",
+	"current editor buffer",
+	"current_editor_buffer",
+] as const;

--- a/client/src/core/ai/actions/BaseCodeAction.ts
+++ b/client/src/core/ai/actions/BaseCodeAction.ts
@@ -1,5 +1,6 @@
 import type { CodeBlock } from "@/types";
 import { isEmptyString } from "@/utils/string";
+import { EDITOR_BUFFER_PLACEHOLDER_PATTERNS } from "@/constants/placeholders";
 import type { CodeActionContext, CodeActionValidation, ICodeAction } from "./ICodeAction";
 
 /**
@@ -59,14 +60,8 @@ export abstract class BaseCodeAction implements ICodeAction {
 	): boolean {
 		if (!targetFile) return true;
 
-		const placeholderPatterns = [
-			"<current editor buffer>",
-			"current editor buffer",
-			"current_editor_buffer",
-		];
-
 		return (
-			placeholderPatterns.some((pattern) => targetFile.includes(pattern)) ||
+			EDITOR_BUFFER_PLACEHOLDER_PATTERNS.some((pattern) => targetFile.includes(pattern)) ||
 			targetFile.startsWith("<") ||
 			targetFile === editorFilepath
 		);

--- a/client/src/core/ai/actions/actions/CreateFileAction.ts
+++ b/client/src/core/ai/actions/actions/CreateFileAction.ts
@@ -1,5 +1,6 @@
 import type { CodeBlock } from "@/types";
 import { isEmptyString } from "@/utils/string";
+import { EDITOR_BUFFER_PLACEHOLDER_PATTERNS } from "@/constants/placeholders";
 import type { CodeActionContext, CodeActionValidation, ICodeAction } from "../ICodeAction";
 
 /**
@@ -23,13 +24,9 @@ export class CreateFileAction implements ICodeAction {
 		}
 
 		// Check for placeholder/invalid paths
-		const invalidPatterns = [
-			"<current editor buffer>",
-			"current editor buffer",
-			"current_editor_buffer",
-		];
-
-		if (invalidPatterns.some((pattern) => codeBlock.filepath?.includes(pattern))) {
+		if (
+			EDITOR_BUFFER_PLACEHOLDER_PATTERNS.some((pattern) => codeBlock.filepath?.includes(pattern))
+		) {
 			return {
 				valid: false,
 				error: "Cannot create file with placeholder path",

--- a/client/src/core/ai/actions/actions/ReplaceAllAction.ts
+++ b/client/src/core/ai/actions/actions/ReplaceAllAction.ts
@@ -1,5 +1,6 @@
 import type { CodeBlock } from "@/types";
 import { isEmptyString } from "@/utils/string";
+import { EDITOR_BUFFER_PLACEHOLDER_PATTERNS } from "@/constants/placeholders";
 import type { CodeActionContext, CodeActionValidation, ICodeAction } from "../ICodeAction";
 /**
  * Action for replacing entire file contents
@@ -47,14 +48,8 @@ export class ReplaceAllAction implements ICodeAction {
 	): boolean {
 		if (!targetFile) return true;
 
-		const placeholderPatterns = [
-			"<current editor buffer>",
-			"current editor buffer",
-			"current_editor_buffer",
-		];
-
 		return (
-			placeholderPatterns.some((pattern) => targetFile.includes(pattern)) ||
+			EDITOR_BUFFER_PLACEHOLDER_PATTERNS.some((pattern) => targetFile.includes(pattern)) ||
 			targetFile.startsWith("<") ||
 			targetFile === editorFilepath
 		);


### PR DESCRIPTION
## Summary
- Eliminated duplicate placeholder pattern arrays across AI code action files
- Created centralized constant file for shared placeholder patterns
- Updated all action files to import from the new constant location

## Changes
- Created `client/src/constants/placeholders.ts` with `EDITOR_BUFFER_PLACEHOLDER_PATTERNS`
- Updated `BaseCodeAction.ts` to use centralized constants
- Updated `ReplaceAllAction.ts` to use centralized constants
- Updated `CreateFileAction.ts` to use centralized constants

## Technical Details
Previously, three files (`BaseCodeAction.ts`, `ReplaceAllAction.ts`, and `CreateFileAction.ts`) each defined the same placeholder patterns array independently. This created maintenance overhead and increased the risk of inconsistency.

Now all files import `EDITOR_BUFFER_PLACEHOLDER_PATTERNS` from a single source, making the codebase more maintainable and ensuring consistency across all placeholder validation logic.

## Testing
- TypeScript compilation: Passed
- Biome linting: Passed
- Pre-commit/pre-push hooks: Passed

Fixes #329