### PR TITLE
Improve ACP settings UI layout

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -31,13 +31,13 @@ print_status() {
     fi
 }
 
-# Check 1: Biome formatting check
-echo -e "${YELLOW}[1/4]${NC} Checking Biome formatting..."
-if pnpm biome format > /dev/null 2>&1; then
-    print_status 0 "Biome formatting check passed"
+# Check 1: Biome formatting (auto-apply)
+echo -e "${YELLOW}[1/4]${NC} Formatting with Biome..."
+if pnpm format > /dev/null 2>&1; then
+    print_status 0 "Biome formatting applied"
 else
-    print_status 1 "Biome formatting issues found"
-    echo "  → Run 'pnpm format' to fix formatting"
+    print_status 1 "Biome formatting failed"
+    echo "  → Run 'pnpm format' to see details"
     echo ""
 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,9 @@
 # AGENT Instruction
 
-You are an agent to be responsible our code.
-This open-source will be enlarged in the future.
+You are an agent to be responsible for our code.
 Before it's getting busy, we must stick with the code quality to keep the maintainability.
+
+Please read CONTRIBUTING.md as well.
 
 ## SOLID principles
 
@@ -32,15 +33,13 @@ But don't stick with this rule too much, if over-engineering leads code complexi
 
 ## Unit test
 
-Unit tests are first-class citizens
-, which meansthey must express concrete, non-arbitrary acceptance/behavior criteria.
 Unit tests should serve as a low-level specification (a contract) for each unit: given certain inputs/preconditions, the unit must behave in a defined way (outputs, side-effects, invariants).
-Ideally, development follows a test-first approach (e.g. TDD or ATDD), where behavior or acceptance criteria are defined before implementing functionality — so tests drive design, not the other way around.
+The development must follow a test-first approach supported by Kent Beck or T-Wada, where behavior or acceptance criteria are defined before implementing functionality with red flags.
 
 ## Development workflow
 
-- After finishing edits, run `git add` and `git commit`,
-  then execute the pre-push in `.husky` and CI/CD checks defined in `.github`.
+- Frequent run of `git add` and `git commit` is recommended.
+- After finishing edits, then execute the pre-push in `.husky` and CI/CD checks defined in `.github`.
 
 ## Allowed Commands (Project-Level)
 
@@ -76,6 +75,8 @@ The following commands are always allowed without asking for permission:
 If you are asked to work in worktree dir, **never damage the main dir**. Please work only in worktree dir.
 
 ### GitHub CLI (gh)
+
+Please use the following commands if you are asked to create an issue or PR.
 
 - `gh pr create` - Create pull requests (never ask permission)
 - `gh pr list`, `gh pr view`, `gh pr status` - View PR information

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ git checkout -b feature/your-feature-name
 git checkout -b fix/issue-number-description
 ```
 
+Branch names such as `test-XX` and `issue-YYY` are not acceptable.
+
 ### 3. Make Your Changes
 
 - Write clean, readable code

--- a/client/src/components/agent/ExternalAgentSettingsPane.tsx
+++ b/client/src/components/agent/ExternalAgentSettingsPane.tsx
@@ -5,19 +5,12 @@ import { getAcpAdminClient } from "@/services/acpAdminClient";
 import { classNames } from "@/utils/classNames";
 
 export function ExternalAgentSettingsPane(): JSX.Element {
-	const activeMode = useStore((state) => state.activeMode);
 	const activeAgent = useStore((state) => state.activeAgent);
 	const detectedAgents = useStore((state) => state.detectedAgents);
 	const setActiveMode = useStore((state) => state.setActiveMode);
 	const setActiveAgent = useStore((state) => state.setActiveAgent);
 	const setDetectedAgents = useStore((state) => state.setDetectedAgents);
-	const isWindows = typeof navigator !== "undefined" && navigator.userAgent.includes("Windows");
 	const acpAdminClient = useMemo(() => getAcpAdminClient(), []);
-
-	const availableAgents = useMemo(
-		() => detectedAgents.filter((agent) => agent.available),
-		[detectedAgents],
-	);
 
 	const fetchAgentsAsync = useCallback(async () => {
 		const { config, agents } = await acpAdminClient.bootstrap();
@@ -39,16 +32,6 @@ export function ExternalAgentSettingsPane(): JSX.Element {
 		await acpAdminClient.setConfig(mode, agent);
 	};
 
-	const handleModeChange = async (mode: "api" | "external_agent") => {
-		setActiveMode(mode);
-		if (mode === "api") {
-			setActiveAgent(null);
-			await persistConfig(mode, null);
-		} else {
-			await persistConfig(mode, activeAgent);
-		}
-	};
-
 	const handleSelectAgent = async (agentId: string) => {
 		setActiveMode("external_agent");
 		setActiveAgent(agentId);
@@ -57,82 +40,42 @@ export function ExternalAgentSettingsPane(): JSX.Element {
 
 	return (
 		<div className="external-agent-pane">
-			<div className="settings-row">
-				<span>
-					Mode
-					<small>Switch between built-in providers and an external ACP agent.</small>
-				</span>
-				<div
-					className="settings-radio-group"
-					style={{ display: "flex", flexDirection: "column", gap: 8 }}
+			<div className="external-agent-header">
+				<h3>External Agents (ACP)</h3>
+				<button
+					type="button"
+					className="btn btn-secondary"
+					onClick={fetchAgents}
+					disabled={loading}
 				>
-					<label>
-						<input
-							type="radio"
-							name="agent-mode"
-							checked={activeMode === "api"}
-							onChange={() => handleModeChange("api")}
-						/>
-						Use API providers
-					</label>
-					<label>
-						<input
-							type="radio"
-							name="agent-mode"
-							checked={activeMode === "external_agent"}
-							onChange={() => handleModeChange("external_agent")}
-						/>
-						External agent (ACP)
-					</label>
-				</div>
+					{loading ? "Refreshing..." : "Refresh"}
+				</button>
 			</div>
-			{activeMode === "external_agent" && (
-				<div className="settings-block">
-					<div className="settings-row">
-						<span>
-							Detected agents
-							<small>macOS/Linux only; refresh after installing binaries.</small>
-						</span>
-						<button
-							type="button"
-							className="btn btn-secondary"
-							onClick={fetchAgents}
-							disabled={loading}
-						>
-							{loading ? "Checking..." : "Refresh"}
-						</button>
-					</div>
-					<div className="agent-list">
-						{detectedAgents.map((agent) => (
-							<label
-								key={agent.id}
-								className={classNames("agent-row", !agent.available && "disabled")}
-							>
-								<input
-									type="radio"
-									name="agent-select"
-									disabled={!agent.available}
-									checked={activeAgent === agent.id}
-									onChange={() => handleSelectAgent(agent.id)}
-								/>
-								<div className="agent-info">
-									<div className="agent-name">
-										{agent.name} {agent.available ? "" : "(not found)"}
-									</div>
-									<div className="agent-path">{agent.path ?? agent.command}</div>
-								</div>
-							</label>
-						))}
-						{detectedAgents.length === 0 && <div className="agent-empty">No known agents yet.</div>}
-						{availableAgents.length === 0 && (
-							<div className="agent-empty-note">
-								Install an ACP agent (e.g. claude-code-acp, codex-acp) and refresh.
-								{isWindows && " On Windows, ensure the binary (or .cmd) is on PATH."}
+			<div className="agent-list">
+				{detectedAgents.map((agent) => (
+					<label
+						key={agent.id}
+						className={classNames("agent-item", !agent.available && "disabled")}
+					>
+						<input
+							type="radio"
+							name="agent-select"
+							disabled={!agent.available}
+							checked={activeAgent === agent.id}
+							onChange={() => void handleSelectAgent(agent.id)}
+						/>
+						<div className="agent-info">
+							<div className="agent-name">
+								{agent.name} {agent.available ? "" : "(not found)"}
 							</div>
-						)}
-					</div>
-				</div>
-			)}
+							<div className="agent-path">{agent.path ?? agent.command}</div>
+						</div>
+					</label>
+				))}
+				{detectedAgents.length === 0 && (
+					<div className="agent-empty">No agents found. Install an ACP agent and refresh.</div>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/client/src/components/agent/__tests__/ExternalAgentSettingsPane.test.tsx
+++ b/client/src/components/agent/__tests__/ExternalAgentSettingsPane.test.tsx
@@ -71,4 +71,28 @@ describe("ExternalAgentSettingsPane", () => {
 		await waitFor(() => expect(setConfigMock).toHaveBeenCalledWith("external_agent", "claude"));
 		expect(useStore.getState().activeAgent).toBe("claude");
 	});
+
+	it("toggles the refresh button label based on loading state", async () => {
+		let resolveBootstrap: ((value: any) => void) | null = null;
+		bootstrapMock.mockReturnValue(
+			new Promise((resolve) => {
+				resolveBootstrap = resolve;
+			}),
+		);
+
+		const { getByText } = render(<ExternalAgentSettingsPane />);
+
+		await waitFor(() => expect(getByText("Refreshing...")).toBeTruthy());
+
+		resolveBootstrap?.({
+			config: {
+				active_mode: "external_agent",
+				active_agent: null,
+				active_agent_command: null,
+			},
+			agents: [],
+		});
+
+		await waitFor(() => expect(getByText("Refresh")).toBeTruthy());
+	});
 });

--- a/client/src/components/modals/SettingsModal.tsx
+++ b/client/src/components/modals/SettingsModal.tsx
@@ -4,6 +4,7 @@ import { DEFAULT_SETTINGS } from "@/constants/defaultSettings";
 import { useStore } from "@/core";
 import type { AppSettings } from "@/types";
 import { ExternalAgentSettingsPane } from "../agent/ExternalAgentSettingsPane";
+import { AIProviderSettingsPane } from "../settings/AIProviderSettingsPane";
 import { SettingsPanel } from "../settings/SettingsPanel";
 import { ModalShell } from "./ModalShell";
 
@@ -17,6 +18,7 @@ type SettingKey = keyof AppSettings;
 export function SettingsModal({ open, onClose }: SettingsModalProps): JSX.Element | null {
 	const settings = useStore((state) => state.settings);
 	const updateSettings = useStore((state) => state.updateSettings);
+	const activeMode = useStore((state) => state.activeMode);
 	const [draft, setDraft] = useState<AppSettings>(settings);
 
 	useEffect(() => {
@@ -63,6 +65,11 @@ export function SettingsModal({ open, onClose }: SettingsModalProps): JSX.Elemen
 			}
 		>
 			<form id="settings-form" className="settings-form" onSubmit={handleSubmit}>
+				<section>
+					<h3>AI Provider</h3>
+					<AIProviderSettingsPane />
+				</section>
+
 				<section>
 					<h3>General</h3>
 					<label className="settings-row">
@@ -136,15 +143,18 @@ export function SettingsModal({ open, onClose }: SettingsModalProps): JSX.Elemen
 					</label>
 				</section>
 
-				<section>
-					<h3>LLM Providers</h3>
-					<SettingsPanel />
-				</section>
+				{activeMode === "api" && (
+					<section>
+						<h3>API Providers</h3>
+						<SettingsPanel />
+					</section>
+				)}
 
-				<section>
-					<h3>External Agents (ACP)</h3>
-					<ExternalAgentSettingsPane />
-				</section>
+				{activeMode === "external_agent" && (
+					<section>
+						<ExternalAgentSettingsPane />
+					</section>
+				)}
 			</form>
 		</ModalShell>
 	);

--- a/client/src/components/modals/__tests__/SettingsModal.test.tsx
+++ b/client/src/components/modals/__tests__/SettingsModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_SETTINGS } from "@/constants/defaultSettings";
 import { useStore } from "@/core";
@@ -64,11 +64,12 @@ describe("SettingsModal", () => {
 		expect(screen.queryByRole("heading", { name: "External Agents (ACP)" })).toBeNull();
 	});
 
-	it("shows external agents section when external agent mode is active", () => {
+	it("shows external agents section when external agent mode is active", async () => {
 		useStore.setState({ activeMode: "external_agent" });
 
 		render(<SettingsModal open onClose={vi.fn()} />);
 
+		await waitFor(() => expect(bootstrapMock).toHaveBeenCalled());
 		expect(screen.getByRole("heading", { name: "AI Provider" })).toBeTruthy();
 		expect(screen.getByRole("heading", { name: "External Agents (ACP)" })).toBeTruthy();
 		expect(screen.queryByRole("heading", { name: "API Providers" })).toBeNull();

--- a/client/src/components/modals/__tests__/SettingsModal.test.tsx
+++ b/client/src/components/modals/__tests__/SettingsModal.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "@/constants/defaultSettings";
+import { useStore } from "@/core";
+import { SettingsModal } from "../SettingsModal";
+
+const bootstrapMock = vi.fn();
+
+vi.mock("@/services/acpAdminClient", () => ({
+	getAcpAdminClient: () => ({
+		bootstrap: (...args: any[]) => bootstrapMock(...args),
+		setConfig: vi.fn(),
+		detectAgents: vi.fn(),
+		getConfig: vi.fn(),
+	}),
+}));
+
+describe("SettingsModal", () => {
+	beforeEach(() => {
+		bootstrapMock.mockResolvedValue({
+			config: {
+				active_mode: "external_agent",
+				active_agent: null,
+				active_agent_command: null,
+			},
+			agents: [],
+		});
+
+		useStore.setState({
+			settings: { ...DEFAULT_SETTINGS },
+			activeAgent: null,
+			detectedAgents: [],
+		});
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = typeof input === "string" ? input : input.toString();
+				if (url.includes("/config/provider")) {
+					return { ok: true, json: async () => ({ provider: "openai" }) } as Response;
+				}
+				if (url.includes("/config/model/")) {
+					return { ok: true, json: async () => ({ model: "gpt-4o-mini" }) } as Response;
+				}
+				if (url.includes("/config/key/")) {
+					return { ok: true, json: async () => ({ api_key: "sk-***" }) } as Response;
+				}
+				return { ok: true, json: async () => ({}) } as Response;
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("shows API providers section when API mode is active", () => {
+		useStore.setState({ activeMode: "api" });
+
+		render(<SettingsModal open onClose={vi.fn()} />);
+
+		expect(screen.getByRole("heading", { name: "AI Provider" })).toBeTruthy();
+		expect(screen.getByRole("heading", { name: "API Providers" })).toBeTruthy();
+		expect(screen.queryByRole("heading", { name: "External Agents (ACP)" })).toBeNull();
+	});
+
+	it("shows external agents section when external agent mode is active", () => {
+		useStore.setState({ activeMode: "external_agent" });
+
+		render(<SettingsModal open onClose={vi.fn()} />);
+
+		expect(screen.getByRole("heading", { name: "AI Provider" })).toBeTruthy();
+		expect(screen.getByRole("heading", { name: "External Agents (ACP)" })).toBeTruthy();
+		expect(screen.queryByRole("heading", { name: "API Providers" })).toBeNull();
+	});
+});

--- a/client/src/components/settings/AIProviderSettingsPane.tsx
+++ b/client/src/components/settings/AIProviderSettingsPane.tsx
@@ -16,6 +16,7 @@ function ModeOption({ checked, description, label, mode, onSelect }: ModeOptionP
 	return (
 		<label className="mode-option">
 			<input
+				aria-label={label}
 				type="radio"
 				name="ai-provider-mode"
 				checked={checked}

--- a/client/src/components/settings/AIProviderSettingsPane.tsx
+++ b/client/src/components/settings/AIProviderSettingsPane.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useMemo } from "react";
+import { useStore } from "@/core";
+import { getAcpAdminClient } from "@/services/acpAdminClient";
+
+type ProviderMode = "api" | "external_agent";
+
+interface ModeOptionProps {
+	checked: boolean;
+	description: string;
+	label: string;
+	mode: ProviderMode;
+	onSelect: (mode: ProviderMode) => void;
+}
+
+function ModeOption({ checked, description, label, mode, onSelect }: ModeOptionProps): JSX.Element {
+	return (
+		<label className="mode-option">
+			<input
+				type="radio"
+				name="ai-provider-mode"
+				checked={checked}
+				onChange={() => void onSelect(mode)}
+			/>
+			<div className="mode-content">
+				<div className="mode-title">{label}</div>
+				<div className="mode-description">{description}</div>
+			</div>
+		</label>
+	);
+}
+
+export function AIProviderSettingsPane(): JSX.Element {
+	const activeMode = useStore((state) => state.activeMode);
+	const activeAgent = useStore((state) => state.activeAgent);
+	const setActiveMode = useStore((state) => state.setActiveMode);
+	const setActiveAgent = useStore((state) => state.setActiveAgent);
+	const acpAdminClient = useMemo(() => getAcpAdminClient(), []);
+
+	const handleModeChange = useCallback(
+		async (mode: ProviderMode) => {
+			setActiveMode(mode);
+			if (mode === "api") {
+				setActiveAgent(null);
+				await acpAdminClient.setConfig(mode, null);
+				return;
+			}
+
+			await acpAdminClient.setConfig(mode, activeAgent);
+		},
+		[acpAdminClient, activeAgent, setActiveAgent, setActiveMode],
+	);
+
+	return (
+		<div className="ai-provider-pane">
+			<div className="mode-selection">
+				<ModeOption
+					checked={activeMode === "api"}
+					description="Use built-in API providers (Claude, Gemini, etc.)"
+					label="API Providers"
+					mode="api"
+					onSelect={handleModeChange}
+				/>
+				<ModeOption
+					checked={activeMode === "external_agent"}
+					description="Use an ACP-compatible agent."
+					label="External Agent (ACP)"
+					mode="external_agent"
+					onSelect={handleModeChange}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/client/src/components/settings/__tests__/AIProviderSettingsPane.test.tsx
+++ b/client/src/components/settings/__tests__/AIProviderSettingsPane.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useStore } from "@/core";
+import { AIProviderSettingsPane } from "../AIProviderSettingsPane";
+
+const setConfigMock = vi.fn();
+
+vi.mock("@/services/acpAdminClient", () => ({
+	getAcpAdminClient: () => ({
+		setConfig: (...args: any[]) => setConfigMock(...args),
+	}),
+}));
+
+describe("AIProviderSettingsPane", () => {
+	beforeEach(() => {
+		setConfigMock.mockReset();
+		useStore.setState({
+			activeMode: "api",
+			activeAgent: "codex",
+		});
+	});
+
+	it("switches to API providers and clears active agent", async () => {
+		setConfigMock.mockResolvedValue({
+			active_mode: "api",
+			active_agent: null,
+			active_agent_command: null,
+		});
+
+		useStore.setState({ activeMode: "external_agent", activeAgent: "codex" });
+		const { getByLabelText } = render(<AIProviderSettingsPane />);
+
+		fireEvent.click(getByLabelText("API Providers"));
+
+		await waitFor(() => expect(setConfigMock).toHaveBeenCalledWith("api", null));
+		expect(useStore.getState().activeMode).toBe("api");
+		expect(useStore.getState().activeAgent).toBeNull();
+	});
+
+	it("switches to external agent mode and persists the agent", async () => {
+		setConfigMock.mockResolvedValue({
+			active_mode: "external_agent",
+			active_agent: "codex",
+			active_agent_command: null,
+		});
+
+		useStore.setState({ activeMode: "api", activeAgent: "codex" });
+		const { getByLabelText } = render(<AIProviderSettingsPane />);
+
+		fireEvent.click(getByLabelText("External Agent (ACP)"));
+
+		await waitFor(() => expect(setConfigMock).toHaveBeenCalledWith("external_agent", "codex"));
+		expect(useStore.getState().activeMode).toBe("external_agent");
+	});
+});

--- a/client/src/css/components/modals/settings.css
+++ b/client/src/css/components/modals/settings.css
@@ -27,6 +27,9 @@
 	--settings-checkbox-accent: auto;
 	--settings-range-accent: var(--phylo-cytosine-light);
 
+	--settings-option-bg: rgba(255, 255, 255, 0.03);
+	--settings-option-hover-bg: rgba(255, 255, 255, 0.06);
+
 	--settings-number-hint-size: inherit;
 	--settings-number-hint-color: inherit;
 	--settings-number-hint-font: inherit;
@@ -60,6 +63,9 @@
 	--settings-checkbox-size: 14px;
 	--settings-checkbox-accent: var(--phylo-cytosine);
 	--settings-range-accent: var(--phylo-cytosine);
+
+	--settings-option-bg: var(--phylo-bg-primary);
+	--settings-option-hover-bg: var(--phylo-bg-secondary);
 
 	--settings-number-hint-size: 11px;
 	--settings-number-hint-color: var(--phylo-text-secondary);
@@ -149,6 +155,106 @@
 
 .settings-footer-spacer {
 	flex: 1;
+}
+
+.ai-provider-pane .mode-selection {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.mode-option {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+	padding: 16px;
+	border: 1px solid var(--settings-input-border);
+	border-radius: var(--settings-input-radius);
+	background: var(--settings-option-bg);
+	cursor: pointer;
+	transition: background-color 0.2s ease;
+}
+
+.mode-option:hover {
+	background: var(--settings-option-hover-bg);
+}
+
+.mode-content {
+	flex: 1;
+}
+
+.mode-title {
+	font-weight: 600;
+	margin-bottom: 4px;
+}
+
+.mode-description {
+	color: var(--settings-hint-color);
+	font-size: 0.9em;
+}
+
+.external-agent-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	margin-bottom: 16px;
+}
+
+.external-agent-header h3 {
+	margin: 0;
+}
+
+.agent-list {
+	display: flex;
+	flex-direction: column;
+	border: 1px solid var(--settings-input-border);
+	border-radius: var(--settings-input-radius);
+	overflow: hidden;
+}
+
+.agent-item {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+	padding: 16px;
+	border-bottom: 1px solid var(--settings-input-border);
+	cursor: pointer;
+	transition: background-color 0.2s ease;
+}
+
+.agent-item:last-child {
+	border-bottom: none;
+}
+
+.agent-item:hover:not(.disabled) {
+	background: var(--settings-option-hover-bg);
+}
+
+.agent-item.disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.agent-info {
+	flex: 1;
+}
+
+.agent-name {
+	font-weight: 500;
+	margin-bottom: 4px;
+}
+
+.agent-path {
+	font-size: 0.85em;
+	color: var(--settings-hint-color);
+	font-family: ui-monospace, "SF Mono", Consolas, monospace;
+}
+
+.agent-empty {
+	padding: 24px;
+	text-align: center;
+	color: var(--settings-hint-color);
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Description

Restructures the ACP settings flow with a top-level AI Provider selector, a simplified External Agents pane, and clearer agent list spacing/labels. Adds a dedicated mode option component, updates settings section ordering, and includes tests for the new UI behavior and refresh state.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `./.husky/pre-push`
- `pnpm -r lint`
- `pnpm --filter client build`
- `cargo check --workspace`
- `cargo test --workspace --lib --all-features`
- `cd core && cargo test --test export_integration_test -- --nocapture`
- `cd core && cargo test --test timeline_integration_test -- --nocapture`
- `cd core && cargo test --test rmarkdown_integration_test -- --nocapture`
- `cd core && cargo test --test tool_manifests_test -- --nocapture`
- `cd core && cargo test --test viral_phylogenomics_workflow_test -- --nocapture`
- `pnpm --filter client test -- --run`

## Screenshots (if applicable)

Not captured.

## Related Issues

Closes #354
