### PR TITLE
test: add file explorer e2e coverage (#350)

### DIFF
--- a/desktop/e2e/shared/fixtures/file-explorer-fixture.R
+++ b/desktop/e2e/shared/fixtures/file-explorer-fixture.R
@@ -1,0 +1,3 @@
+# Fixture used by Playwright E2E tests.
+fixture_value <- 42
+print("File Explorer fixture loaded")

--- a/desktop/e2e/shared/selectors.ts
+++ b/desktop/e2e/shared/selectors.ts
@@ -5,6 +5,12 @@
 export const selectors = {
 	// Editor
 	editor: ".monaco-editor textarea",
+	editorTitle: ".editor-panel .panel-title",
+
+	// File browser
+	fileBrowser: ".file-browser",
+	fileTreeNode: ".file-tree-node",
+	fileTreeLabel: ".file-tree-label",
 
 	// Buttons
 	runButton: 'button[title="Run All (Cmd/Ctrl+Shift+Enter)"]',

--- a/desktop/e2e/tests/file-explorer.spec.ts
+++ b/desktop/e2e/tests/file-explorer.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+import { selectors } from "../shared/selectors";
+
+test.describe("File Explorer", () => {
+	test("opens a file and loads editor tab/content", async ({ page }) => {
+		const fixtureFileName = "file-explorer-fixture.R";
+		const fixtureText = "File Explorer fixture loaded";
+
+		await page.goto("/");
+
+		const fileBrowser = page.locator(selectors.fileBrowser);
+		await expect(fileBrowser).toBeVisible({ timeout: 30000 });
+
+		const fileTreeNodeAtDepth = (name: string, depth: number) => {
+			const padding = depth * 16 + 12;
+			return page.locator(`${selectors.fileTreeNode}[style*="padding-left: ${padding}px"]`).filter({
+				has: page.locator(selectors.fileTreeLabel, { hasText: name }),
+			});
+		};
+
+		const ensureFolderExpanded = async (
+			name: string,
+			depth: number,
+			childName: string,
+			childDepth: number,
+		) => {
+			const node = fileTreeNodeAtDepth(name, depth).first();
+			await expect(node).toBeVisible({ timeout: 30000 });
+
+			const childNode = fileTreeNodeAtDepth(childName, childDepth);
+			if ((await childNode.count()) === 0) {
+				await node.click();
+			}
+
+			await expect(childNode.first()).toBeVisible({ timeout: 30000 });
+		};
+
+		await ensureFolderExpanded("desktop", 0, "e2e", 1);
+		await ensureFolderExpanded("e2e", 1, "shared", 2);
+		await ensureFolderExpanded("shared", 2, "fixtures", 3);
+
+		const fixtureNode = fileTreeNodeAtDepth(fixtureFileName, 4).first();
+		await expect(fixtureNode).toBeVisible({ timeout: 30000 });
+		await fixtureNode.dblclick();
+
+		const editorTitle = page.locator(selectors.editorTitle);
+		await expect(editorTitle).toContainText(fixtureFileName, { timeout: 30000 });
+
+		await page.waitForFunction(
+			(expected) => {
+				const monaco = (window as { monaco?: any }).monaco;
+				const editors = monaco?.editor?.getEditors?.() ?? [];
+				return (editors[0]?.getValue?.() ?? "").includes(expected);
+			},
+			fixtureText,
+			{ timeout: 30000 },
+		);
+	});
+});

--- a/desktop/e2e/tests/file-explorer.spec.ts
+++ b/desktop/e2e/tests/file-explorer.spec.ts
@@ -18,6 +18,11 @@ test.describe("File Explorer", () => {
 			});
 		};
 
+		const fileTreeNodeByLabel = (name: string) =>
+			page
+				.locator(selectors.fileTreeNode)
+				.filter({ has: page.locator(selectors.fileTreeLabel, { hasText: name }) });
+
 		const ensureFolderExpanded = async (
 			name: string,
 			depth: number,
@@ -38,8 +43,9 @@ test.describe("File Explorer", () => {
 		await ensureFolderExpanded("desktop", 0, "e2e", 1);
 		await ensureFolderExpanded("e2e", 1, "shared", 2);
 		await ensureFolderExpanded("shared", 2, "fixtures", 3);
+		await ensureFolderExpanded("fixtures", 3, fixtureFileName, 4);
 
-		const fixtureNode = fileTreeNodeAtDepth(fixtureFileName, 4).first();
+		const fixtureNode = fileTreeNodeByLabel(fixtureFileName).first();
 		await expect(fixtureNode).toBeVisible({ timeout: 30000 });
 		await fixtureNode.dblclick();
 


### PR DESCRIPTION
## Description

Add a deterministic Playwright E2E test that opens a fixture file from the File Explorer and verifies the editor tab label and Monaco content. Also adds the fixture file and shared selectors to support the test. Generated TypeScript bindings were updated as part of the existing toolchain.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `.husky/pre-push`
- `pnpm -r lint`
- `pnpm --filter client build`
- `cargo check --workspace`
- `cargo test --workspace --lib --all-features`
- `cargo test --test export_integration_test -- --nocapture`
- `cargo test --test timeline_integration_test -- --nocapture`
- `cargo test --test rmarkdown_integration_test -- --nocapture`
- `cargo test --test tool_manifests_test -- --nocapture`
- `cargo test --test viral_phylogenomics_workflow_test -- --nocapture`
- `pnpm --filter client test -- --run`
- `pnpm --filter @reprod/e2e test -- file-explorer.spec.ts`

## Screenshots (if applicable)

N/A - test-only change.

## Related Issues

Closes #350