### PR TITLE
Standardize empty catch block documentation (#335)

### DIFF
--- a/client/src/components/ai-panel/CodeBlockWithApply.tsx
+++ b/client/src/components/ai-panel/CodeBlockWithApply.tsx
@@ -37,7 +37,10 @@ export function CodeBlockWithApply({ codeBlock, onApply, showDiffPreview }: Prop
 		try {
 			await onApply(currentBlock);
 			setApplied(true);
-		} catch {}
+		} catch {
+			// Intentionally ignored: Apply errors are handled by the onApply callback.
+			// The UI state remains unchanged, allowing users to retry or edit.
+		}
 	};
 
 	const handleCopy = (): void => {
@@ -47,7 +50,10 @@ export function CodeBlockWithApply({ codeBlock, onApply, showDiffPreview }: Prop
 				setCopied(true);
 				setTimeout(() => setCopied(false), COPY_FEEDBACK_DURATION);
 			})
-			.catch(() => {});
+			.catch(() => {
+				// Intentionally ignored: Clipboard write failures are silent.
+				// The copy button simply won't show success feedback if it fails.
+			});
 	};
 
 	const handleRetry = (): void => {

--- a/client/src/core/ai/actions/CodeActionFactory.ts
+++ b/client/src/core/ai/actions/CodeActionFactory.ts
@@ -56,6 +56,8 @@ export class CodeActionFactory {
 			const action = CodeActionFactory.getAction(codeBlock);
 			return action.getLabel(codeBlock);
 		} catch {
+			// Intentionally ignored: Unknown action types fall back to generic label.
+			// This allows UI to display a reasonable label even for unsupported actions.
 			return "Apply suggested change";
 		}
 	}

--- a/client/src/services/socket.ts
+++ b/client/src/services/socket.ts
@@ -63,7 +63,10 @@ class SocketService {
 				this.dispatch("*", response);
 				// Deliver to one-shot handler matching this message
 				this.consumeOneShot(response);
-			} catch (e) {}
+			} catch (e) {
+				// Intentionally ignored: Malformed WebSocket messages are ignored to prevent
+				// service disruption. The connection remains open and will process valid messages.
+			}
 		};
 
 		this.ws.onerror = () => {
@@ -272,7 +275,10 @@ class SocketService {
 		handlers?.forEach((handler) => {
 			try {
 				handler(message);
-			} catch {}
+			} catch {
+				// Intentionally ignored: Individual handler errors should not prevent other
+				// handlers from processing the message. Faulty handlers are isolated.
+			}
 		});
 	}
 
@@ -290,14 +296,20 @@ class SocketService {
 		const [{ handler }] = this.oneShotHandlers.splice(index, 1);
 		try {
 			handler(message);
-		} catch {}
+		} catch {
+			// Intentionally ignored: One-shot handler errors are isolated to prevent
+			// disruption of the WebSocket service. The handler is consumed and removed.
+		}
 	}
 
 	private notifyConnection(status: ConnectionStatus): void {
 		this.connectionListeners.forEach((listener) => {
 			try {
 				listener(status);
-			} catch {}
+			} catch {
+				// Intentionally ignored: Individual listener errors should not prevent other
+				// listeners from being notified. Faulty listeners are isolated.
+			}
 		});
 	}
 

--- a/client/src/theme/index.ts
+++ b/client/src/theme/index.ts
@@ -18,7 +18,8 @@ export function applyTheme(theme: ThemeName): ThemeName {
 	try {
 		window.localStorage.setItem(STORAGE_KEY, theme);
 	} catch {
-		/* ignore storage failures (private mode, etc.) */
+		// Intentionally ignored: localStorage write failures (private mode, quota exceeded)
+		// do not prevent theme application. Theme is applied to DOM regardless.
 	}
 
 	return theme;
@@ -31,6 +32,8 @@ export function getStoredTheme(): ThemeName | null {
 		const stored = window.localStorage.getItem(STORAGE_KEY);
 		return stored === "phylo" ? stored : null;
 	} catch {
+		// Intentionally ignored: localStorage read failures (private mode, disabled storage)
+		// return null, causing the app to fall back to default theme.
 		return null;
 	}
 }


### PR DESCRIPTION
## Summary

Added explicit comments to all empty catch blocks explaining why errors are intentionally ignored and what fallback behavior occurs. This improves code maintainability and helps future developers understand error handling decisions.

## Changes

### client/src/services/socket.ts (4 catch blocks)
- **WebSocket message parsing**: Malformed messages are ignored to prevent service disruption
- **Message handler errors**: Individual handler errors are isolated from other handlers
- **One-shot handler errors**: Handler errors are isolated, handler is still consumed
- **Connection listener errors**: Individual listener errors don't prevent other notifications

### client/src/core/ai/actions/CodeActionFactory.ts (1 catch block)
- **Unknown action types**: Falls back to generic label for UI display

### client/src/components/ai-panel/CodeBlockWithApply.tsx (2 catch blocks)
- **Apply errors**: Errors are handled by callback, UI remains unchanged for retry
- **Clipboard failures**: Silent failure, success feedback simply doesn't show

### client/src/theme/index.ts (2 catch blocks)
- **localStorage write failures**: Theme is applied to DOM regardless of storage
- **localStorage read failures**: Falls back to default theme

## Comment Format

All catch blocks now follow a consistent format:

```typescript
catch {
  // Intentionally ignored: [reason why error can be safely ignored]
  // [what fallback behavior occurs]
}
```

## Testing

- TypeScript compilation: Passed
- Biome formatting: Passed
- Pre-commit/pre-push hooks: Passed
- No runtime behavior changes

## Impact

- **No functional changes**: Only documentation improvements
- **Better maintainability**: Future developers understand error handling decisions
- **Consistent style**: All empty catch blocks follow same format

Fixes #335