### PR TITLE
feat: web project switching for server-hosted projects (#368)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import { MenuBar, StatusBar } from "@/components/menu";
 import {
 	AboutModal,
 	KeyboardShortcutsModal,
+	ProjectSwitchModal,
 	SessionInfoModal,
 	SettingsModal,
 } from "@/components/modals";
@@ -130,6 +131,10 @@ function App(): JSX.Element {
 					onClose={() => setModalOpen("sessionInfo", false)}
 				/>
 				<SettingsModal open={modals.settings} onClose={() => setModalOpen("settings", false)} />
+				<ProjectSwitchModal
+					open={modals.projectSwitch}
+					onClose={() => setModalOpen("projectSwitch", false)}
+				/>
 				<PermissionRequestManager />
 			</div>
 		</ToastProvider>

--- a/client/src/components/agent/ExternalAgentSettingsPane.tsx
+++ b/client/src/components/agent/ExternalAgentSettingsPane.tsx
@@ -7,21 +7,17 @@ import { classNames } from "@/utils/classNames";
 export function ExternalAgentSettingsPane(): JSX.Element {
 	const activeAgent = useStore((state) => state.activeAgent);
 	const detectedAgents = useStore((state) => state.detectedAgents);
-	const setActiveMode = useStore((state) => state.setActiveMode);
-	const setActiveAgent = useStore((state) => state.setActiveAgent);
 	const setDetectedAgents = useStore((state) => state.setDetectedAgents);
 	const acpAdminClient = useMemo(() => getAcpAdminClient(), []);
 
 	const fetchAgentsAsync = useCallback(async () => {
-		const { config, agents } = await acpAdminClient.bootstrap();
+		const agents = await acpAdminClient.detectAgents();
 		setDetectedAgents(agents);
-		setActiveMode((config.active_mode as "api" | "external_agent") ?? "api");
-		setActiveAgent(config.active_agent);
 		return null;
-	}, [acpAdminClient, setDetectedAgents, setActiveMode, setActiveAgent]);
+	}, [acpAdminClient, setDetectedAgents]);
 
 	const { loading, execute: fetchAgents } = useAsyncState(fetchAgentsAsync, {
-		onError: (error) => console.error("Failed to load ACP agents/config", error),
+		onError: (error) => console.error("Failed to load ACP agents", error),
 	});
 
 	useEffect(() => {

--- a/client/src/components/agent/ExternalAgentSettingsPane.tsx
+++ b/client/src/components/agent/ExternalAgentSettingsPane.tsx
@@ -7,6 +7,8 @@ import { classNames } from "@/utils/classNames";
 export function ExternalAgentSettingsPane(): JSX.Element {
 	const activeAgent = useStore((state) => state.activeAgent);
 	const detectedAgents = useStore((state) => state.detectedAgents);
+	const setActiveMode = useStore((state) => state.setActiveMode);
+	const setActiveAgent = useStore((state) => state.setActiveAgent);
 	const setDetectedAgents = useStore((state) => state.setDetectedAgents);
 	const acpAdminClient = useMemo(() => getAcpAdminClient(), []);
 

--- a/client/src/components/agent/ExternalAgentSettingsPane.tsx
+++ b/client/src/components/agent/ExternalAgentSettingsPane.tsx
@@ -6,7 +6,7 @@ import { classNames } from "@/utils/classNames";
 
 export function ExternalAgentSettingsPane(): JSX.Element {
 	const activeAgent = useStore((state) => state.activeAgent);
-	const detectedAgents = useStore((state) => state.detectedAgents);
+	const detectedAgents = useStore((state) => state.detectedAgents) ?? [];
 	const setActiveMode = useStore((state) => state.setActiveMode);
 	const setActiveAgent = useStore((state) => state.setActiveAgent);
 	const setDetectedAgents = useStore((state) => state.setDetectedAgents);

--- a/client/src/components/agent/__tests__/ExternalAgentSettingsPane.test.tsx
+++ b/client/src/components/agent/__tests__/ExternalAgentSettingsPane.test.tsx
@@ -3,22 +3,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useStore } from "@/core";
 import { ExternalAgentSettingsPane } from "../ExternalAgentSettingsPane";
 
-const bootstrapMock = vi.fn();
 const setConfigMock = vi.fn();
+const detectAgentsMock = vi.fn();
 
 vi.mock("@/services/acpAdminClient", () => ({
 	getAcpAdminClient: () => ({
-		bootstrap: (...args: any[]) => bootstrapMock(...args),
+		bootstrap: vi.fn(),
 		setConfig: (...args: any[]) => setConfigMock(...args),
-		detectAgents: vi.fn(),
+		detectAgents: (...args: any[]) => detectAgentsMock(...args),
 		getConfig: vi.fn(),
 	}),
 }));
 
 describe("ExternalAgentSettingsPane", () => {
 	beforeEach(() => {
-		bootstrapMock.mockReset();
 		setConfigMock.mockReset();
+		detectAgentsMock.mockReset();
 		useStore.setState({
 			activeMode: "api",
 			activeAgent: null,
@@ -26,37 +26,23 @@ describe("ExternalAgentSettingsPane", () => {
 		});
 	});
 
-	it("bootstraps agent config and detection on mount", async () => {
-		bootstrapMock.mockResolvedValue({
-			config: {
-				active_mode: "external_agent",
-				active_agent: "claude",
-				active_agent_command: null,
-			},
-			agents: [
-				{ id: "claude", name: "Claude", command: "claude-code-acp", available: true, path: null },
-			],
-		});
+	it("loads available agents on mount", async () => {
+		detectAgentsMock.mockResolvedValue([
+			{ id: "claude", name: "Claude", command: "claude-code-acp", available: true, path: null },
+		]);
 
 		render(<ExternalAgentSettingsPane />);
 
-		await waitFor(() => expect(bootstrapMock).toHaveBeenCalled());
-		expect(useStore.getState().activeMode).toBe("external_agent");
-		expect(useStore.getState().activeAgent).toBe("claude");
+		await waitFor(() => expect(detectAgentsMock).toHaveBeenCalled());
+		expect(useStore.getState().activeMode).toBe("api");
+		expect(useStore.getState().activeAgent).toBeNull();
 		expect(useStore.getState().detectedAgents).toHaveLength(1);
 	});
 
 	it("persists selection when choosing an agent", async () => {
-		bootstrapMock.mockResolvedValue({
-			config: {
-				active_mode: "external_agent",
-				active_agent: null,
-				active_agent_command: null,
-			},
-			agents: [
-				{ id: "claude", name: "Claude", command: "claude-code-acp", available: true, path: null },
-			],
-		});
+		detectAgentsMock.mockResolvedValue([
+			{ id: "claude", name: "Claude", command: "claude-code-acp", available: true, path: null },
+		]);
 		setConfigMock.mockResolvedValue({
 			active_mode: "external_agent",
 			active_agent: "claude",
@@ -73,10 +59,10 @@ describe("ExternalAgentSettingsPane", () => {
 	});
 
 	it("toggles the refresh button label based on loading state", async () => {
-		let resolveBootstrap: ((value: any) => void) | null = null;
-		bootstrapMock.mockReturnValue(
+		let resolveAgents: ((value: any) => void) | null = null;
+		detectAgentsMock.mockReturnValue(
 			new Promise((resolve) => {
-				resolveBootstrap = resolve;
+				resolveAgents = resolve;
 			}),
 		);
 
@@ -84,14 +70,7 @@ describe("ExternalAgentSettingsPane", () => {
 
 		await waitFor(() => expect(getByText("Refreshing...")).toBeTruthy());
 
-		resolveBootstrap?.({
-			config: {
-				active_mode: "external_agent",
-				active_agent: null,
-				active_agent_command: null,
-			},
-			agents: [],
-		});
+		resolveAgents?.([]);
 
 		await waitFor(() => expect(getByText("Refresh")).toBeTruthy());
 	});

--- a/client/src/components/agent/__tests__/ExternalAgentSettingsPane.test.tsx
+++ b/client/src/components/agent/__tests__/ExternalAgentSettingsPane.test.tsx
@@ -39,6 +39,23 @@ describe("ExternalAgentSettingsPane", () => {
 		expect(useStore.getState().detectedAgents).toHaveLength(1);
 	});
 
+	it("does not reset active mode while refreshing agents", async () => {
+		useStore.setState({
+			activeMode: "external_agent",
+			activeAgent: "claude",
+			detectedAgents: [],
+		});
+		detectAgentsMock.mockResolvedValue([
+			{ id: "claude", name: "Claude", command: "claude-code-acp", available: true, path: null },
+		]);
+
+		render(<ExternalAgentSettingsPane />);
+
+		await waitFor(() => expect(detectAgentsMock).toHaveBeenCalled());
+		expect(useStore.getState().activeMode).toBe("external_agent");
+		expect(useStore.getState().activeAgent).toBe("claude");
+	});
+
 	it("persists selection when choosing an agent", async () => {
 		detectAgentsMock.mockResolvedValue([
 			{ id: "claude", name: "Claude", command: "claude-code-acp", available: true, path: null },

--- a/client/src/components/modals/ProjectSwitchModal.tsx
+++ b/client/src/components/modals/ProjectSwitchModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { IS_TAURI } from "@/constants/features";
 import { socketService } from "@/services/socket";
-import type { ProjectRecord } from "@/types";
+import type { ExtractServerMessage, ProjectRecord } from "@/types";
 import { getErrorMessage } from "@/utils/error";
 import { ModalShell } from "./ModalShell";
 
@@ -73,10 +73,17 @@ export function ProjectSwitchModal({ open, onClose }: ProjectSwitchModalProps): 
 		setCreating(true);
 		setError(null);
 		try {
-			const response = await socketService.request(
+			const response = await socketService.sendAndWait(
 				{ type: "project_create", name },
-				"project_created",
+				(
+					message,
+				): message is ExtractServerMessage<"project_created"> | ExtractServerMessage<"error"> =>
+					message.type === "project_created" || message.type === "error",
 			);
+			if (response.type === "error") {
+				setError(response.message);
+				return;
+			}
 			setProjects((prev) => [response.project, ...prev]);
 			setSelectedId(response.project.id);
 			setNewProjectName("");

--- a/client/src/components/modals/ProjectSwitchModal.tsx
+++ b/client/src/components/modals/ProjectSwitchModal.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useMemo, useState } from "react";
+import { IS_TAURI } from "@/constants/features";
+import { socketService } from "@/services/socket";
+import type { ProjectRecord } from "@/types";
+import { getErrorMessage } from "@/utils/error";
+import { ModalShell } from "./ModalShell";
+
+interface ProjectSwitchModalProps {
+	open: boolean;
+	onClose: () => void;
+}
+
+export function ProjectSwitchModal({ open, onClose }: ProjectSwitchModalProps): JSX.Element | null {
+	const [projects, setProjects] = useState<ProjectRecord[]>([]);
+	const [selectedId, setSelectedId] = useState<string | null>(null);
+	const [search, setSearch] = useState("");
+	const [newProjectName, setNewProjectName] = useState("");
+	const [loading, setLoading] = useState(false);
+	const [creating, setCreating] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!open || IS_TAURI) return;
+
+		let active = true;
+		setLoading(true);
+		setError(null);
+
+		socketService
+			.request({ type: "project_list" }, "project_list_result")
+			.then((message) => {
+				if (!active) return;
+				setProjects(message.projects);
+				setSelectedId(message.projects[0]?.id ?? null);
+			})
+			.catch((err) => {
+				if (!active) return;
+				setError(getErrorMessage(err, "Failed to load projects"));
+			})
+			.finally(() => {
+				if (!active) return;
+				setLoading(false);
+			});
+
+		return () => {
+			active = false;
+		};
+	}, [open]);
+
+	const filteredProjects = useMemo(() => {
+		const query = search.trim().toLowerCase();
+		if (!query) return projects;
+		return projects.filter((project) => {
+			return (
+				project.name.toLowerCase().includes(query) || project.path.toLowerCase().includes(query)
+			);
+		});
+	}, [projects, search]);
+
+	const handleOpenProject = () => {
+		if (!selectedId) return;
+		socketService.send({ type: "project_switch", project_id: selectedId });
+		onClose();
+	};
+
+	const handleCreateProject = async () => {
+		const name = newProjectName.trim();
+		if (!name) {
+			setError("Project name is required");
+			return;
+		}
+
+		setCreating(true);
+		setError(null);
+		try {
+			const response = await socketService.request(
+				{ type: "project_create", name },
+				"project_created",
+			);
+			setProjects((prev) => [response.project, ...prev]);
+			setSelectedId(response.project.id);
+			setNewProjectName("");
+		} catch (err) {
+			setError(getErrorMessage(err, "Failed to create project"));
+		} finally {
+			setCreating(false);
+		}
+	};
+
+	if (IS_TAURI) {
+		return null;
+	}
+
+	return (
+		<ModalShell
+			open={open}
+			onClose={onClose}
+			title="Switch Project"
+			subtitle="Select a server-side project"
+			footer={
+				<div className="modal-footer-actions">
+					<button type="button" className="btn" onClick={onClose}>
+						Cancel
+					</button>
+					<button
+						type="button"
+						className="btn btn-primary"
+						onClick={handleOpenProject}
+						disabled={!selectedId}
+					>
+						Open Project
+					</button>
+				</div>
+			}
+		>
+			<div className="project-switch">
+				<div className="project-switch-header">
+					<label htmlFor="project-switch-search">Search</label>
+					<input
+						id="project-switch-search"
+						type="text"
+						placeholder="Filter by name or path"
+						value={search}
+						onChange={(event) => setSearch(event.target.value)}
+					/>
+				</div>
+
+				{error && <div className="project-switch-error">{error}</div>}
+				{loading ? (
+					<div className="project-switch-loading">Loading projects...</div>
+				) : (
+					<div className="project-switch-list" role="listbox" aria-label="Projects">
+						{filteredProjects.length === 0 ? (
+							<div className="project-switch-empty">No projects found.</div>
+						) : (
+							filteredProjects.map((project) => (
+								<button
+									key={project.id}
+									type="button"
+									className={
+										project.id === selectedId
+											? "project-switch-item selected"
+											: "project-switch-item"
+									}
+									role="option"
+									aria-selected={project.id === selectedId}
+									onClick={() => setSelectedId(project.id)}
+								>
+									<span className="project-switch-name">{project.name}</span>
+									<span className="project-switch-path">{project.path}</span>
+								</button>
+							))
+						)}
+					</div>
+				)}
+
+				<div className="project-switch-create">
+					<label htmlFor="project-create-name">Create new project</label>
+					<div className="project-switch-create-row">
+						<input
+							id="project-create-name"
+							type="text"
+							placeholder="Project name"
+							value={newProjectName}
+							onChange={(event) => setNewProjectName(event.target.value)}
+							disabled={creating}
+						/>
+						<button
+							type="button"
+							className="btn btn-secondary"
+							onClick={handleCreateProject}
+							disabled={creating}
+						>
+							{creating ? "Creating..." : "Create"}
+						</button>
+					</div>
+				</div>
+			</div>
+		</ModalShell>
+	);
+}

--- a/client/src/components/modals/__tests__/ProjectSwitchModal.test.tsx
+++ b/client/src/components/modals/__tests__/ProjectSwitchModal.test.tsx
@@ -5,6 +5,7 @@ import { ProjectSwitchModal } from "../ProjectSwitchModal";
 
 const requestMock = vi.fn();
 const sendMock = vi.fn();
+const sendAndWaitMock = vi.fn();
 
 vi.mock("@/constants/features", () => ({
 	IS_TAURI: false,
@@ -15,6 +16,7 @@ vi.mock("@/services/socket", () => ({
 	socketService: {
 		request: (...args: any[]) => requestMock(...args),
 		send: (...args: any[]) => sendMock(...args),
+		sendAndWait: (...args: any[]) => sendAndWaitMock(...args),
 	},
 }));
 
@@ -22,6 +24,7 @@ describe("ProjectSwitchModal", () => {
 	beforeEach(() => {
 		requestMock.mockReset();
 		sendMock.mockReset();
+		sendAndWaitMock.mockReset();
 	});
 
 	it("loads and renders project list", async () => {
@@ -42,20 +45,13 @@ describe("ProjectSwitchModal", () => {
 	});
 
 	it("creates a project and adds it to the list", async () => {
-		requestMock.mockImplementation(async (payload: { type: string }) => {
-			if (payload.type === "project_list") {
-				return {
-					type: "project_list_result",
-					projects: [],
-				};
-			}
-			if (payload.type === "project_create") {
-				return {
-					type: "project_created",
-					project: { id: "3", name: "New Project", path: "/srv/new", created_at: 3 },
-				};
-			}
-			throw new Error("Unexpected request");
+		requestMock.mockResolvedValueOnce({
+			type: "project_list_result",
+			projects: [],
+		});
+		sendAndWaitMock.mockResolvedValueOnce({
+			type: "project_created",
+			project: { id: "3", name: "New Project", path: "/srv/new", created_at: 3 },
 		});
 
 		render(<ProjectSwitchModal open onClose={vi.fn()} />);

--- a/client/src/components/modals/__tests__/ProjectSwitchModal.test.tsx
+++ b/client/src/components/modals/__tests__/ProjectSwitchModal.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectSwitchModal } from "../ProjectSwitchModal";
+
+const requestMock = vi.fn();
+const sendMock = vi.fn();
+
+vi.mock("@/constants/features", () => ({
+	IS_TAURI: false,
+	isTauri: () => false,
+}));
+
+vi.mock("@/services/socket", () => ({
+	socketService: {
+		request: (...args: any[]) => requestMock(...args),
+		send: (...args: any[]) => sendMock(...args),
+	},
+}));
+
+describe("ProjectSwitchModal", () => {
+	beforeEach(() => {
+		requestMock.mockReset();
+		sendMock.mockReset();
+	});
+
+	it("loads and renders project list", async () => {
+		requestMock.mockResolvedValueOnce({
+			type: "project_list_result",
+			projects: [
+				{ id: "1", name: "Alpha", path: "/srv/alpha", created_at: 1 },
+				{ id: "2", name: "Beta", path: "/srv/beta", created_at: 2 },
+			],
+		});
+
+		render(<ProjectSwitchModal open onClose={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("Alpha")).toBeTruthy();
+		});
+		expect(screen.getByText("Beta")).toBeTruthy();
+	});
+
+	it("creates a project and adds it to the list", async () => {
+		requestMock.mockImplementation(async (payload: { type: string }) => {
+			if (payload.type === "project_list") {
+				return {
+					type: "project_list_result",
+					projects: [],
+				};
+			}
+			if (payload.type === "project_create") {
+				return {
+					type: "project_created",
+					project: { id: "3", name: "New Project", path: "/srv/new", created_at: 3 },
+				};
+			}
+			throw new Error("Unexpected request");
+		});
+
+		render(<ProjectSwitchModal open onClose={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(screen.getByText("No projects found.")).toBeTruthy();
+		});
+
+		const input = screen.getByLabelText("Create new project");
+		await userEvent.type(input, "New Project");
+		await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+		await waitFor(() => {
+			expect(screen.getByText("New Project")).toBeTruthy();
+		});
+	});
+});

--- a/client/src/components/modals/__tests__/SettingsModal.test.tsx
+++ b/client/src/components/modals/__tests__/SettingsModal.test.tsx
@@ -4,27 +4,20 @@ import { DEFAULT_SETTINGS } from "@/constants/defaultSettings";
 import { useStore } from "@/core";
 import { SettingsModal } from "../SettingsModal";
 
-const bootstrapMock = vi.fn();
+const detectAgentsMock = vi.fn();
 
 vi.mock("@/services/acpAdminClient", () => ({
 	getAcpAdminClient: () => ({
-		bootstrap: (...args: any[]) => bootstrapMock(...args),
+		bootstrap: vi.fn(),
 		setConfig: vi.fn(),
-		detectAgents: vi.fn(),
+		detectAgents: (...args: any[]) => detectAgentsMock(...args),
 		getConfig: vi.fn(),
 	}),
 }));
 
 describe("SettingsModal", () => {
 	beforeEach(() => {
-		bootstrapMock.mockResolvedValue({
-			config: {
-				active_mode: "external_agent",
-				active_agent: null,
-				active_agent_command: null,
-			},
-			agents: [],
-		});
+		detectAgentsMock.mockResolvedValue([]);
 
 		useStore.setState({
 			settings: { ...DEFAULT_SETTINGS },
@@ -69,7 +62,7 @@ describe("SettingsModal", () => {
 
 		render(<SettingsModal open onClose={vi.fn()} />);
 
-		await waitFor(() => expect(bootstrapMock).toHaveBeenCalled());
+		await waitFor(() => expect(detectAgentsMock).toHaveBeenCalled());
 		expect(screen.getByRole("heading", { name: "AI Provider" })).toBeTruthy();
 		expect(screen.getByRole("heading", { name: "External Agents (ACP)" })).toBeTruthy();
 		expect(screen.queryByRole("heading", { name: "API Providers" })).toBeNull();

--- a/client/src/components/modals/index.ts
+++ b/client/src/components/modals/index.ts
@@ -1,4 +1,5 @@
 export { AboutModal } from "./AboutModal";
 export { KeyboardShortcutsModal } from "./KeyboardShortcutsModal";
+export { ProjectSwitchModal } from "./ProjectSwitchModal";
 export { SessionInfoModal } from "./SessionInfoModal";
 export { SettingsModal } from "./SettingsModal";

--- a/client/src/constants/features.ts
+++ b/client/src/constants/features.ts
@@ -9,3 +9,4 @@ const detectTauri = (): boolean => {
 };
 
 export const IS_TAURI = detectTauri();
+export const isTauri = (): boolean => detectTauri();

--- a/client/src/core/commands/modules/file.ts
+++ b/client/src/core/commands/modules/file.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_FILENAMES } from "@/constants/ui";
+import { IS_TAURI, isTauri } from "@/constants/features";
 import { DEFAULT_R_SCRIPT, type Buffer } from "@/core/state/slices/editorSlice";
 import { createBufferId } from "@/core/state/utils/createBufferId";
 import { useStore } from "@/core/state/store";
@@ -8,6 +9,7 @@ import { openFolder } from "@/utils/folderOperations";
 import { commandRegistry } from "../registry";
 
 export function setupFileCommands() {
+	const openFolderTitle = IS_TAURI ? "Open Folder..." : "Open Project...";
 	commandRegistry.registerMany([
 		{
 			id: "file.new",
@@ -60,17 +62,21 @@ export function setupFileCommands() {
 		},
 		{
 			id: "file.openFolder",
-			title: "Open Folder...",
+			title: openFolderTitle,
 			category: "File",
 			keybinding: "Mod+Shift+O",
 			execute: async () => {
 				try {
-					const folderPath = await openFolder();
-					if (!folderPath) return;
-					socketService.send({
-						type: "project_switch_folder",
-						path: folderPath,
-					});
+					if (isTauri()) {
+						const folderPath = await openFolder();
+						if (!folderPath) return;
+						socketService.send({
+							type: "project_switch_folder",
+							path: folderPath,
+						});
+						return;
+					}
+					useStore.getState().setModalOpen("projectSwitch", true);
 				} catch (error) {}
 			},
 		},

--- a/client/src/core/commands/modules/file.ts
+++ b/client/src/core/commands/modules/file.ts
@@ -3,9 +3,12 @@ import { DEFAULT_FILENAMES } from "@/constants/ui";
 import { DEFAULT_R_SCRIPT, type Buffer } from "@/core/state/slices/editorSlice";
 import { createBufferId } from "@/core/state/utils/createBufferId";
 import { useStore } from "@/core/state/store";
+import { useFileSystemStore } from "@/core/fileSystemStore";
 import { socketService } from "@/services/socket";
+import { showError } from "@/services/toastService";
 import { downloadFile, openFile } from "@/utils/fileOperations";
 import { openFolder } from "@/utils/folderOperations";
+import type { ExtractServerMessage } from "@/types";
 import { CommandBuilder } from "../builders";
 import { CommandResolver } from "../resolvers";
 import { commandRegistry } from "../registry";
@@ -83,10 +86,21 @@ export function setupFileCommands() {
 				if (isTauri()) {
 					const folderPath = await openFolder();
 					if (!folderPath) return;
-					socketService.send({
-						type: "project_switch_folder",
-						path: folderPath,
-					});
+					const response = await socketService.sendAndWait(
+						{ type: "project_switch_folder", path: folderPath },
+						(
+							message,
+						): message is ExtractServerMessage<"project_opened"> | ExtractServerMessage<"error"> =>
+							message.type === "project_opened" || message.type === "error",
+					);
+					if (response.type === "error") {
+						showError(response.message);
+						return;
+					}
+					useFileSystemStore
+						.getState()
+						.resetAndLoadRoot()
+						.catch(() => {});
 					return;
 				}
 				useStore.getState().setModalOpen("projectSwitch", true);

--- a/client/src/core/menu/menuConfig.ts
+++ b/client/src/core/menu/menuConfig.ts
@@ -1,4 +1,5 @@
 import type { ViewPane } from "@/core/state/slices/viewSlice";
+import { IS_TAURI } from "@/constants/features";
 import { MenuBuilder } from "./builders";
 import type { MenuSection } from "./domain";
 import { IsViewPaneVisible, When } from "./specifications";
@@ -22,7 +23,7 @@ export function buildMenuSections(): MenuSection[] {
 		.item("file:open", "Open...", "file.open", {
 			shortcut: "⌘O",
 		})
-		.item("file:open-folder", "Open Folder...", "file.openFolder", {
+		.item("file:open-folder", IS_TAURI ? "Open Folder..." : "Open Project...", "file.openFolder", {
 			shortcut: "⌘⇧O",
 		})
 		.separator()

--- a/client/src/core/state/slices/viewSlice.test.ts
+++ b/client/src/core/state/slices/viewSlice.test.ts
@@ -21,6 +21,7 @@ describe("viewSlice", () => {
 			about: false,
 			sessionInfo: false,
 			settings: false,
+			projectSwitch: false,
 		});
 		expect(store.view.zoom).toBe(1);
 	});

--- a/client/src/core/state/slices/viewSlice.ts
+++ b/client/src/core/state/slices/viewSlice.ts
@@ -1,7 +1,13 @@
 import type { StateCreator } from "zustand";
 
 export type ViewPane = "files" | "editor" | "assistant";
-export type ModalType = "export" | "shortcuts" | "about" | "sessionInfo" | "settings";
+export type ModalType =
+	| "export"
+	| "shortcuts"
+	| "about"
+	| "sessionInfo"
+	| "settings"
+	| "projectSwitch";
 
 export interface ViewData {
 	panes: Record<ViewPane, boolean>;
@@ -56,6 +62,7 @@ export const createViewSlice: StateCreator<ViewState> = (set, get) => ({
 			about: false,
 			sessionInfo: false,
 			settings: false,
+			projectSwitch: false,
 		},
 		zoom: 1,
 	},

--- a/client/src/css/components/modals/index.css
+++ b/client/src/css/components/modals/index.css
@@ -3,3 +3,4 @@
 @import "./shortcuts.css";
 @import "./about.css";
 @import "./session-info.css";
+@import "./project-switch.css";

--- a/client/src/css/components/modals/project-switch.css
+++ b/client/src/css/components/modals/project-switch.css
@@ -1,0 +1,87 @@
+.project-switch {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.project-switch-header,
+.project-switch-create {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.project-switch-header label,
+.project-switch-create label {
+	font-size: 0.85rem;
+	color: var(--modal-subtext-color);
+}
+
+.project-switch-header input,
+.project-switch-create input {
+	background: var(--modal-contrast-bg);
+	border: 1px solid var(--modal-contrast-border);
+	border-radius: 8px;
+	padding: 10px 12px;
+	color: inherit;
+}
+
+.project-switch-list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-height: 280px;
+	overflow-y: auto;
+	padding: 8px;
+	border: 1px solid var(--modal-surface-border);
+	border-radius: var(--modal-surface-radius);
+	background: var(--modal-surface-bg);
+}
+
+.project-switch-item {
+	text-align: left;
+	border: 1px solid var(--modal-card-border);
+	border-radius: var(--modal-card-radius);
+	background: var(--modal-card-bg);
+	padding: 10px 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	color: inherit;
+	cursor: pointer;
+}
+
+.project-switch-item.selected {
+	border-color: var(--modal-accent);
+	box-shadow: 0 0 0 1px var(--modal-accent);
+}
+
+.project-switch-name {
+	font-weight: 600;
+}
+
+.project-switch-path {
+	font-size: 0.85rem;
+	color: var(--modal-muted-color);
+}
+
+.project-switch-empty,
+.project-switch-loading,
+.project-switch-error {
+	font-size: 0.9rem;
+	color: var(--modal-subtext-color);
+}
+
+.project-switch-error {
+	color: #ffb3b3;
+}
+
+.project-switch-create-row {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+}
+
+.project-switch-create-row input {
+	flex: 1;
+}

--- a/client/src/services/sessionPersistence.ts
+++ b/client/src/services/sessionPersistence.ts
@@ -23,6 +23,7 @@ export const DEFAULT_VIEW_STATE: ViewData = {
 		about: false,
 		sessionInfo: false,
 		settings: false,
+		projectSwitch: false,
 	},
 	zoom: 1,
 };

--- a/client/src/types/ws.ts
+++ b/client/src/types/ws.ts
@@ -121,6 +121,9 @@ export type ClientMessage =
 			to?: string;
 	  }
 	| { type: "project_switch_folder"; path: string }
+	| { type: "project_list" }
+	| { type: "project_switch"; project_id: string }
+	| { type: "project_create"; name: string; base_path?: string }
 	| { type: "plot_history_get" }
 	| { type: "plot_history_set_active"; plot_id: string }
 	| { type: "plot_history_export"; plot_id: string; path: string; format?: PlotHistoryExportFormat }
@@ -172,6 +175,8 @@ export type ServerMessage =
 			error?: string | null;
 	  }
 	| { type: "project_opened"; project: ProjectRecord; state?: Record<string, unknown> | null }
+	| { type: "project_list_result"; projects: ProjectRecord[] }
+	| { type: "project_created"; project: ProjectRecord }
 	| {
 			type: "plot_history_state";
 			activePlotId?: string | null;

--- a/client/src/utils/__tests__/folderOperations.test.ts
+++ b/client/src/utils/__tests__/folderOperations.test.ts
@@ -20,16 +20,13 @@ describe("openFolder", () => {
 		(window as unknown as { __TAURI__?: object }).__TAURI__ = originalTauri;
 	});
 
-	it("returns null and shows an error when not running in Tauri", async () => {
+	it("returns null when not running in Tauri", async () => {
 		(window as unknown as { __TAURI__?: object }).__TAURI__ = undefined;
-		const toast = await import("@/services/toastService");
-
 		const result = await openFolder();
 
 		expect(result).toBeNull();
-		expect(toast.showError).toHaveBeenCalledWith(
-			"Open Folder is only available in the desktop app.",
-		);
+		const toast = await import("@/services/toastService");
+		expect(toast.showError).not.toHaveBeenCalled();
 	});
 
 	it("returns the selected folder path", async () => {

--- a/client/src/utils/folderOperations.ts
+++ b/client/src/utils/folderOperations.ts
@@ -1,11 +1,8 @@
+import { isTauri } from "@/constants/features";
 import { showError } from "@/services/toastService";
 
-type TauriWindow = Window & { __TAURI__?: object };
-
 export const openFolder = async (): Promise<string | null> => {
-	const tauriWindow = window as TauriWindow;
-	if (!tauriWindow.__TAURI__) {
-		showError("Open Folder is only available in the desktop app.");
+	if (!isTauri()) {
 		return null;
 	}
 

--- a/desktop/e2e/playwright.config.ts
+++ b/desktop/e2e/playwright.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { defineConfig, devices } from "@playwright/test";
 
 /**
@@ -71,5 +72,9 @@ export default defineConfig({
 		timeout: 120000,
 		stdout: "ignore",
 		stderr: "ignore",
+		env: {
+			...process.env,
+			REPROD_WORKSPACE_ROOT: path.resolve(__dirname, "shared/fixtures/projects"),
+		},
 	},
 });

--- a/desktop/e2e/shared/fixtures/projects/alpha/alpha.R
+++ b/desktop/e2e/shared/fixtures/projects/alpha/alpha.R
@@ -1,0 +1,2 @@
+# E2E Alpha project file
+message("Alpha project loaded")

--- a/desktop/e2e/shared/fixtures/projects/alpha/reprod.json
+++ b/desktop/e2e/shared/fixtures/projects/alpha/reprod.json
@@ -1,0 +1,8 @@
+{
+	"id": "e2e-project-alpha-0001",
+	"name": "E2E Alpha",
+	"git_remote": null,
+	"created_at": 1769000000000,
+	"last_opened_at": 1769000001000,
+	"version": 1
+}

--- a/desktop/e2e/shared/fixtures/projects/beta/beta.R
+++ b/desktop/e2e/shared/fixtures/projects/beta/beta.R
@@ -1,0 +1,2 @@
+# E2E Beta project file
+message("Beta project loaded")

--- a/desktop/e2e/shared/fixtures/projects/beta/reprod.json
+++ b/desktop/e2e/shared/fixtures/projects/beta/reprod.json
@@ -1,0 +1,8 @@
+{
+	"id": "e2e-project-beta-0001",
+	"name": "E2E Beta",
+	"git_remote": null,
+	"created_at": 1769000002000,
+	"last_opened_at": 1769000003000,
+	"version": 1
+}

--- a/desktop/e2e/tests/open-folder.spec.ts
+++ b/desktop/e2e/tests/open-folder.spec.ts
@@ -3,6 +3,40 @@ import { expect, test } from "@playwright/test";
 import { selectors } from "../shared/selectors";
 
 test.describe("Open Folder", () => {
+	test("updates file explorer after workspace switch", async ({ page }) => {
+		const repoRoot = path.resolve(process.cwd(), "../..");
+		const fixtureFolder = path.join(repoRoot, "desktop/e2e/shared/fixtures/open-folder");
+		const fixtureFileName = "sample.R";
+
+		await page.goto("/");
+
+		const fileBrowser = page.locator(selectors.fileBrowser);
+		await expect(fileBrowser).toBeVisible({ timeout: 30000 });
+		await expect(page.getByText("Connected")).toBeVisible({ timeout: 30000 });
+		await page.waitForFunction(() => {
+			const helper = (window as { reprodTest?: { isConnected?: () => boolean } }).reprodTest;
+			return helper?.isConnected?.();
+		});
+
+		const didSend = await page.evaluate((folderPath) => {
+			const helper = (window as { reprodTest?: { sendMessage: (payload: any) => boolean } })
+				.reprodTest;
+			if (!helper?.sendMessage) {
+				throw new Error("reprodTest helper not available");
+			}
+			return helper.sendMessage({ type: "project_switch_folder", path: folderPath });
+		}, fixtureFolder);
+		expect(didSend).toBeTruthy();
+
+		await expect(page.getByText("Project: open-folder")).toBeVisible({ timeout: 30000 });
+
+		const fixtureLabel = page.locator(selectors.fileTreeLabel).filter({ hasText: fixtureFileName });
+		await expect(fixtureLabel).toBeVisible({ timeout: 30000 });
+
+		const repoFile = page.locator(selectors.fileTreeLabel).filter({ hasText: "AGENTS.md" });
+		await expect(repoFile).toHaveCount(0);
+	});
+
 	test("switches workspace and loads file content", async ({ page }) => {
 		const repoRoot = path.resolve(process.cwd(), "../..");
 		const fixtureFolder = path.join(repoRoot, "desktop/e2e/shared/fixtures/open-folder");

--- a/desktop/e2e/tests/project-switch.spec.ts
+++ b/desktop/e2e/tests/project-switch.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { selectors } from "../shared/selectors";
+
+test.describe("Project Switch (Web)", () => {
+	test("opens modal and switches to a server project", async ({ page }) => {
+		await page.goto("/");
+
+		const fileBrowser = page.locator(selectors.fileBrowser);
+		await expect(fileBrowser).toBeVisible({ timeout: 30000 });
+		await expect(page.getByText("Connected")).toBeVisible({ timeout: 30000 });
+		await page.waitForFunction(() => {
+			const helper = (window as { reprodTest?: { isConnected?: () => boolean } }).reprodTest;
+			return helper?.isConnected?.();
+		});
+
+		await page.keyboard.press("Control+Shift+O");
+
+		const modalTitle = page.getByRole("heading", { name: "Switch Project" });
+		await expect(modalTitle).toBeVisible({ timeout: 30000 });
+
+		const alphaItem = page.locator(".project-switch-item", { hasText: "E2E Alpha" });
+		await expect(alphaItem).toBeVisible({ timeout: 30000 });
+		await alphaItem.click();
+
+		const openButton = page.getByRole("button", { name: "Open Project" });
+		await expect(openButton).toBeEnabled();
+		await openButton.click();
+
+		await expect(modalTitle).toBeHidden({ timeout: 30000 });
+
+		const alphaFile = page
+			.locator(selectors.fileTreeNode)
+			.filter({
+				has: page.locator(selectors.fileTreeLabel, { hasText: "alpha.R" }),
+			})
+			.first();
+		await expect(alphaFile).toBeVisible({ timeout: 30000 });
+	});
+});

--- a/desktop/e2e/tests/settings-acp-mode.spec.ts
+++ b/desktop/e2e/tests/settings-acp-mode.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+const settingsDialogName = "Settings";
+
+test.describe("Settings ACP mode", () => {
+	test("keeps External Agent (ACP) selected after agent refresh", async ({ page }) => {
+		await page.goto("/");
+
+		const statusBarSettingsButton = page.locator(".statusbar-ai");
+		await expect(statusBarSettingsButton).toBeVisible({ timeout: 30000 });
+		await statusBarSettingsButton.click();
+
+		const settingsDialog = page.getByRole("dialog", { name: settingsDialogName });
+		await expect(settingsDialog).toBeVisible({ timeout: 10000 });
+
+		const externalAgentRadio = page.getByLabel("External Agent (ACP)");
+		await externalAgentRadio.click();
+		await expect(externalAgentRadio).toBeChecked({ timeout: 10000 });
+
+		const externalAgentHeading = page.getByRole("heading", { name: "External Agents (ACP)" });
+		await expect(externalAgentHeading).toBeVisible({ timeout: 10000 });
+
+		const refreshButton = page.getByRole("button", { name: "Refresh" });
+		await expect(refreshButton).toBeVisible({ timeout: 10000 });
+
+		await expect(externalAgentRadio).toBeChecked({ timeout: 5000 });
+		await expect(page.getByLabel("API Providers")).not.toBeChecked();
+	});
+});

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -130,6 +130,16 @@ pub(super) enum WSRequest {
     },
     #[serde(rename = "project_switch_folder")]
     ProjectSwitchFolder { path: String },
+    #[serde(rename = "project_list")]
+    ProjectList,
+    #[serde(rename = "project_switch")]
+    ProjectSwitch { project_id: String },
+    #[serde(rename = "project_create")]
+    ProjectCreate {
+        name: String,
+        #[serde(default)]
+        base_path: Option<String>,
+    },
     #[serde(rename = "plot_history_get")]
     PlotHistoryGet,
     #[serde(rename = "plot_history_set_active")]
@@ -246,6 +256,10 @@ pub(super) enum WSResponse {
         #[serde(skip_serializing_if = "Option::is_none")]
         state: Option<Value>,
     },
+    #[serde(rename = "project_list_result")]
+    ProjectListResult { projects: Vec<ProjectRecord> },
+    #[serde(rename = "project_created")]
+    ProjectCreated { project: ProjectRecord },
     #[serde(rename = "acp_pending_edit_resolved")]
     AcpPendingEditResolved {
         edit_id: String,

--- a/server/src/handlers/project_requests.rs
+++ b/server/src/handlers/project_requests.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::extract::ws::WebSocket;
@@ -8,6 +8,7 @@ use super::common::{error_response, WSRequest};
 use super::runtime_fs::restart_fs_watcher;
 use super::{build_project_opened_response, send_responses, AppState};
 use crate::projects::{ProjectRuntime, RuntimeBroadcastEvent};
+use reprod_core::config::workspace_root_override;
 use reprod_core::acp::types::{AcpPermissionRequestPayload, AcpSessionUpdateEnvelope};
 use reprod_core::fs::FileSystemEvent;
 use tokio::sync::mpsc as tokio_mpsc;
@@ -56,6 +57,72 @@ pub async fn handle_project_request(
                 .await,
             )
         }
+        WSRequest::ProjectList => {
+            let root = resolve_project_root(current_runtime);
+            match state.projects.list_projects(&root).await {
+                Ok(projects) => Some(
+                    send_responses(
+                        socket,
+                        vec![super::common::WSResponse::ProjectListResult { projects }],
+                    )
+                    .await,
+                ),
+                Err(error) => Some(send_responses(socket, error_response(error.to_string())).await),
+            }
+        }
+        WSRequest::ProjectSwitch { project_id } => {
+            let root = resolve_project_root(current_runtime);
+            match state
+                .projects
+                .runtime_for_project_id(&root, project_id)
+                .await
+            {
+                Ok(runtime) => Some(
+                    switch_runtime(
+                        current_runtime,
+                        run_event_rx,
+                        acp_update_rx,
+                        acp_permission_rx,
+                        fs_watcher,
+                        fs_event_tx,
+                        fs_events_closed,
+                        socket,
+                        runtime,
+                    )
+                    .await,
+                ),
+                Err(error) => Some(send_responses(socket, error_response(error.to_string())).await),
+            }
+        }
+        WSRequest::ProjectCreate { name, base_path } => {
+            let root = match workspace_root_override() {
+                Some(path) => path,
+                None => {
+                    return Some(
+                        send_responses(
+                            socket,
+                            error_response("Project root is not configured"),
+                        )
+                        .await,
+                    )
+                }
+            };
+            let base_path = base_path.as_deref().map(Path::new);
+            match state
+                .projects
+                .create_project(&root, name, base_path)
+                .await
+            {
+                Ok(project) => Some(
+                    send_responses(
+                        socket,
+                        vec![super::common::WSResponse::ProjectCreated { project }],
+                    )
+                    .await,
+                ),
+                Err(error) => Some(send_responses(socket, error_response(error.to_string())).await),
+            }
+        }
         _ => None,
     }
 }
@@ -74,15 +141,44 @@ async fn switch_runtime_for_path(
 ) -> bool {
     match state.projects.runtime_for_path(folder_path).await {
         Ok(runtime) => {
-            *current_runtime = runtime;
-            *run_event_rx = current_runtime.run_events.subscribe();
-            *acp_update_rx = current_runtime.acp.subscribe_session_updates().await;
-            *acp_permission_rx = current_runtime.acp.subscribe_permission_requests().await;
-            restart_fs_watcher(current_runtime, fs_watcher, fs_event_tx, fs_events_closed);
-
-            let responses = vec![build_project_opened_response(current_runtime).await];
-            send_responses(socket, responses).await
+            switch_runtime(
+                current_runtime,
+                run_event_rx,
+                acp_update_rx,
+                acp_permission_rx,
+                fs_watcher,
+                fs_event_tx,
+                fs_events_closed,
+                socket,
+                runtime,
+            )
+            .await
         }
         Err(error) => send_responses(socket, error_response(error.to_string())).await,
     }
+}
+
+fn resolve_project_root(current_runtime: &Arc<ProjectRuntime>) -> PathBuf {
+    workspace_root_override().unwrap_or_else(|| current_runtime.descriptor.root_path.clone())
+}
+
+async fn switch_runtime(
+    current_runtime: &mut Arc<ProjectRuntime>,
+    run_event_rx: &mut broadcast::Receiver<RuntimeBroadcastEvent>,
+    acp_update_rx: &mut broadcast::Receiver<AcpSessionUpdateEnvelope>,
+    acp_permission_rx: &mut broadcast::Receiver<AcpPermissionRequestPayload>,
+    fs_watcher: &mut Option<FsWatcherHandle>,
+    fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
+    fs_events_closed: &mut bool,
+    socket: &mut WebSocket,
+    runtime: Arc<ProjectRuntime>,
+) -> bool {
+    *current_runtime = runtime;
+    *run_event_rx = current_runtime.run_events.subscribe();
+    *acp_update_rx = current_runtime.acp.subscribe_session_updates().await;
+    *acp_permission_rx = current_runtime.acp.subscribe_permission_requests().await;
+    restart_fs_watcher(current_runtime, fs_watcher, fs_event_tx, fs_events_closed);
+
+    let responses = vec![build_project_opened_response(current_runtime).await];
+    send_responses(socket, responses).await
 }

--- a/server/src/projects.rs
+++ b/server/src/projects.rs
@@ -12,7 +12,7 @@ use reprod_core::{
     web_search::{cloud_provider::CloudWebSearchProvider, WebSearchRegistry},
 };
 use reprod_core::{
-    project::{locate_config, ProjectDescriptor},
+    project::{locate_config, ProjectDescriptor, ProjectRecord},
     Config, ExecutionEvent, RExecutor, RunOutputChunk, RunSummary,
 };
 use std::{
@@ -233,11 +233,127 @@ impl ProjectController {
 
         Ok(runtime)
     }
+
+    pub async fn list_projects(&self, root: &Path) -> Result<Vec<ProjectRecord>> {
+        if !root.exists() {
+            return Err(anyhow!("Project root {} does not exist", root.display()));
+        }
+        if !root.is_dir() {
+            return Err(anyhow!("Project root {} is not a directory", root.display()));
+        }
+
+        let mut records = Vec::new();
+        if locate_config(root).is_ok() {
+            let descriptor = ProjectDescriptor::load(root)?;
+            records.push(ProjectRecord::from(&descriptor));
+        }
+
+        for entry in std::fs::read_dir(root)
+            .with_context(|| format!("Failed to read {}", root.display()))?
+        {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let path = entry.path();
+            if locate_config(&path).is_err() {
+                continue;
+            }
+            let descriptor = ProjectDescriptor::load(&path)?;
+            records.push(ProjectRecord::from(&descriptor));
+        }
+
+        records.sort_by(|a, b| {
+            let a_opened = a.last_opened_at.unwrap_or(0);
+            let b_opened = b.last_opened_at.unwrap_or(0);
+            b_opened.cmp(&a_opened).then_with(|| a.name.cmp(&b.name))
+        });
+
+        Ok(records)
+    }
+
+    pub async fn runtime_for_project_id(
+        &self,
+        root: &Path,
+        project_id: &str,
+    ) -> Result<Arc<ProjectRuntime>> {
+        let records = self.list_projects(root).await?;
+        let record = records
+            .into_iter()
+            .find(|record| record.id == project_id)
+            .ok_or_else(|| anyhow!("Project {} not found", project_id))?;
+        let path = PathBuf::from(record.path);
+        self.runtime_for_path(&path).await
+    }
+
+    pub async fn create_project(
+        &self,
+        root: &Path,
+        name: &str,
+        base_path: Option<&Path>,
+    ) -> Result<ProjectRecord> {
+        if name.trim().is_empty() {
+            return Err(anyhow!("Project name cannot be empty"));
+        }
+
+        if !root.exists() {
+            return Err(anyhow!("Project root {} does not exist", root.display()));
+        }
+        if !root.is_dir() {
+            return Err(anyhow!("Project root {} is not a directory", root.display()));
+        }
+
+        let canonical_root = root
+            .canonicalize()
+            .with_context(|| format!("Failed to resolve {}", root.display()))?;
+        let base = base_path.unwrap_or(root);
+        let canonical_base = base
+            .canonicalize()
+            .with_context(|| format!("Failed to resolve {}", base.display()))?;
+        if !canonical_base.starts_with(&canonical_root) {
+            return Err(anyhow!("Project base path is outside the allowed root"));
+        }
+
+        let slug = slugify_project_dir(name);
+        let mut candidate = canonical_base.join(&slug);
+        let mut suffix = 2u32;
+        while candidate.exists() {
+            candidate = canonical_base.join(format!("{slug}-{suffix}"));
+            suffix += 1;
+        }
+
+        std::fs::create_dir_all(&candidate).with_context(|| {
+            format!("Failed to create project directory {}", candidate.display())
+        })?;
+        let descriptor = ProjectDescriptor::create(&candidate, name, None)?;
+        Ok(ProjectRecord::from(&descriptor))
+    }
+}
+
+fn slugify_project_dir(name: &str) -> String {
+    let mut out = String::new();
+    let mut prev_dash = false;
+    for ch in name.trim().chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "project".to_string()
+    } else {
+        trimmed
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     #[tokio::test]
     async fn runtime_for_path_creates_reprod_dir() {
@@ -270,5 +386,72 @@ mod tests {
         let result = controller.runtime_for_path(&file_path).await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn list_projects_returns_project_records() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("projects");
+        std::fs::create_dir_all(&root).expect("create root");
+
+        let alpha_path = root.join("alpha");
+        std::fs::create_dir_all(&alpha_path).expect("create alpha");
+        let alpha = ProjectDescriptor::create(&alpha_path, "Alpha", None).expect("alpha");
+
+        let beta_path = root.join("beta");
+        std::fs::create_dir_all(&beta_path).expect("create beta");
+        let beta = ProjectDescriptor::create(&beta_path, "Beta", None).expect("beta");
+
+        let controller = ProjectController::new(Arc::new(Mutex::new(Config::default())))
+            .await
+            .expect("controller");
+        let projects = controller.list_projects(&root).await.expect("projects");
+
+        let ids: HashSet<String> = projects.into_iter().map(|p| p.id).collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&alpha.config.id));
+        assert!(ids.contains(&beta.config.id));
+    }
+
+    #[tokio::test]
+    async fn runtime_for_project_id_finds_matching_project() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("projects");
+        std::fs::create_dir_all(&root).expect("create root");
+
+        let project_path = root.join("gamma");
+        std::fs::create_dir_all(&project_path).expect("create project");
+        let descriptor =
+            ProjectDescriptor::create(&project_path, "Gamma", None).expect("descriptor");
+
+        let controller = ProjectController::new(Arc::new(Mutex::new(Config::default())))
+            .await
+            .expect("controller");
+        let runtime = controller
+            .runtime_for_project_id(&root, &descriptor.config.id)
+            .await
+            .expect("runtime");
+
+        assert_eq!(runtime.descriptor.config.id, descriptor.config.id);
+    }
+
+    #[tokio::test]
+    async fn create_project_creates_unique_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("projects");
+        std::fs::create_dir_all(&root).expect("create root");
+
+        let controller = ProjectController::new(Arc::new(Mutex::new(Config::default())))
+            .await
+            .expect("controller");
+        let project = controller
+            .create_project(&root, "My Project", None)
+            .await
+            .expect("project");
+
+        let project_path = PathBuf::from(&project.path);
+        assert!(project_path.exists());
+        assert!(project_path.join(".reprod").join("config.json").exists());
+        assert_eq!(project.name, "My Project");
     }
 }


### PR DESCRIPTION
## Description

Adds Web project switching for server-hosted projects while keeping Desktop "Open Folder..." behavior intact. The Web client now opens a modal to list projects and switches by project id via new WS messages, and the server exposes list/switch/create handlers. Includes a new Playwright E2E test and fixtures for the Web project switch flow.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [x] Documentation updated (if needed) (not required)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `pnpm test`
- `pnpm --filter client test -- --run`
- `cargo test`
- `pnpm --filter @reprod/e2e test -- file-explorer.spec.ts`
- `pnpm --filter @reprod/e2e test -- open-folder.spec.ts`
- `pnpm --filter @reprod/e2e test -- project-switch.spec.ts` (headless Chromium SIGTRAP in this environment)
- `pnpm --filter @reprod/e2e test -- settings-acp-mode.spec.ts` (headless Chromium SIGTRAP in this environment)
- `pnpm --filter @reprod/e2e test -- settings-acp-mode.spec.ts --headed`

## Screenshots (if applicable)

Before (Web):
```
┌─────────────────────────────┐
│ File > Open Folder...        │
├─────────────────────────────┤
│ Error: desktop only          │
└─────────────────────────────┘
```

After (Web):
```
┌──────────────────────────────────────────────┐
│ File > Open Project...                       │
├──────────────────────────────────────────────┤
│ Switch Project                               │
│  [Search..............................]      │
│  ● Project A     /srv/projects/a             │
│  ○ Project B     /srv/projects/b             │
│  [Create]                      [Open Project]│
└──────────────────────────────────────────────┘
```

## Related Issues

Closes #368
