### PR TITLE
Remove 'as any' cast from MenuResolver.ts - #372

### DIFF
--- a/client/src/core/menu/resolvers/MenuResolver.ts
+++ b/client/src/core/menu/resolvers/MenuResolver.ts
@@ -1,5 +1,5 @@
 import { commandRegistry } from "@/core/commands/registry";
-import type { MenuEntry, MenuSection as LegacyMenuSection } from "@/types/menu";
+import type { MenuEntry, MenuSection as LegacyMenuSection, MenuSectionId } from "@/types/menu";
 import type { MenuItemWithConditions } from "../builders";
 import type { MenuNode } from "../domain";
 import { MenuItem, MenuSection } from "../domain";
@@ -23,7 +23,7 @@ export class MenuResolver {
 
 	private resolveSection(section: MenuSection): LegacyMenuSection {
 		return {
-			id: section.id as any, // MenuSectionId
+			id: section.id as MenuSectionId,
 			label: section.label,
 			items: section.getChildren().map((child) => this.resolveNode(child)),
 		};
@@ -41,7 +41,7 @@ export class MenuResolver {
 		const item = node as MenuItem & MenuItemWithConditions;
 
 		const enabledWhen = item.enabledWhen || new AlwaysTrue();
-		const checkedWhen = (item as any).checkedWhen;
+		const checkedWhen = item.checkedWhen;
 
 		const baseItem = {
 			id: item.id,


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Change `MenuResolver.ts` to remove use of `as any` cast. Specifically:
```typescript

id: section.id as MenuSectionId, // Without explicit cast, 'id' is 'string'.      
...
const item = node as MenuItem & MenuItemWithConditions;

const enabledWhen = item.enabledWhen || new AlwaysTrue();
const checkedWhen = item.checkedWhen; // No need to cast as the first line is defining the type.  

```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [x] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

<!-- Describe the tests you ran and how to reproduce them -->
<img width="1057" height="129" alt="image" src="https://github.com/user-attachments/assets/975dbaf7-c4bd-48f9-b82e-a61b2dd1a7fc" />

## Related Issues

Closes #372 
