### PR TITLE
Add multi-buffer editor tabs

### DIFF
--- a/client/src/components/ai-panel/CodeBlockDiffPreview.tsx
+++ b/client/src/components/ai-panel/CodeBlockDiffPreview.tsx
@@ -10,8 +10,9 @@ interface Props {
 }
 
 export function CodeBlockDiffPreview({ codeBlock, onRetry }: Props): JSX.Element | null {
-	const editorContent = useStore((state) => state.editor.content);
-	const editorFilepath = useStore((state) => state.editor.filepath);
+	const activeBuffer = useStore((state) => state.getActiveBuffer());
+	const editorContent = activeBuffer?.content ?? "";
+	const editorFilepath = activeBuffer?.filepath ?? "";
 
 	const diffData = useMemo(
 		() => buildDiffFromCodeBlock(codeBlock, editorContent, editorFilepath),

--- a/client/src/components/ai-panel/StreamingMessage.tsx
+++ b/client/src/components/ai-panel/StreamingMessage.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useMemo } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
-import { useStore } from "@/core";
 import { BrailleSpinner, useToast } from "@/components/shared";
+import { useStore } from "@/core";
+import type { Buffer } from "@/core/state/slices/editorSlice";
+import { createBufferId } from "@/core/state/utils/createBufferId";
 import { fileSystem } from "@/services/fileSystem";
 import type { AIMessage, CodeBlock, ToolCallLog as ToolCallLogEntry } from "@/types";
 import { classNames } from "@/utils/classNames";
@@ -13,7 +15,6 @@ import { FileAccessIndicator } from "./FileAccessIndicator";
 import { ToolCallLog } from "./ToolCallLog";
 import "github-markdown-css/github-markdown.css";
 import "./Markdown.css";
-import type { Components } from "react-markdown";
 
 interface Props {
 	message: AIMessage;
@@ -69,9 +70,9 @@ const extractReadFilePaths = (logs?: ToolCallLogEntry[]): string[] => {
 };
 
 export function StreamingMessage({ message, onApplyCode }: Props): JSX.Element {
-	const setEditorContent = useStore((state) => state.setEditorContent);
-	const setEditorFilepath = useStore((state) => state.setEditorFilepath);
-	const setEditorIsDirty = useStore((state) => state.setEditorIsDirty);
+	const addBuffer = useStore((state) => state.addBuffer);
+	const setActiveBuffer = useStore((state) => state.setActiveBuffer);
+	const getBufferByFilepath = useStore((state) => state.getBufferByFilepath);
 	const toast = useToast();
 	const isAssistant = message.role === "assistant";
 	const isStreaming = Boolean(message.streamingId && !message.isComplete);
@@ -86,16 +87,26 @@ export function StreamingMessage({ message, onApplyCode }: Props): JSX.Element {
 	const handleOpenPath = useCallback(
 		async (path: string) => {
 			try {
+				const existingBuffer = getBufferByFilepath(path);
+				if (existingBuffer) {
+					setActiveBuffer(existingBuffer.id);
+					return;
+				}
 				const content = await fileSystem.readFile(path);
-				setEditorContent(content);
-				setEditorFilepath(path);
-				setEditorIsDirty(false);
+				const buffer: Buffer = {
+					id: createBufferId(),
+					filepath: path,
+					content,
+					isDirty: false,
+					cursorPosition: { line: 1, column: 1 },
+				};
+				addBuffer(buffer);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : "Unknown error";
 				toast.showError(`Failed to open file: ${message}`);
 			}
 		},
-		[setEditorContent, setEditorFilepath, setEditorIsDirty, toast],
+		[addBuffer, getBufferByFilepath, setActiveBuffer, toast],
 	);
 
 	// Custom components for react-markdown

--- a/client/src/components/ai-panel/__tests__/CodeBlockDiffPreview.test.tsx
+++ b/client/src/components/ai-panel/__tests__/CodeBlockDiffPreview.test.tsx
@@ -30,8 +30,16 @@ beforeEach(() => {
 	useStore.setState((state) => ({
 		editor: {
 			...state.editor,
-			content: 'print("old")',
-			filepath: "analysis.R",
+			buffers: [
+				{
+					id: "buffer-1",
+					filepath: "analysis.R",
+					content: 'print("old")',
+					isDirty: false,
+					cursorPosition: { line: 1, column: 1 },
+				},
+			],
+			activeBufferId: "buffer-1",
 		},
 	}));
 });
@@ -55,8 +63,16 @@ describe("CodeBlockDiffPreview", () => {
 		useStore.setState((state) => ({
 			editor: {
 				...state.editor,
-				content: "different content",
-				filepath: "analysis.R",
+				buffers: [
+					{
+						id: "buffer-1",
+						filepath: "analysis.R",
+						content: "different content",
+						isDirty: false,
+						cursorPosition: { line: 1, column: 1 },
+					},
+				],
+				activeBufferId: "buffer-1",
 			},
 		}));
 

--- a/client/src/components/ai-panel/__tests__/StreamingMessage.test.tsx
+++ b/client/src/components/ai-panel/__tests__/StreamingMessage.test.tsx
@@ -46,9 +46,16 @@ beforeEach(() => {
 	useStore.setState((state) => ({
 		editor: {
 			...state.editor,
-			content: "",
-			filepath: "",
-			isDirty: false,
+			buffers: [
+				{
+					id: "buffer-1",
+					filepath: null,
+					content: "",
+					isDirty: false,
+					cursorPosition: { line: 1, column: 1 },
+				},
+			],
+			activeBufferId: "buffer-1",
 		},
 	}));
 });
@@ -87,9 +94,9 @@ describe("StreamingMessage read file indicator", () => {
 			expect(readFileMock).toHaveBeenCalledWith("analysis.R");
 		});
 
-		const state = useStore.getState().editor;
-		expect(state.filepath).toBe("analysis.R");
-		expect(state.content).toBe("file contents");
-		expect(state.isDirty).toBe(false);
+		const activeBuffer = useStore.getState().getActiveBuffer();
+		expect(activeBuffer?.filepath).toBe("analysis.R");
+		expect(activeBuffer?.content).toBe("file contents");
+		expect(activeBuffer?.isDirty).toBe(false);
 	});
 });

--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -36,6 +36,7 @@ import {
 	type DiffChange,
 	type DiffHunk,
 } from "@/utils/pendingEditDiff";
+import { TabBar } from "./TabBar";
 import { PendingEditDiffView } from "./PendingEditDiffView";
 import type { EditorRef } from "./editorRef";
 
@@ -52,12 +53,11 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	}, []);
 
 	const toast = useToast();
-	const editor = useStore((state) => state.editor);
+	const activeBuffer = useStore((state) => state.getActiveBuffer());
 	const execution = useStore((state) => state.execution);
 	const settings = useStore((state) => state.settings);
 	const workspaceRoot = useFileSystemStore((state) => state.workspaceRoot);
-	const setEditorContent = useStore((state) => state.setEditorContent);
-	const setEditorCursorPosition = useStore((state) => state.setEditorCursorPosition);
+	const updateBuffer = useStore((state) => state.updateBuffer);
 	const setApplyCodeChange = useStore((state) => state.setApplyCodeChange);
 	const setRunCurrentCell = useStore((state) => state.setRunCurrentCell);
 	const setRunAll = useStore((state) => state.setRunAll);
@@ -65,9 +65,12 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const setEditorRef = useStore((state) => state.setEditorRef);
 	const recordPatchMatchFailure = useStore((state) => state.recordPatchMatchFailure);
 	const recordPatchMatchSuccess = useStore((state) => state.recordPatchMatchSuccess);
+	const activeBufferId = activeBuffer?.id ?? null;
+	const editorContent = activeBuffer?.content ?? "";
+	const editorFilepath = activeBuffer?.filepath ?? "";
 	const normalizedEditorPath = useMemo(
-		() => normalizeWorkspaceRelativePath(editor.filepath, workspaceRoot, { keepRootEmpty: true }),
-		[editor.filepath, workspaceRoot],
+		() => normalizeWorkspaceRelativePath(editorFilepath, workspaceRoot, { keepRootEmpty: true }),
+		[editorFilepath, workspaceRoot],
 	);
 	const pendingEdit = useStore((state) => state.pendingEdits[normalizedEditorPath]);
 	const clearPendingEdit = useStore((state) => state.clearPendingEdit);
@@ -76,6 +79,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const setPendingEditReviewMap = useStore((state) => state.setPendingEditReviewMap);
 	const editorMethodsRef = useRef<EditorRef | null>(null);
 	const monacoEditorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
+	const activeBufferIdRef = useRef<string | null>(activeBufferId);
 	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
 	const pendingEditWarningRef = useRef(false);
 	const skipPendingNoticeRef = useRef(false);
@@ -89,6 +93,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const [activeHunkId, setActiveHunkId] = useState<string | null>(null);
 	const pendingEditReviewMap = pendingEdit?.reviewedChanges ?? {};
 	const [pendingEditDiff, setPendingEditDiff] = useState<PendingEditDiff | null>(null);
+	const activeCursorPosition = activeBuffer?.cursorPosition;
 	const reviewedContent = useMemo(() => {
 		if (!pendingEdit || !pendingEditDiff) return null;
 		return applyPendingEditChanges(
@@ -180,7 +185,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 		};
 	}, [monacoInstance, pendingEdit]);
 
-	const cells = useEditorCells(editor.content, editor.filepath);
+	const cells = useEditorCells(editorContent, editorFilepath);
 	const { state, actions } = useEditorExecution({
 		editorRef: monacoEditorRef,
 		cells,
@@ -200,12 +205,27 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	}, [pendingEdit?.id]);
 
 	useEffect(() => {
+		activeBufferIdRef.current = activeBufferId;
+	}, [activeBufferId]);
+
+	useEffect(() => {
+		if (!activeCursorPosition) return;
+		const monacoEditor = monacoEditorRef.current;
+		if (!monacoEditor) return;
+		const { line, column } = activeCursorPosition;
+		monacoEditor.setPosition({ lineNumber: line, column });
+		monacoEditor.revealLineInCenter(line);
+	}, [activeBufferId, activeCursorPosition]);
+
+	useEffect(() => {
 		if (!pendingEdit) return;
 		if (reviewedContent === null) return;
-		if (editor.content === reviewedContent) return;
+		if (editorContent === reviewedContent) return;
 		skipPendingNoticeRef.current = true;
-		setEditorContent(reviewedContent);
-	}, [editor.content, pendingEdit, reviewedContent, setEditorContent]);
+		if (activeBufferId) {
+			updateBuffer(activeBufferId, { content: reviewedContent, isDirty: true });
+		}
+	}, [activeBufferId, editorContent, pendingEdit, reviewedContent, updateBuffer]);
 
 	useEffect(() => {
 		if (!pendingEdit || !pendingEditDiff) return;
@@ -225,7 +245,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const handlePendingAccept = useCallback(async () => {
 		if (!pendingEdit) return;
 		const resolvedContent = reviewedContent ?? pendingEdit.newContent;
-		if (editor.content !== resolvedContent) {
+		if (editorContent !== resolvedContent) {
 			setPendingNotice({
 				type: "warning",
 				message: "Editor content changed since the pending edit review.",
@@ -251,7 +271,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 		}
 	}, [
 		clearPendingEdit,
-		editor.content,
+		editorContent,
 		pendingEdit,
 		reviewedContent,
 		updatePendingEdit,
@@ -262,7 +282,9 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 		if (!pendingEdit) return;
 		try {
 			await rejectPendingEdit(pendingEdit);
-			setEditorContent(pendingEdit.oldContent);
+			if (activeBufferId) {
+				updateBuffer(activeBufferId, { content: pendingEdit.oldContent, isDirty: true });
+			}
 			updatePendingEditStatus(pendingEdit.filePath, "rejected");
 			clearPendingEdit(pendingEdit.filePath);
 			setPendingNotice(null);
@@ -275,7 +297,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 					: message,
 			});
 		}
-	}, [clearPendingEdit, pendingEdit, setEditorContent, updatePendingEditStatus]);
+	}, [activeBufferId, clearPendingEdit, pendingEdit, updateBuffer, updatePendingEditStatus]);
 
 	const navigateToLine = useCallback((lineNumber: number): void => {
 		const monacoEditor = monacoEditorRef.current;
@@ -394,7 +416,9 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 		if (value !== undefined) {
 			if (pendingEdit && skipPendingNoticeRef.current) {
 				skipPendingNoticeRef.current = false;
-				setEditorContent(value);
+				if (activeBufferId) {
+					updateBuffer(activeBufferId, { content: value, isDirty: true });
+				}
 				return;
 			}
 			if (pendingEdit && !pendingEditWarningRef.current) {
@@ -406,7 +430,9 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 				}
 				pendingEditWarningRef.current = true;
 			}
-			setEditorContent(value);
+			if (activeBufferId) {
+				updateBuffer(activeBufferId, { content: value, isDirty: true });
+			}
 		}
 	};
 
@@ -490,7 +516,9 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 						text,
 					},
 				]);
-				setEditorContent(monacoEditor.getValue());
+				if (activeBufferId) {
+					updateBuffer(activeBufferId, { content: monacoEditor.getValue(), isDirty: true });
+				}
 			};
 
 			const applySnapshotEdit = (snapshot: string, range: CodeRange, text: string): string => {
@@ -651,7 +679,9 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 					const confirmed = await showConfirm("Confirm Replace All", confirmationMessage);
 					if (confirmed) {
 						monacoEditor.setValue(codeBlock.code);
-						setEditorContent(codeBlock.code);
+						if (activeBufferId) {
+							updateBuffer(activeBufferId, { content: codeBlock.code, isDirty: true });
+						}
 						return finalizeChange();
 					}
 					return null;
@@ -674,7 +704,9 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 					);
 					if (confirmed) {
 						monacoEditor.setValue(codeBlock.code);
-						setEditorContent(codeBlock.code);
+						if (activeBufferId) {
+							updateBuffer(activeBufferId, { content: codeBlock.code, isDirty: true });
+						}
 						return finalizeChange();
 					}
 					return null;
@@ -711,7 +743,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 					return null;
 			}
 		},
-		[setEditorContent, showConfirm, recordPatchMatchFailure, recordPatchMatchSuccess],
+		[activeBufferId, updateBuffer, showConfirm, recordPatchMatchFailure, recordPatchMatchSuccess],
 	);
 
 	useEffect(() => {
@@ -740,10 +772,15 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 
 		// Track cursor position
 		monacoEditor.onDidChangeCursorPosition((e) => {
-			setEditorCursorPosition({
-				line: e.position.lineNumber,
-				column: e.position.column,
-			});
+			const currentBufferId = activeBufferIdRef.current;
+			if (currentBufferId) {
+				updateBuffer(currentBufferId, {
+					cursorPosition: {
+						line: e.position.lineNumber,
+						column: e.position.column,
+					},
+				});
+			}
 		});
 
 		// Keyboard shortcuts
@@ -764,11 +801,8 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	return (
 		<>
 			<div className="panel editor-panel">
-				<div className="panel-header">
-					<div className="panel-title">
-						{editor.filepath || "Untitled.R"}
-						{editor.isDirty && <span className="dirty-marker"> •</span>}
-					</div>
+				<div className="panel-header editor-panel-header">
+					<TabBar />
 					<div className="panel-actions">
 						<button
 							className="btn"
@@ -887,7 +921,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 									height="100%"
 									defaultLanguage="r"
 									theme="vs"
-									value={editor.content}
+									value={editorContent}
 									onChange={handleEditorChange}
 									options={{
 										fontSize: settings.fontSize,
@@ -939,7 +973,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 							height="100%"
 							defaultLanguage="r"
 							theme="vs"
-							value={editor.content}
+							value={editorContent}
 							onChange={handleEditorChange}
 							options={{
 								fontSize: settings.fontSize,

--- a/client/src/components/editor/TabBar.tsx
+++ b/client/src/components/editor/TabBar.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useMemo, useState } from "react";
+import { useStore } from "@/core";
+import { commandRegistry } from "@/core/commands/registry";
+import type { Buffer } from "@/core/state/slices/editorSlice";
+import { classNames } from "@/utils/classNames";
+import { UnsavedChangesDialog } from "./UnsavedChangesDialog";
+
+const getDisplayName = (buffer: Buffer): string => {
+	if (buffer.displayName) return buffer.displayName;
+	if (!buffer.filepath) return "Untitled";
+	const parts = buffer.filepath.split(/[\\/]/);
+	return parts[parts.length - 1] ?? "Untitled";
+};
+
+export function TabBar(): JSX.Element {
+	const buffers = useStore((state) => state.editor.buffers);
+	const activeBufferId = useStore((state) => state.editor.activeBufferId);
+	const setActiveBuffer = useStore((state) => state.setActiveBuffer);
+	const removeBuffer = useStore((state) => state.removeBuffer);
+
+	const [pendingClose, setPendingClose] = useState<Buffer | null>(null);
+
+	const handleClose = useCallback(
+		(event: React.MouseEvent, buffer: Buffer) => {
+			event.stopPropagation();
+			if (buffer.isDirty) {
+				setPendingClose(buffer);
+				return;
+			}
+			removeBuffer(buffer.id);
+		},
+		[removeBuffer],
+	);
+
+	const handleSave = useCallback(async () => {
+		if (!pendingClose) return;
+		setActiveBuffer(pendingClose.id);
+		await commandRegistry.execute("file.save");
+		const updated = useStore.getState().getBufferById(pendingClose.id);
+		if (!updated || !updated.isDirty) {
+			removeBuffer(pendingClose.id);
+		}
+		setPendingClose(null);
+	}, [pendingClose, removeBuffer, setActiveBuffer]);
+
+	const handleDontSave = useCallback(() => {
+		if (!pendingClose) return;
+		removeBuffer(pendingClose.id);
+		setPendingClose(null);
+	}, [pendingClose, removeBuffer]);
+
+	const handleCancel = useCallback(() => {
+		setPendingClose(null);
+	}, []);
+
+	const pendingFilename = useMemo(
+		() => (pendingClose ? getDisplayName(pendingClose) : "Untitled"),
+		[pendingClose],
+	);
+
+	return (
+		<div className="tab-bar">
+			<div className="tab-list" role="tablist" aria-label="Open files">
+				{buffers.map((buffer) => (
+					<div
+						key={buffer.id}
+						role="tab"
+						aria-selected={buffer.id === activeBufferId}
+						className={classNames("tab", buffer.id === activeBufferId && "active")}
+						tabIndex={0}
+						onClick={() => setActiveBuffer(buffer.id)}
+						onKeyDown={(event) => {
+							if (event.key === "Enter" || event.key === " ") {
+								event.preventDefault();
+								setActiveBuffer(buffer.id);
+							}
+						}}
+					>
+						<span className="tab-label">
+							{getDisplayName(buffer)}
+							{buffer.isDirty && (
+								<span className="tab-dirty-indicator" aria-hidden>
+									•
+								</span>
+							)}
+						</span>
+						<button
+							type="button"
+							className="tab-close"
+							onClick={(event) => handleClose(event, buffer)}
+							aria-label="Close tab"
+						>
+							×
+						</button>
+					</div>
+				))}
+			</div>
+			<button
+				type="button"
+				className="tab-new"
+				onClick={() => commandRegistry.execute("file.new")}
+				aria-label="New file"
+			>
+				+
+			</button>
+			<UnsavedChangesDialog
+				open={Boolean(pendingClose)}
+				filename={pendingFilename}
+				onSave={handleSave}
+				onDontSave={handleDontSave}
+				onCancel={handleCancel}
+			/>
+		</div>
+	);
+}

--- a/client/src/components/editor/UnsavedChangesDialog.tsx
+++ b/client/src/components/editor/UnsavedChangesDialog.tsx
@@ -1,0 +1,38 @@
+import { ConfirmDialog } from "@/components/shared";
+
+interface UnsavedChangesDialogProps {
+	open: boolean;
+	filename: string;
+	onSave: () => void;
+	onDontSave: () => void;
+	onCancel: () => void;
+}
+
+export function UnsavedChangesDialog({
+	open,
+	filename,
+	onSave,
+	onDontSave,
+	onCancel,
+}: UnsavedChangesDialogProps): JSX.Element {
+	return (
+		<ConfirmDialog
+			open={open}
+			title={`Save changes to "${filename}"?`}
+			message="Your changes will be lost if you don't save them."
+			onClose={onCancel}
+		>
+			<div className="dialog-actions">
+				<button type="button" className="btn btn-secondary" onClick={onDontSave}>
+					Don't Save
+				</button>
+				<button type="button" className="btn btn-secondary" onClick={onCancel}>
+					Cancel
+				</button>
+				<button type="button" className="btn btn-primary" onClick={onSave}>
+					Save
+				</button>
+			</div>
+		</ConfirmDialog>
+	);
+}

--- a/client/src/components/editor/UnsavedChangesDialog.tsx
+++ b/client/src/components/editor/UnsavedChangesDialog.tsx
@@ -1,5 +1,3 @@
-import { ConfirmDialog } from "@/components/shared";
-
 interface UnsavedChangesDialogProps {
 	open: boolean;
 	filename: string;
@@ -14,25 +12,48 @@ export function UnsavedChangesDialog({
 	onSave,
 	onDontSave,
 	onCancel,
-}: UnsavedChangesDialogProps): JSX.Element {
+}: UnsavedChangesDialogProps): JSX.Element | null {
+	if (!open) return null;
+
+	const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>): void => {
+		if (event.target === event.currentTarget) {
+			onCancel();
+		}
+	};
+
 	return (
-		<ConfirmDialog
-			open={open}
-			title={`Save changes to "${filename}"?`}
-			message="Your changes will be lost if you don't save them."
-			onClose={onCancel}
-		>
-			<div className="dialog-actions">
-				<button type="button" className="btn btn-secondary" onClick={onDontSave}>
-					Don't Save
-				</button>
-				<button type="button" className="btn btn-secondary" onClick={onCancel}>
-					Cancel
-				</button>
-				<button type="button" className="btn btn-primary" onClick={onSave}>
-					Save
-				</button>
+		<div className="confirm-dialog-overlay" onClick={handleOverlayClick} role="presentation">
+			<div
+				className="confirm-dialog"
+				onClick={(event) => event.stopPropagation()}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="unsaved-dialog-title"
+				aria-describedby="unsaved-dialog-message"
+			>
+				<div className="confirm-dialog-header">
+					<h2 id="unsaved-dialog-title">{`Save changes to "${filename}"?`}</h2>
+					<button type="button" className="btn btn-icon" onClick={onCancel}>
+						×
+					</button>
+				</div>
+				<div className="confirm-dialog-content">
+					<p id="unsaved-dialog-message" className="confirm-dialog-message">
+						Your changes will be lost if you don't save them.
+					</p>
+				</div>
+				<div className="confirm-dialog-footer">
+					<button type="button" className="btn" onClick={onDontSave}>
+						Don't Save
+					</button>
+					<button type="button" className="btn" onClick={onCancel}>
+						Cancel
+					</button>
+					<button type="button" className="btn btn-primary" onClick={onSave}>
+						Save
+					</button>
+				</div>
 			</div>
-		</ConfirmDialog>
+		</div>
 	);
 }

--- a/client/src/components/file-browser/FileBrowserPane.tsx
+++ b/client/src/components/file-browser/FileBrowserPane.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/components/shared";
 import { useFileSystemStore, useStore } from "@/core";
 import { normalizeRelativePath, normalizeSeparators, ROOT_PATH } from "@/core/pathUtils";
+import type { Buffer } from "@/core/state/slices/editorSlice";
+import { createBufferId } from "@/core/state/utils/createBufferId";
 import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { useFileBrowserState } from "@/hooks/useFileBrowserState";
 import { useFileSystemData } from "@/hooks/useFileSystemData";
@@ -136,16 +138,16 @@ const buildAbsolutePath = (workspaceRoot: string, path: string): string => {
 };
 
 const useEditorActions = () => {
-	const setEditorContent = useStore((state) => state.setEditorContent);
-	const setEditorFilepath = useStore((state) => state.setEditorFilepath);
-	const setEditorIsDirty = useStore((state) => state.setEditorIsDirty);
-	return { setEditorContent, setEditorFilepath, setEditorIsDirty };
+	const addBuffer = useStore((state) => state.addBuffer);
+	const setActiveBuffer = useStore((state) => state.setActiveBuffer);
+	const getBufferByFilepath = useStore((state) => state.getBufferByFilepath);
+	return { addBuffer, setActiveBuffer, getBufferByFilepath };
 };
 
 export function FileBrowserPane(): JSX.Element {
 	useFileSystemData();
 	const toast = useToast();
-	const { setEditorContent, setEditorFilepath, setEditorIsDirty } = useEditorActions();
+	const { addBuffer, setActiveBuffer, getBufferByFilepath } = useEditorActions();
 	const files = useFileSystemStore((state) => state.files);
 	const expandedFolders = useFileSystemStore((state) => state.expandedFolders);
 	const pendingFolders = useFileSystemStore((state) => state.pendingFolders);
@@ -318,10 +320,20 @@ export function FileBrowserPane(): JSX.Element {
 				}
 			}
 			try {
+				const existingBuffer = getBufferByFilepath(node.path);
+				if (existingBuffer) {
+					setActiveBuffer(existingBuffer.id);
+					return;
+				}
 				const content = await fileSystem.readFile(node.path);
-				setEditorContent(content);
-				setEditorFilepath(node.path);
-				setEditorIsDirty(false);
+				const buffer: Buffer = {
+					id: createBufferId(),
+					filepath: node.path,
+					content,
+					isDirty: false,
+					cursorPosition: { line: 1, column: 1 },
+				};
+				addBuffer(buffer);
 			} catch (error) {
 				alertFileOperationError(
 					toast,
@@ -329,7 +341,7 @@ export function FileBrowserPane(): JSX.Element {
 				);
 			}
 		},
-		[openInSystemViewer, setEditorContent, setEditorFilepath, setEditorIsDirty, toast],
+		[addBuffer, getBufferByFilepath, openInSystemViewer, setActiveBuffer, toast],
 	);
 
 	const handleContextMenu = useCallback(

--- a/client/src/components/menu/StatusBar.tsx
+++ b/client/src/components/menu/StatusBar.tsx
@@ -9,7 +9,7 @@ import { classNames } from "@/utils/classNames";
 // }
 
 export function StatusBar(): JSX.Element {
-	const editor = useStore((state) => state.editor);
+	const activeBuffer = useStore((state) => state.getActiveBuffer());
 	const settings = useStore((state) => state.settings);
 	const execution = useStore((state) => state.execution);
 	const project = useStore((state) => state.project);
@@ -32,10 +32,15 @@ export function StatusBar(): JSX.Element {
 		<div className="statusbar">
 			<div className="statusbar-left">
 				{project && <span className="statusbar-item">Project: {project.name}</span>}
-				<span className="statusbar-item">{editor.filepath || "Untitled"}</span>
-				{editor.isDirty && <span className="statusbar-item statusbar-modified">Modified</span>}
 				<span className="statusbar-item">
-					Ln {editor.cursorPosition.line}, Col {editor.cursorPosition.column}
+					{activeBuffer?.filepath || activeBuffer?.displayName || "Untitled"}
+				</span>
+				{activeBuffer?.isDirty && (
+					<span className="statusbar-item statusbar-modified">Modified</span>
+				)}
+				<span className="statusbar-item">
+					Ln {activeBuffer?.cursorPosition.line ?? 1}, Col{" "}
+					{activeBuffer?.cursorPosition.column ?? 1}
 				</span>
 			</div>
 			<div className="statusbar-right">

--- a/client/src/core/commands/init.ts
+++ b/client/src/core/commands/init.ts
@@ -1,5 +1,6 @@
 import { setupAICommands } from "./modules/ai";
 import { setupCodeCommands } from "./modules/code";
+import { setupEditorCommands } from "./modules/editor";
 import { setupEditCommands } from "./modules/edit";
 import { setupFileCommands } from "./modules/file";
 import { setupHelpCommands } from "./modules/help";
@@ -10,6 +11,7 @@ export function initializeCommands() {
 	setupViewCommands();
 	setupAICommands();
 	setupFileCommands();
+	setupEditorCommands();
 	setupEditCommands();
 	setupCodeCommands();
 	setupSessionCommands();

--- a/client/src/core/commands/modules/editor.ts
+++ b/client/src/core/commands/modules/editor.ts
@@ -1,0 +1,53 @@
+import { useStore } from "@/core/state/store";
+import { commandRegistry } from "../registry";
+
+export function setupEditorCommands() {
+	commandRegistry.registerMany([
+		{
+			id: "editor.closeBuffer",
+			title: "Close Buffer",
+			category: "Editor",
+			keybinding: "Mod+W",
+			execute: () => {
+				const store = useStore.getState();
+				const activeBuffer = store.getActiveBuffer();
+				if (!activeBuffer) return;
+				if (activeBuffer.isDirty && !confirm("Discard unsaved changes?")) {
+					return;
+				}
+				store.removeBuffer(activeBuffer.id);
+			},
+		},
+		{
+			id: "editor.nextBuffer",
+			title: "Next Buffer",
+			category: "Editor",
+			keybinding: "Mod+Shift+]",
+			execute: () => {
+				const store = useStore.getState();
+				const { buffers, activeBufferId } = store.editor;
+				if (buffers.length === 0) return;
+				const currentIndex = buffers.findIndex((buffer) => buffer.id === activeBufferId);
+				const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % buffers.length : 0;
+				store.setActiveBuffer(buffers[nextIndex].id);
+			},
+		},
+		{
+			id: "editor.previousBuffer",
+			title: "Previous Buffer",
+			category: "Editor",
+			keybinding: "Mod+Shift+[",
+			execute: () => {
+				const store = useStore.getState();
+				const { buffers, activeBufferId } = store.editor;
+				if (buffers.length === 0) return;
+				const currentIndex = buffers.findIndex((buffer) => buffer.id === activeBufferId);
+				const prevIndex =
+					currentIndex >= 0
+						? (currentIndex - 1 + buffers.length) % buffers.length
+						: buffers.length - 1;
+				store.setActiveBuffer(buffers[prevIndex].id);
+			},
+		},
+	]);
+}

--- a/client/src/core/commands/modules/file.ts
+++ b/client/src/core/commands/modules/file.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_FILENAMES } from "@/constants/ui";
-import { DEFAULT_R_SCRIPT } from "@/core/state/slices/editorSlice";
+import { DEFAULT_R_SCRIPT, type Buffer } from "@/core/state/slices/editorSlice";
+import { createBufferId } from "@/core/state/utils/createBufferId";
 import { useStore } from "@/core/state/store";
 import { socketService } from "@/services/socket";
 import { downloadFile, openFile } from "@/utils/fileOperations";
@@ -15,17 +16,18 @@ export function setupFileCommands() {
 			keybinding: "Mod+N",
 			execute: () => {
 				const store = useStore.getState();
-				const isDirty = store.editor?.isDirty;
-
-				if (isDirty) {
-					if (!confirm("Discard unsaved changes?")) {
-						return;
-					}
-				}
-
-				store.setEditorContent(DEFAULT_R_SCRIPT);
-				store.setEditorFilepath(DEFAULT_FILENAMES.NEW_R_SCRIPT);
-				store.setEditorIsDirty(false);
+				const untitledCount = store.editor.buffers.filter((buffer) =>
+					buffer.displayName?.startsWith("Untitled"),
+				).length;
+				const buffer: Buffer = {
+					id: createBufferId(),
+					filepath: null,
+					content: DEFAULT_R_SCRIPT,
+					isDirty: true,
+					cursorPosition: { line: 1, column: 1 },
+					displayName: `Untitled-${untitledCount + 1}`,
+				};
+				store.addBuffer(buffer);
 			},
 		},
 		{
@@ -40,9 +42,19 @@ export function setupFileCommands() {
 
 					const content = await file.text();
 					const store = useStore.getState();
-					store.setEditorContent(content);
-					store.setEditorFilepath(file.name);
-					store.setEditorIsDirty(false);
+					const existing = store.getBufferByFilepath(file.name);
+					if (existing) {
+						store.setActiveBuffer(existing.id);
+						return;
+					}
+					const buffer: Buffer = {
+						id: createBufferId(),
+						filepath: file.name,
+						content,
+						isDirty: false,
+						cursorPosition: { line: 1, column: 1 },
+					};
+					store.addBuffer(buffer);
 				} catch (error) {}
 			},
 		},
@@ -69,20 +81,24 @@ export function setupFileCommands() {
 			keybinding: "Mod+S",
 			execute: () => {
 				const store = useStore.getState();
-				const { filepath, content } = store.editor || {};
+				const activeBuffer = store.getActiveBuffer();
 
-				if (!filepath) {
-					return commandRegistry.execute("file.saveAs");
-				}
-
-				if (!content) {
+				if (!activeBuffer) {
 					return;
 				}
 
-				downloadFile(filepath, content);
-				store.setEditorIsDirty(false);
+				if (!activeBuffer.filepath) {
+					return commandRegistry.execute("file.saveAs");
+				}
+
+				if (!activeBuffer.content) {
+					return;
+				}
+
+				downloadFile(activeBuffer.filepath, activeBuffer.content);
+				store.updateBuffer(activeBuffer.id, { isDirty: false });
 			},
-			enabled: () => useStore.getState().editor?.isDirty ?? false,
+			enabled: () => useStore.getState().getActiveBuffer()?.isDirty ?? false,
 		},
 		{
 			id: "file.saveAs",
@@ -91,13 +107,20 @@ export function setupFileCommands() {
 			keybinding: "Mod+Shift+S",
 			execute: () => {
 				const store = useStore.getState();
-				const { content } = store.editor || {};
+				const activeBuffer = store.getActiveBuffer();
 
-				if (!content) {
+				if (!activeBuffer?.content) {
 					return;
 				}
 
-				downloadFile(DEFAULT_FILENAMES.UNTITLED_R_SCRIPT, content);
+				const filename =
+					activeBuffer.filepath || activeBuffer.displayName || DEFAULT_FILENAMES.UNTITLED_R_SCRIPT;
+				downloadFile(filename, activeBuffer.content);
+				store.updateBuffer(activeBuffer.id, {
+					isDirty: false,
+					filepath: activeBuffer.filepath ?? filename,
+					displayName: activeBuffer.filepath ? activeBuffer.displayName : undefined,
+				});
 			},
 		},
 	]);

--- a/client/src/core/state/__tests__/store.test.ts
+++ b/client/src/core/state/__tests__/store.test.ts
@@ -22,10 +22,16 @@ describe("Zustand Store", () => {
 	beforeEach(() => {
 		useStore.setState({
 			editor: {
-				content: "",
-				filepath: "",
-				isDirty: false,
-				cursorPosition: { line: 1, column: 1 },
+				buffers: [
+					{
+						id: "buffer-1",
+						filepath: null,
+						content: "",
+						isDirty: false,
+						cursorPosition: { line: 1, column: 1 },
+					},
+				],
+				activeBufferId: "buffer-1",
 			},
 			applyCodeChange: null,
 			execution: {
@@ -52,13 +58,13 @@ describe("Zustand Store", () => {
 	});
 
 	it("updates editor content and dirty flag", () => {
-		const setEditorContent = useStore.getState().setEditorContent;
+		const updateBuffer = useStore.getState().updateBuffer;
 
-		setEditorContent("x <- 1");
+		updateBuffer("buffer-1", { content: "x <- 1", isDirty: true });
 
 		const state = useStore.getState();
-		expect(state.editor.content).toBe("x <- 1");
-		expect(state.editor.isDirty).toBe(true);
+		expect(state.editor.buffers[0].content).toBe("x <- 1");
+		expect(state.editor.buffers[0].isDirty).toBe(true);
 	});
 
 	it("tracks execution results in history", () => {

--- a/client/src/core/state/slices/__tests__/editorSlice.test.ts
+++ b/client/src/core/state/slices/__tests__/editorSlice.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { createStore } from "zustand/vanilla";
+import { createEditorSlice, type Buffer, type EditorState } from "@/core/state/slices/editorSlice";
+
+const makeBuffer = (overrides: Partial<Buffer> = {}): Buffer => ({
+	id: overrides.id ?? "buffer-1",
+	filepath: overrides.filepath ?? null,
+	content: overrides.content ?? "",
+	isDirty: overrides.isDirty ?? false,
+	cursorPosition: overrides.cursorPosition ?? { line: 1, column: 1 },
+	displayName: overrides.displayName,
+});
+
+const createTestStore = () => createStore<EditorState>()((...args) => createEditorSlice(...args));
+
+describe("editorSlice", () => {
+	it("adds a buffer and sets it active", () => {
+		const store = createTestStore();
+		const buffer = makeBuffer({ id: "buffer-new", content: "x <- 1" });
+
+		store.getState().addBuffer(buffer);
+
+		const state = store.getState();
+		expect(state.editor.buffers).toContainEqual(buffer);
+		expect(state.editor.activeBufferId).toBe("buffer-new");
+	});
+
+	it("updates buffer content and dirty state", () => {
+		const store = createTestStore();
+		const [first] = store.getState().editor.buffers;
+
+		store.getState().updateBuffer(first.id, { content: "y <- 2", isDirty: true });
+
+		const updated = store.getState().getBufferById(first.id);
+		expect(updated?.content).toBe("y <- 2");
+		expect(updated?.isDirty).toBe(true);
+	});
+
+	it("selects the next buffer when removing the active buffer", () => {
+		const store = createTestStore();
+		const first = store.getState().editor.buffers[0];
+		const second = makeBuffer({ id: "buffer-2", filepath: "file.R" });
+		store.getState().addBuffer(second);
+		store.getState().setActiveBuffer(first.id);
+
+		store.getState().removeBuffer(first.id);
+
+		const state = store.getState();
+		expect(state.editor.buffers).toHaveLength(1);
+		expect(state.editor.activeBufferId).toBe(second.id);
+	});
+
+	it("finds buffers by filepath", () => {
+		const store = createTestStore();
+		const buffer = makeBuffer({ id: "buffer-3", filepath: "foo/bar.R" });
+
+		store.getState().addBuffer(buffer);
+
+		expect(store.getState().getBufferByFilepath("foo/bar.R")?.id).toBe("buffer-3");
+	});
+});

--- a/client/src/core/state/slices/editorSlice.ts
+++ b/client/src/core/state/slices/editorSlice.ts
@@ -1,6 +1,7 @@
 import type { RefObject } from "react";
 import type { StateCreator } from "zustand";
 import type { EditorRef } from "@/components/editor/editorRef";
+import { createBufferId } from "@/core/state/utils/createBufferId";
 import type { CodeBlock } from "@/types";
 
 export interface AppliedCodeChange {
@@ -15,25 +16,39 @@ export const DEFAULT_R_SCRIPT = `# Welcome to Re-prod ----
 # Start coding here
 `;
 
+export interface Buffer {
+	id: string;
+	filepath: string | null;
+	content: string;
+	isDirty: boolean;
+	cursorPosition: {
+		line: number;
+		column: number;
+	};
+	scrollPosition?: {
+		top: number;
+		left: number;
+	};
+	displayName?: string;
+}
+
 export interface EditorState {
 	editor: {
-		content: string;
-		filepath: string;
-		isDirty: boolean;
-		cursorPosition: {
-			line: number;
-			column: number;
-		};
+		buffers: Buffer[];
+		activeBufferId: string | null;
 	};
 	monacoEditor: any | null;
 	applyCodeChange: ((codeBlock: CodeBlock) => Promise<AppliedCodeChange | null>) | null;
 	runCurrentCell: (() => void) | null;
 	runAll: (() => void) | null;
 	editorRef: RefObject<EditorRef> | null;
-	setEditorContent: (content: string) => void;
-	setEditorFilepath: (filepath: string) => void;
-	setEditorCursorPosition: (position: { line: number; column: number }) => void;
-	setEditorIsDirty: (isDirty: boolean) => void;
+	addBuffer: (buffer: Buffer) => void;
+	removeBuffer: (bufferId: string) => void;
+	updateBuffer: (bufferId: string, updates: Partial<Buffer>) => void;
+	setActiveBuffer: (bufferId: string) => void;
+	getActiveBuffer: () => Buffer | null;
+	getBufferById: (id: string) => Buffer | null;
+	getBufferByFilepath: (filepath: string) => Buffer | null;
 	setMonacoEditor: (editor: any) => void;
 	setApplyCodeChange: (
 		handler: (codeBlock: CodeBlock) => Promise<AppliedCodeChange | null>,
@@ -43,37 +58,96 @@ export interface EditorState {
 	setEditorRef: (editorRef: RefObject<EditorRef> | null) => void;
 }
 
-export const createEditorSlice: StateCreator<EditorState> = (set) => ({
-	editor: {
-		content: DEFAULT_R_SCRIPT,
-		filepath: "",
-		isDirty: false,
-		cursorPosition: { line: 1, column: 1 },
-	},
-	monacoEditor: null,
-	applyCodeChange: null,
-	runCurrentCell: null,
-	runAll: null,
-	editorRef: null,
-	setEditorContent: (content) =>
-		set((state) => ({
-			editor: { ...state.editor, content, isDirty: true },
-		})),
-	setEditorFilepath: (filepath) =>
-		set((state) => ({
-			editor: { ...state.editor, filepath },
-		})),
-	setEditorCursorPosition: (cursorPosition) =>
-		set((state) => ({
-			editor: { ...state.editor, cursorPosition },
-		})),
-	setEditorIsDirty: (isDirty) =>
-		set((state) => ({
-			editor: { ...state.editor, isDirty },
-		})),
-	setMonacoEditor: (monacoEditor) => set({ monacoEditor }),
-	setApplyCodeChange: (handler) => set({ applyCodeChange: handler }),
-	setRunCurrentCell: (handler) => set({ runCurrentCell: handler }),
-	setRunAll: (handler) => set({ runAll: handler }),
-	setEditorRef: (editorRef: RefObject<EditorRef> | null) => set({ editorRef }),
+const createDefaultBuffer = (): Buffer => ({
+	id: createBufferId(),
+	filepath: null,
+	content: DEFAULT_R_SCRIPT,
+	isDirty: false,
+	cursorPosition: { line: 1, column: 1 },
+	displayName: "Untitled-1",
 });
+
+export const createEditorSlice: StateCreator<EditorState> = (set, get) => {
+	const initialBuffer = createDefaultBuffer();
+	return {
+		editor: {
+			buffers: [initialBuffer],
+			activeBufferId: initialBuffer.id,
+		},
+		monacoEditor: null,
+		applyCodeChange: null,
+		runCurrentCell: null,
+		runAll: null,
+		editorRef: null,
+		addBuffer: (buffer) =>
+			set((state) => ({
+				editor: {
+					...state.editor,
+					buffers: [...state.editor.buffers, buffer],
+					activeBufferId: buffer.id,
+				},
+			})),
+		removeBuffer: (bufferId) =>
+			set((state) => ({
+				editor: (() => {
+					const buffers = state.editor.buffers.filter((buffer) => buffer.id !== bufferId);
+					if (buffers.length === 0) {
+						const fallback = createDefaultBuffer();
+						return {
+							...state.editor,
+							buffers: [fallback],
+							activeBufferId: fallback.id,
+						};
+					}
+					let activeBufferId = state.editor.activeBufferId;
+					if (bufferId === state.editor.activeBufferId) {
+						const currentIndex = state.editor.buffers.findIndex((buffer) => buffer.id === bufferId);
+						const nextIndex = currentIndex < buffers.length ? currentIndex : currentIndex - 1;
+						activeBufferId = buffers[nextIndex]?.id ?? null;
+					}
+					return {
+						...state.editor,
+						buffers,
+						activeBufferId,
+					};
+				})(),
+			})),
+		updateBuffer: (bufferId, updates) =>
+			set((state) => ({
+				editor: {
+					...state.editor,
+					buffers: state.editor.buffers.map((buffer) =>
+						buffer.id === bufferId ? { ...buffer, ...updates } : buffer,
+					),
+				},
+			})),
+		setActiveBuffer: (bufferId) =>
+			set((state) => ({
+				editor: {
+					...state.editor,
+					activeBufferId: bufferId,
+				},
+			})),
+		getActiveBuffer: () => {
+			const state = get();
+			const { activeBufferId, buffers } = state.editor;
+			if (!activeBufferId) {
+				return buffers[0] ?? null;
+			}
+			return buffers.find((buffer) => buffer.id === activeBufferId) ?? null;
+		},
+		getBufferById: (id) => {
+			const state = get();
+			return state.editor.buffers.find((buffer) => buffer.id === id) ?? null;
+		},
+		getBufferByFilepath: (filepath) => {
+			const state = get();
+			return state.editor.buffers.find((buffer) => buffer.filepath === filepath) ?? null;
+		},
+		setMonacoEditor: (monacoEditor) => set({ monacoEditor }),
+		setApplyCodeChange: (handler) => set({ applyCodeChange: handler }),
+		setRunCurrentCell: (handler) => set({ runCurrentCell: handler }),
+		setRunAll: (handler) => set({ runAll: handler }),
+		setEditorRef: (editorRef: RefObject<EditorRef> | null) => set({ editorRef }),
+	};
+};

--- a/client/src/core/state/utils/createBufferId.ts
+++ b/client/src/core/state/utils/createBufferId.ts
@@ -1,0 +1,6 @@
+export const createBufferId = (): string => {
+	if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+		return crypto.randomUUID();
+	}
+	return `buffer-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};

--- a/client/src/css/components/editor.css
+++ b/client/src/css/components/editor.css
@@ -118,6 +118,116 @@
 	overflow: hidden;
 }
 
+.editor-panel-header {
+	gap: 12px;
+}
+
+.editor-panel-header .tab-bar {
+	flex: 1;
+}
+
+.tab-bar {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	min-height: 100%;
+	overflow: hidden;
+}
+
+.tab-list {
+	display: flex;
+	align-items: center;
+	flex: 1;
+	gap: 0;
+	min-width: 0;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scrollbar-width: thin;
+}
+
+.tab {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 12px;
+	background: transparent;
+	border: none;
+	border-right: 1px solid var(--border-color, #e0e0e0);
+	cursor: pointer;
+	transition: background-color 0.15s ease;
+	min-width: 140px;
+	max-width: 220px;
+}
+
+.tab:hover {
+	background: var(--hover-bg, rgba(0, 0, 0, 0.04));
+}
+
+.tab.active {
+	background: var(--bg-primary);
+	box-shadow: inset 0 -2px 0 var(--accent-color, #2f6fed);
+}
+
+.tab:focus-visible {
+	outline: 2px solid var(--accent-color, #2f6fed);
+	outline-offset: -2px;
+}
+
+.tab-label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.tab-dirty-indicator {
+	color: var(--warning-color);
+	font-size: 1.1em;
+}
+
+.tab-close {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+	background: transparent;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	opacity: 0.6;
+	transition:
+		background-color 0.15s ease,
+		opacity 0.15s ease;
+}
+
+.tab-close:hover {
+	opacity: 1;
+	background: rgba(255, 77, 79, 0.12);
+	color: var(--danger-color, #d92d20);
+}
+
+.tab-new {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 6px 12px;
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	font-size: 1.1em;
+	opacity: 0.6;
+	transition: opacity 0.15s ease;
+}
+
+.tab-new:hover {
+	opacity: 1;
+}
+
 .pending-edit-hunk-header {
 	display: flex;
 	align-items: center;

--- a/client/src/hooks/useAICodeApplication.ts
+++ b/client/src/hooks/useAICodeApplication.ts
@@ -10,10 +10,12 @@ type PostAssistantMessage = (content: string, extras?: Partial<AIMessage>) => vo
 
 export function useAICodeApplication(postAssistantMessage: PostAssistantMessage) {
 	const applyCodeChange = useStore((state) => state.applyCodeChange);
-	const editorFilepath = useStore((state) => state.editor.filepath);
+	const activeBuffer = useStore((state) => state.getActiveBuffer());
+	const updateBuffer = useStore((state) => state.updateBuffer);
+	const editorFilepath = activeBuffer?.filepath ?? "";
 	const pendingEdit = useStore((state) => state.pendingEdits[editorFilepath]);
 	const registerPendingEdit = useStore((state) => state.registerPendingEdit);
-	const setEditorContent = useStore((state) => state.setEditorContent);
+	const activeBufferId = activeBuffer?.id ?? null;
 
 	const handleApplyCode = useCallback(
 		async (codeBlock: CodeBlock): Promise<void> => {
@@ -60,7 +62,12 @@ export function useAICodeApplication(postAssistantMessage: PostAssistantMessage)
 
 							const registered = registerPendingEdit(pendingEdit);
 							if (!registered) {
-								setEditorContent(snapshot.oldContent);
+								if (activeBufferId) {
+									updateBuffer(activeBufferId, {
+										content: snapshot.oldContent,
+										isDirty: true,
+									});
+								}
 								postAssistantMessage("A pending edit already exists for this file.");
 							}
 							return snapshot;
@@ -81,11 +88,12 @@ export function useAICodeApplication(postAssistantMessage: PostAssistantMessage)
 		},
 		[
 			applyCodeChange,
+			activeBufferId,
 			editorFilepath,
 			pendingEdit,
 			postAssistantMessage,
 			registerPendingEdit,
-			setEditorContent,
+			updateBuffer,
 		],
 	);
 

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -60,8 +60,11 @@ export function useAIConversation() {
 	const startStreamingMessage = useStore((state) => state.startStreamingMessage);
 	const setAILoading = useStore((state) => state.setAILoading);
 	const completeStreamingMessage = useStore((state) => state.completeStreamingMessage);
-	const editorContent = useStore((state) => state.editor.content);
-	const editorFilepath = useStore((state) => state.editor.filepath);
+	const activeBuffer = useStore((state) => state.getActiveBuffer());
+	const updateBuffer = useStore((state) => state.updateBuffer);
+	const editorContent = activeBuffer?.content ?? "";
+	const editorFilepath = activeBuffer?.filepath ?? "";
+	const activeBufferId = activeBuffer?.id ?? null;
 	const consoleHistory = useStore((state) => state.execution.results);
 	const workspaceRoot = useFileSystemStore((state) => state.workspaceRoot);
 
@@ -107,7 +110,6 @@ export function useAIConversation() {
 
 	const { handleApplyCode } = useAICodeApplication(postAssistantMessage);
 	const registerPendingEdit = useStore((state) => state.registerPendingEdit);
-	const setEditorContent = useStore((state) => state.setEditorContent);
 
 	const clearActiveRequest = useCallback((options: { dispose?: boolean } = {}) => {
 		if (!activeRequestRef.current) {
@@ -279,7 +281,12 @@ export function useAIConversation() {
 
 						const registered = registerPendingEdit(pendingEdit);
 						if (registered && pendingEdit.filePath === normalizedEditorPath) {
-							setEditorContent(pendingEdit.newContent);
+							if (activeBufferId) {
+								updateBuffer(activeBufferId, {
+									content: pendingEdit.newContent,
+									isDirty: true,
+								});
+							}
 						}
 					}
 				}
@@ -293,6 +300,7 @@ export function useAIConversation() {
 			appendAcpChunk(streamingId, chunk.kind, chunk.text);
 		},
 		[
+			activeBufferId,
 			appendAcpChunk,
 			extractAcpChunk,
 			finalizeAcpStream,
@@ -304,7 +312,7 @@ export function useAIConversation() {
 			summarizeAcpToolUpdate,
 			registerPendingEdit,
 			editorFilepath,
-			setEditorContent,
+			updateBuffer,
 			startStreamingMessage,
 			workspaceRoot,
 			updatePlan,

--- a/client/src/hooks/useEditorExecution.ts
+++ b/client/src/hooks/useEditorExecution.ts
@@ -36,9 +36,10 @@ export function useEditorExecution({
 	editorRef,
 	cells,
 }: UseEditorExecutionProps): UseEditorExecutionReturn {
-	const editorContent = useStore((state) => state.editor.content);
-	const editorFilepath = useStore((state) => state.editor.filepath);
-	const cursorLine = useStore((state) => state.editor.cursorPosition.line);
+	const activeBuffer = useStore((state) => state.getActiveBuffer());
+	const editorContent = activeBuffer?.content ?? "";
+	const editorFilepath = activeBuffer?.filepath ?? "";
+	const cursorLine = activeBuffer?.cursorPosition.line ?? 1;
 	const setIsRunning = useStore((state) => state.setIsRunning);
 	const setExecutionError = useStore((state) => state.setExecutionError);
 

--- a/client/src/hooks/useMenuSections.ts
+++ b/client/src/hooks/useMenuSections.ts
@@ -3,7 +3,7 @@ import { useStore } from "@/core";
 import { buildMenuSections } from "@/core/menu/menuConfig";
 
 export function useMenuSections() {
-	const isEditorDirty = useStore((state) => state.editor?.isDirty ?? false);
+	const isEditorDirty = useStore((state) => state.getActiveBuffer()?.isDirty ?? false);
 	const isExecutionRunning = useStore((state) => state.execution?.isRunning ?? false);
 	const viewPanes = useStore((state) => state.view.panes);
 

--- a/client/src/hooks/useProjectSession.ts
+++ b/client/src/hooks/useProjectSession.ts
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useStore } from "@/core";
 import { useFileSystemStore } from "@/core/fileSystemStore";
+import { DEFAULT_R_SCRIPT, type Buffer } from "@/core/state/slices/editorSlice";
+import { createBufferId } from "@/core/state/utils/createBufferId";
 import { requestPlotHistory } from "@/services/plotHistoryService";
 import { DEFAULT_VIEW_STATE } from "@/services/sessionPersistence";
 import { socketService } from "@/services/socket";
@@ -8,8 +10,20 @@ import type { ProjectRecord } from "@/types";
 
 function resetWorkspace(): void {
 	const store = useStore.getState();
+	const buffer: Buffer = {
+		id: createBufferId(),
+		filepath: null,
+		content: DEFAULT_R_SCRIPT,
+		isDirty: false,
+		cursorPosition: { line: 1, column: 1 },
+		displayName: "Untitled-1",
+	};
 	useStore.setState((state) => ({
-		editor: { ...state.editor, content: "", filepath: "", isDirty: false },
+		editor: {
+			...state.editor,
+			buffers: [buffer],
+			activeBufferId: buffer.id,
+		},
 		view: {
 			panes: { ...DEFAULT_VIEW_STATE.panes },
 			modals: { ...DEFAULT_VIEW_STATE.modals },

--- a/client/src/services/sessionPersistence.ts
+++ b/client/src/services/sessionPersistence.ts
@@ -1,5 +1,7 @@
 import { useStore } from "@/core";
 import { useFileSystemStore } from "@/core/fileSystemStore";
+import { DEFAULT_R_SCRIPT, type Buffer } from "@/core/state/slices/editorSlice";
+import { createBufferId } from "@/core/state/utils/createBufferId";
 import type { ViewData } from "@/core/state/slices/viewSlice";
 import { fileSystem } from "@/services/fileSystem";
 import { queryTimeline } from "@/services/timelineService";
@@ -60,41 +62,72 @@ const resetDomainState = (): void => {
 	state.reset();
 };
 
+const createSnapshotBuffer = (content: string, filepath: string | null): Buffer => ({
+	id: createBufferId(),
+	filepath,
+	content,
+	isDirty: false,
+	cursorPosition: { line: 1, column: 1 },
+	displayName: filepath ? undefined : "Untitled-1",
+});
+
 const restoreEditorFromFilesystem = async (filepath: string | null): Promise<void> => {
 	const normalizedPath = filepath ?? "";
 	useFileSystemStore.getState().setActivePath(normalizedPath || null);
 
 	if (!normalizedPath) {
+		const buffer = createSnapshotBuffer(DEFAULT_R_SCRIPT, null);
 		useStore.setState((state) => ({
-			editor: { ...state.editor, content: "", filepath: "", isDirty: false },
+			editor: {
+				...state.editor,
+				buffers: [buffer],
+				activeBufferId: buffer.id,
+			},
 		}));
 		return;
 	}
 
+	const buffer = createSnapshotBuffer("", normalizedPath);
 	useStore.setState((state) => ({
-		editor: { ...state.editor, content: "", filepath: normalizedPath, isDirty: false },
+		editor: {
+			...state.editor,
+			buffers: [buffer],
+			activeBufferId: buffer.id,
+		},
 	}));
 
 	try {
 		const content = await fileSystem.readFile(normalizedPath);
 		useStore.setState((state) => ({
-			editor: { ...state.editor, content, filepath: normalizedPath, isDirty: false },
+			editor: {
+				...state.editor,
+				buffers: [
+					{
+						...buffer,
+						content,
+					},
+				],
+			},
 		}));
 	} catch (error) {
 		console.error("Failed to load file from filesystem", error);
 		useStore.setState((state) => ({
-			editor: { ...state.editor, content: "", filepath: normalizedPath, isDirty: false },
+			editor: {
+				...state.editor,
+				buffers: [buffer],
+			},
 		}));
 	}
 };
 
 export function getSessionSnapshot(): SessionSnapshot {
 	const state = useStore.getState();
+	const activeBuffer = state.getActiveBuffer();
 	return {
 		version: SNAPSHOT_VERSION,
 		savedAt: Date.now(),
 		editor: {
-			filepath: state.editor.filepath || null,
+			filepath: activeBuffer?.filepath || null,
 		},
 		view: mergeViewState(state.view),
 	};

--- a/desktop/e2e/shared/fixtures/tab-switch-fixture.R
+++ b/desktop/e2e/shared/fixtures/tab-switch-fixture.R
@@ -1,0 +1,6 @@
+# Tab switch fixture
+
+tab_switch_fixture <- function() {
+  "Tab switch fixture loaded"
+}
+

--- a/desktop/e2e/shared/selectors.ts
+++ b/desktop/e2e/shared/selectors.ts
@@ -5,12 +5,13 @@
 export const selectors = {
 	// Editor
 	editor: ".monaco-editor textarea",
+	editorSurface: ".monaco-editor .editor-scrollable",
 	tabBar: ".tab-bar",
 	tab: ".tab-bar .tab",
 	tabActive: ".tab-bar .tab.active",
-	tabLabel: ".tab-bar .tab-label",
-	tabDirty: ".tab-bar .tab-dirty-indicator",
-	tabClose: ".tab-bar .tab-close",
+	tabLabel: ".tab-label",
+	tabDirty: ".tab-dirty-indicator",
+	tabClose: ".tab-close",
 
 	// File browser
 	fileBrowser: ".file-browser",

--- a/desktop/e2e/shared/selectors.ts
+++ b/desktop/e2e/shared/selectors.ts
@@ -6,11 +6,11 @@ export const selectors = {
 	// Editor
 	editor: ".monaco-editor textarea",
 	tabBar: ".tab-bar",
-	tab: ".tab",
-	tabActive: ".tab.active",
-	tabLabel: ".tab-label",
-	tabDirty: ".tab-dirty-indicator",
-	tabClose: ".tab-close",
+	tab: ".tab-bar .tab",
+	tabActive: ".tab-bar .tab.active",
+	tabLabel: ".tab-bar .tab-label",
+	tabDirty: ".tab-bar .tab-dirty-indicator",
+	tabClose: ".tab-bar .tab-close",
 
 	// File browser
 	fileBrowser: ".file-browser",

--- a/desktop/e2e/shared/selectors.ts
+++ b/desktop/e2e/shared/selectors.ts
@@ -5,7 +5,12 @@
 export const selectors = {
 	// Editor
 	editor: ".monaco-editor textarea",
-	editorTitle: ".editor-panel .panel-title",
+	tabBar: ".tab-bar",
+	tab: ".tab",
+	tabActive: ".tab.active",
+	tabLabel: ".tab-label",
+	tabDirty: ".tab-dirty-indicator",
+	tabClose: ".tab-close",
 
 	// File browser
 	fileBrowser: ".file-browser",

--- a/desktop/e2e/tests/file-explorer.spec.ts
+++ b/desktop/e2e/tests/file-explorer.spec.ts
@@ -49,8 +49,8 @@ test.describe("File Explorer", () => {
 		await expect(fixtureNode).toBeVisible({ timeout: 30000 });
 		await fixtureNode.dblclick();
 
-		const editorTitle = page.locator(selectors.editorTitle);
-		await expect(editorTitle).toContainText(fixtureFileName, { timeout: 30000 });
+		const activeTab = page.locator(selectors.tabActive);
+		await expect(activeTab).toContainText(fixtureFileName, { timeout: 30000 });
 
 		await page.waitForFunction(
 			(expected) => {

--- a/desktop/e2e/tests/multi-buffer-tabs.spec.ts
+++ b/desktop/e2e/tests/multi-buffer-tabs.spec.ts
@@ -51,18 +51,18 @@ test.describe("Editor tabs", () => {
 		await expect(page.locator(selectors.fileBrowser)).toBeVisible({ timeout: 30000 });
 
 		await openFixture(page, firstFile);
+		await expect(page.locator(selectors.tabActive)).toContainText(firstFile);
 		await openFixture(page, secondFile);
+		await expect(page.locator(selectors.tabActive)).toContainText(secondFile);
 
 		const tabs = page.locator(selectors.tab);
-		await expect(tabs).toHaveCount(2);
+		await expect(tabs.filter({ hasText: firstFile })).toHaveCount(1);
+		await expect(tabs.filter({ hasText: secondFile })).toHaveCount(1);
 
 		const activeTab = page.locator(selectors.tabActive);
 		await expect(activeTab).toContainText(secondFile);
 
-		await page
-			.locator(selectors.tab)
-			.filter({ has: page.locator(selectors.tabLabel, { hasText: firstFile }) });
-		first().click();
+		await page.locator(selectors.tab).filter({ hasText: firstFile }).first().click();
 		await expect(page.locator(selectors.tabActive)).toContainText(firstFile);
 
 		await page.locator(selectors.editor).click();

--- a/desktop/e2e/tests/multi-buffer-tabs.spec.ts
+++ b/desktop/e2e/tests/multi-buffer-tabs.spec.ts
@@ -65,8 +65,15 @@ test.describe("Editor tabs", () => {
 		await page.locator(selectors.tab).filter({ hasText: firstFile }).first().click();
 		await expect(page.locator(selectors.tabActive)).toContainText(firstFile);
 
-		await page.locator(selectors.editor).click();
-		await page.keyboard.type("\n# dirty");
+		await page.waitForSelector(".monaco-editor", { timeout: 30000 });
+		await page.evaluate(() => {
+			const monaco = (window as any).monaco;
+			const editors = monaco?.editor?.getEditors?.() ?? [];
+			if (!editors.length) return;
+			const editor = editors[0];
+			editor.setValue(`${editor.getValue()}\n# dirty`);
+			editor.focus();
+		});
 		await expect(page.locator(selectors.tabActive).locator(selectors.tabDirty)).toBeVisible();
 
 		await page.locator(selectors.tabActive).locator(selectors.tabClose).click();

--- a/desktop/e2e/tests/multi-buffer-tabs.spec.ts
+++ b/desktop/e2e/tests/multi-buffer-tabs.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test, type Page } from "@playwright/test";
+import { selectors } from "../shared/selectors";
+
+test.describe("Editor tabs", () => {
+	const fileTreeNodeAtDepth = (page: Page, name: string, depth: number) => {
+		const padding = depth * 16 + 12;
+		return page.locator(`${selectors.fileTreeNode}[style*="padding-left: ${padding}px"]`).filter({
+			has: page.locator(selectors.fileTreeLabel, { hasText: name }),
+		});
+	};
+
+	const fileTreeNodeByLabel = (page: Page, name: string) =>
+		page
+			.locator(selectors.fileTreeNode)
+			.filter({ has: page.locator(selectors.fileTreeLabel, { hasText: name }) });
+
+	const ensureFolderExpanded = async (
+		page: Page,
+		name: string,
+		depth: number,
+		childName: string,
+		childDepth: number,
+	) => {
+		const node = fileTreeNodeAtDepth(page, name, depth).first();
+		await expect(node).toBeVisible({ timeout: 30000 });
+
+		const childNode = fileTreeNodeAtDepth(page, childName, childDepth);
+		if ((await childNode.count()) === 0) {
+			await node.click();
+		}
+
+		await expect(childNode.first()).toBeVisible({ timeout: 30000 });
+	};
+
+	const openFixture = async (page: Page, filename: string) => {
+		await ensureFolderExpanded(page, "desktop", 0, "e2e", 1);
+		await ensureFolderExpanded(page, "e2e", 1, "shared", 2);
+		await ensureFolderExpanded(page, "shared", 2, "fixtures", 3);
+		await ensureFolderExpanded(page, "fixtures", 3, filename, 4);
+
+		const fixtureNode = fileTreeNodeByLabel(page, filename).first();
+		await expect(fixtureNode).toBeVisible({ timeout: 30000 });
+		await fixtureNode.dblclick();
+	};
+
+	test("opens multiple files in tabs and handles dirty close", async ({ page }) => {
+		const firstFile = "file-explorer-fixture.R";
+		const secondFile = "tab-switch-fixture.R";
+
+		await page.goto("/");
+		await expect(page.locator(selectors.fileBrowser)).toBeVisible({ timeout: 30000 });
+
+		await openFixture(page, firstFile);
+		await openFixture(page, secondFile);
+
+		const tabs = page.locator(selectors.tab);
+		await expect(tabs).toHaveCount(2);
+
+		const activeTab = page.locator(selectors.tabActive);
+		await expect(activeTab).toContainText(secondFile);
+
+		await page
+			.locator(selectors.tab)
+			.filter({ has: page.locator(selectors.tabLabel, { hasText: firstFile }) });
+		first().click();
+		await expect(page.locator(selectors.tabActive)).toContainText(firstFile);
+
+		await page.locator(selectors.editor).click();
+		await page.keyboard.type("\n# dirty");
+		await expect(page.locator(selectors.tabActive).locator(selectors.tabDirty)).toBeVisible();
+
+		await page.locator(selectors.tabActive).locator(selectors.tabClose).click();
+		const dialog = page.getByRole("dialog");
+		await expect(dialog).toBeVisible();
+		await expect(dialog).toContainText(`Save changes to "${firstFile}"?`);
+
+		await page.getByRole("button", { name: "Cancel" }).click();
+		await expect(page.locator(selectors.tabActive)).toContainText(firstFile);
+
+		await page.locator(selectors.tabActive).locator(selectors.tabClose).click();
+		await page.getByRole("button", { name: "Don't Save" }).click();
+		await expect(
+			page
+				.locator(selectors.tab)
+				.filter({ has: page.locator(selectors.tabLabel, { hasText: firstFile }) }),
+		).toHaveCount(0);
+	});
+});

--- a/desktop/e2e/tests/multi-buffer-tabs.spec.ts
+++ b/desktop/e2e/tests/multi-buffer-tabs.spec.ts
@@ -46,24 +46,52 @@ test.describe("Editor tabs", () => {
 	test("opens multiple files in tabs and handles dirty close", async ({ page }) => {
 		const firstFile = "file-explorer-fixture.R";
 		const secondFile = "tab-switch-fixture.R";
+		const firstFixtureText = "File Explorer fixture loaded";
+		const secondFixtureText = "Tab switch fixture loaded";
 
 		await page.goto("/");
 		await expect(page.locator(selectors.fileBrowser)).toBeVisible({ timeout: 30000 });
 
 		await openFixture(page, firstFile);
-		await expect(page.locator(selectors.tabActive)).toContainText(firstFile);
+		await page.waitForFunction(
+			(expected) => {
+				const monaco = (window as { monaco?: any }).monaco;
+				const editors = monaco?.editor?.getEditors?.() ?? [];
+				return (editors[0]?.getValue?.() ?? "").includes(expected);
+			},
+			firstFixtureText,
+			{ timeout: 30000 },
+		);
 		await openFixture(page, secondFile);
-		await expect(page.locator(selectors.tabActive)).toContainText(secondFile);
+		await expect(page.locator(selectors.tab).filter({ hasText: secondFile })).toHaveCount(1);
+		await page.waitForFunction(
+			(expected) => {
+				const monaco = (window as { monaco?: any }).monaco;
+				const editors = monaco?.editor?.getEditors?.() ?? [];
+				return (editors[0]?.getValue?.() ?? "").includes(expected);
+			},
+			secondFixtureText,
+			{ timeout: 30000 },
+		);
 
 		const tabs = page.locator(selectors.tab);
 		await expect(tabs.filter({ hasText: firstFile })).toHaveCount(1);
 		await expect(tabs.filter({ hasText: secondFile })).toHaveCount(1);
 
-		const activeTab = page.locator(selectors.tabActive);
-		await expect(activeTab).toContainText(secondFile);
+		await openFixture(page, firstFile);
+		await expect(tabs.filter({ hasText: firstFile })).toHaveCount(1);
+		await expect(tabs.filter({ hasText: secondFile })).toHaveCount(1);
 
 		await page.locator(selectors.tab).filter({ hasText: firstFile }).first().click();
-		await expect(page.locator(selectors.tabActive)).toContainText(firstFile);
+		await page.waitForFunction(
+			(expected) => {
+				const monaco = (window as { monaco?: any }).monaco;
+				const editors = monaco?.editor?.getEditors?.() ?? [];
+				return (editors[0]?.getValue?.() ?? "").includes(expected);
+			},
+			firstFixtureText,
+			{ timeout: 30000 },
+		);
 
 		await page.waitForSelector(".monaco-editor", { timeout: 30000 });
 		await page.evaluate(() => {
@@ -74,7 +102,9 @@ test.describe("Editor tabs", () => {
 			editor.setValue(`${editor.getValue()}\n# dirty`);
 			editor.focus();
 		});
-		await expect(page.locator(selectors.tabActive).locator(selectors.tabDirty)).toBeVisible();
+		await expect(
+			page.locator(selectors.tab).filter({ hasText: firstFile }).locator(selectors.tabDirty),
+		).toBeVisible();
 
 		await page.locator(selectors.tabActive).locator(selectors.tabClose).click();
 		const dialog = page.getByRole("dialog");

--- a/desktop/e2e/tests/open-folder.spec.ts
+++ b/desktop/e2e/tests/open-folder.spec.ts
@@ -46,11 +46,11 @@ test.describe("Open Folder", () => {
 			.first();
 		await expect(fileNode).toBeVisible({ timeout: 30000 });
 
-		const editorTitle = page.locator(selectors.editorTitle);
-		await expect(editorTitle).toContainText("Untitled.R");
+		const activeTab = page.locator(selectors.tabActive);
+		await expect(activeTab).toContainText("Untitled", { timeout: 30000 });
 
 		await fileNode.dblclick();
-		await expect(editorTitle).toContainText(fixtureFileName, { timeout: 30000 });
+		await expect(activeTab).toContainText(fixtureFileName, { timeout: 30000 });
 
 		await page.waitForFunction(
 			(expected) => {


### PR DESCRIPTION
## Description

Implement multi-buffer editor tabs with dirty indicators and close confirmation, plus E2E coverage for tab switching and dirty-close behavior.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `pnpm -r lint`
- `pnpm --filter client build`
- `cargo check --workspace`
- `cargo test --workspace --lib --all-features`
- `cargo test --test export_integration_test -- --nocapture`
- `cargo test --test timeline_integration_test -- --nocapture`
- `cargo test --test rmarkdown_integration_test -- --nocapture`
- `cargo test --test tool_manifests_test -- --nocapture`
- `cargo test --test viral_phylogenomics_workflow_test -- --nocapture`
- `pnpm --filter client test -- --run`
- `pnpm --filter @reprod/e2e test:playwright:headed -- multi-buffer-tabs` (timed out waiting for the dev server to finish; needs follow-up)

## Screenshots (if applicable)

N/A

## Related Issues

Closes #355
