### PR TITLE
feat: event stream agentic execution (#206)

### DIFF
--- a/client/src/components/ai-panel/AgentEventStream.tsx
+++ b/client/src/components/ai-panel/AgentEventStream.tsx
@@ -1,0 +1,247 @@
+import type {
+	AgentEvent,
+	AgentEventStatus,
+	ApprovalOption,
+	ApprovalRequest,
+	ApprovalResponse,
+	ArtifactEvent,
+	ErrorEvent,
+	TaskEvent,
+	ThoughtEvent,
+	ToolRequestEvent,
+	ToolResultEvent,
+} from "@/types";
+import { aiMessages } from "@/services/messageBuilders";
+import { socketService } from "@/services/socket";
+import { useEffect, useMemo, useState } from "react";
+import { useStore } from "@/core";
+
+interface Props {
+	events?: AgentEvent[];
+	approvals?: ApprovalRequest[];
+}
+
+const STATUS_LABEL: Record<AgentEventStatus, string> = {
+	pending: "Pending",
+	running: "Running",
+	done: "Done",
+	error: "Error",
+	blocked: "Blocked",
+	approved: "Approved",
+	denied: "Denied",
+};
+
+const formatTimestamp = (timestamp: number): string => {
+	const date = new Date(timestamp);
+	if (Number.isNaN(date.getTime())) {
+		return "";
+	}
+	return date.toLocaleTimeString(undefined, {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+	});
+};
+
+const truncate = (value: string, max = 240): string => {
+	if (value.length <= max) {
+		return value;
+	}
+	return `${value.slice(0, max)}...`;
+};
+
+const renderDetails = (event: AgentEvent): string | null => {
+	switch (event.type) {
+		case "thought": {
+			const typed = event as ThoughtEvent;
+			if (typed.reasoning) {
+				return `${typed.text} (Reason: ${typed.reasoning})`;
+			}
+			return typed.text;
+		}
+		case "tool_request": {
+			const typed = event as ToolRequestEvent;
+			const preview =
+				typed.preview?.kind === "command"
+					? `Command: ${typed.preview.command ?? ""}`
+					: typed.preview?.kind === "diff"
+						? `Diff preview${typed.preview.filepath ? `: ${typed.preview.filepath}` : ""}`
+						: typed.preview?.kind === "read"
+							? `Read: ${typed.preview.filepath ?? ""}`
+							: "";
+			const approval = typed.requiresApproval ? "Approval required" : "Auto-approved";
+			return truncate([`Tool: ${typed.tool}`, approval, preview].filter(Boolean).join(" | "));
+		}
+		case "tool_result": {
+			const typed = event as ToolResultEvent;
+			if (typed.error) {
+				return truncate(`Error: ${typed.error}`);
+			}
+			if (typed.output) {
+				return truncate(`Output: ${JSON.stringify(typed.output)}`);
+			}
+			return "Tool completed.";
+		}
+		case "task": {
+			const typed = event as TaskEvent;
+			return typed.label;
+		}
+		case "artifact": {
+			const typed = event as ArtifactEvent;
+			const path = typed.path ? ` (${typed.path})` : "";
+			return `${typed.summary}${path}`;
+		}
+		case "error": {
+			const typed = event as ErrorEvent;
+			const recovery = typed.suggestedAction ? ` Suggested: ${typed.suggestedAction}` : "";
+			return truncate(`${typed.message}${recovery}`);
+		}
+		default:
+			return null;
+	}
+};
+
+export function AgentEventStream({ events, approvals }: Props): JSX.Element | null {
+	const hasEvents = Boolean(events && events.length > 0);
+	const hasApprovals = Boolean(approvals && approvals.length > 0);
+	if (!hasEvents && !hasApprovals) {
+		return null;
+	}
+
+	const approval = approvals?.[0];
+	const resolveApprovalRequest = useStore((state) => state.resolveApprovalRequest);
+	const [isEditing, setIsEditing] = useState(false);
+	const [editedInput, setEditedInput] = useState(
+		approval?.input ? JSON.stringify(approval.input, null, 2) : "{}",
+	);
+	const [inputError, setInputError] = useState<string | null>(null);
+
+	useEffect(() => {
+		setIsEditing(false);
+		setInputError(null);
+		setEditedInput(approval?.input ? JSON.stringify(approval.input, null, 2) : "{}");
+	}, [approval]);
+
+	const previewText = useMemo(() => {
+		if (!approval) return "";
+		if (approval.preview.kind === "diff") {
+			return approval.preview.diff ?? "";
+		}
+		if (approval.preview.kind === "command") {
+			return approval.preview.command ?? "";
+		}
+		if (approval.preview.kind === "read") {
+			return approval.preview.filepath ?? "";
+		}
+		return "";
+	}, [approval]);
+
+	const submitDecision = (decision: ApprovalOption) => {
+		if (!approval) return;
+		let payload: ApprovalResponse = {
+			eventId: approval.eventId,
+			decision,
+		};
+		if (decision === "edit") {
+			try {
+				const parsed = JSON.parse(editedInput);
+				payload = { ...payload, editedInput: parsed };
+				setInputError(null);
+			} catch (error) {
+				setInputError("Invalid JSON input.");
+				return;
+			}
+		}
+		socketService.send(aiMessages.approvalDecision(payload));
+		resolveApprovalRequest(approval.eventId);
+	};
+
+	return (
+		<div className="agent-event-stream">
+			{approval && (
+				<div className="agent-event-stream__approval">
+					<div className="agent-event-stream__approval-header">
+						<div className="agent-event-stream__approval-title">Approval Required</div>
+						<div className="agent-event-stream__approval-tool">{approval.tool}</div>
+					</div>
+					{previewText && <pre className="agent-event-stream__preview">{previewText}</pre>}
+					{approval.input && (
+						<div className="agent-event-stream__input">
+							<button
+								type="button"
+								className="agent-event-stream__button"
+								onClick={() => setIsEditing((prev) => !prev)}
+							>
+								{isEditing ? "Hide Input" : "Edit Input"}
+							</button>
+							{isEditing && (
+								<textarea
+									value={editedInput}
+									onChange={(event) => setEditedInput(event.target.value)}
+									rows={6}
+								/>
+							)}
+							{inputError && <div className="agent-event-stream__error">{inputError}</div>}
+						</div>
+					)}
+					<div className="agent-event-stream__actions">
+						<button
+							type="button"
+							className="agent-event-stream__button"
+							onClick={() => submitDecision("approve_once")}
+						>
+							Approve Once
+						</button>
+						<button
+							type="button"
+							className="agent-event-stream__button"
+							onClick={() => submitDecision("approve_session")}
+						>
+							Approve Session
+						</button>
+						<button
+							type="button"
+							className="agent-event-stream__button"
+							onClick={() => submitDecision("edit")}
+							disabled={!isEditing}
+						>
+							Approve Edited
+						</button>
+						<button
+							type="button"
+							className="agent-event-stream__button agent-event-stream__button--danger"
+							onClick={() => submitDecision("deny")}
+						>
+							Deny
+						</button>
+					</div>
+				</div>
+			)}
+			{hasEvents && (
+				<>
+					<div className="agent-event-stream__header">
+						<div className="agent-event-stream__title">Event Stream</div>
+						<div className="agent-event-stream__count">{events?.length ?? 0}</div>
+					</div>
+					<ul className="agent-event-stream__list">
+						{events?.map((event) => {
+							const details = renderDetails(event);
+							return (
+								<li key={event.id} className="agent-event-stream__item" data-status={event.status}>
+									<div className="agent-event-stream__meta">
+										<span className="agent-event-stream__type">{event.type}</span>
+										<span className="agent-event-stream__status">{STATUS_LABEL[event.status]}</span>
+										<span className="agent-event-stream__time">
+											{formatTimestamp(event.timestamp)}
+										</span>
+									</div>
+									{details && <div className="agent-event-stream__details">{details}</div>}
+								</li>
+							);
+						})}
+					</ul>
+				</>
+			)}
+		</div>
+	);
+}

--- a/client/src/components/ai-panel/AgentEventStream.tsx
+++ b/client/src/components/ai-panel/AgentEventStream.tsx
@@ -15,6 +15,7 @@ import { aiMessages } from "@/services/messageBuilders";
 import { socketService } from "@/services/socket";
 import { useEffect, useMemo, useState } from "react";
 import { useStore } from "@/core";
+import { TaskGraphView } from "./TaskGraphView";
 
 interface Props {
 	events?: AgentEvent[];
@@ -136,6 +137,11 @@ export function AgentEventStream({ events, approvals }: Props): JSX.Element | nu
 		return "";
 	}, [approval]);
 
+	const tasks = useMemo(
+		() => (events ?? []).filter((event): event is TaskEvent => event.type === "task"),
+		[events],
+	);
+
 	const submitDecision = (decision: ApprovalOption) => {
 		if (!approval) return;
 		let payload: ApprovalResponse = {
@@ -217,6 +223,8 @@ export function AgentEventStream({ events, approvals }: Props): JSX.Element | nu
 					</div>
 				</div>
 			)}
+			{tasks.length > 0 && <TaskGraphView tasks={tasks} />}
+
 			{hasEvents && (
 				<>
 					<div className="agent-event-stream__header">

--- a/client/src/components/ai-panel/AgentEventStream.tsx
+++ b/client/src/components/ai-panel/AgentEventStream.tsx
@@ -15,6 +15,7 @@ import { aiMessages } from "@/services/messageBuilders";
 import { socketService } from "@/services/socket";
 import { useEffect, useMemo, useState } from "react";
 import { useStore } from "@/core";
+import { ArtifactListView } from "./ArtifactListView";
 import { TaskGraphView } from "./TaskGraphView";
 
 interface Props {
@@ -141,6 +142,10 @@ export function AgentEventStream({ events, approvals }: Props): JSX.Element | nu
 		() => (events ?? []).filter((event): event is TaskEvent => event.type === "task"),
 		[events],
 	);
+	const artifacts = useMemo(
+		() => (events ?? []).filter((event): event is ArtifactEvent => event.type === "artifact"),
+		[events],
+	);
 
 	const submitDecision = (decision: ApprovalOption) => {
 		if (!approval) return;
@@ -224,6 +229,7 @@ export function AgentEventStream({ events, approvals }: Props): JSX.Element | nu
 				</div>
 			)}
 			{tasks.length > 0 && <TaskGraphView tasks={tasks} />}
+			{artifacts.length > 0 && <ArtifactListView artifacts={artifacts} />}
 
 			{hasEvents && (
 				<>

--- a/client/src/components/ai-panel/ArtifactListView.tsx
+++ b/client/src/components/ai-panel/ArtifactListView.tsx
@@ -1,0 +1,47 @@
+import type { ArtifactEvent } from "@/types";
+
+interface Props {
+	artifacts: ArtifactEvent[];
+}
+
+const STATUS_LABEL: Record<ArtifactEvent["status"], string> = {
+	pending: "Pending",
+	running: "Running",
+	done: "Done",
+	error: "Error",
+	blocked: "Blocked",
+	approved: "Approved",
+	denied: "Denied",
+};
+
+export function ArtifactListView({ artifacts }: Props): JSX.Element | null {
+	if (artifacts.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="artifact-list">
+			<div className="artifact-list__header">
+				<div className="artifact-list__title">Artifacts</div>
+				<div className="artifact-list__count">{artifacts.length}</div>
+			</div>
+			<ul className="artifact-list__list">
+				{artifacts.map((artifact) => (
+					<li key={artifact.id} className="artifact-list__item" data-status={artifact.status}>
+						<div className="artifact-list__meta">
+							<span className="artifact-list__kind">{artifact.kind}</span>
+							<span className="artifact-list__status">{STATUS_LABEL[artifact.status]}</span>
+						</div>
+						<div className="artifact-list__summary">
+							{artifact.summary}
+							{artifact.path ? ` (${artifact.path})` : ""}
+						</div>
+						{artifact.details?.diff && (
+							<pre className="artifact-list__diff">{artifact.details.diff}</pre>
+						)}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/client/src/components/ai-panel/ArtifactListView.tsx
+++ b/client/src/components/ai-panel/ArtifactListView.tsx
@@ -1,4 +1,7 @@
 import type { ArtifactEvent } from "@/types";
+import { fileSystem } from "@/services/fileSystem";
+import { useToast } from "@/components/shared";
+import { useState } from "react";
 
 interface Props {
 	artifacts: ArtifactEvent[];
@@ -19,6 +22,23 @@ export function ArtifactListView({ artifacts }: Props): JSX.Element | null {
 		return null;
 	}
 
+	const toast = useToast();
+	const [busyId, setBusyId] = useState<string | null>(null);
+
+	const handleUndo = async (artifact: ArtifactEvent) => {
+		if (!artifact.path || !artifact.details?.oldText) return;
+		setBusyId(artifact.id);
+		try {
+			await fileSystem.writeFile(artifact.path, artifact.details.oldText);
+			toast.showSuccess(`Reverted ${artifact.path}`);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			toast.showError(`Failed to revert ${artifact.path}: ${message}`);
+		} finally {
+			setBusyId(null);
+		}
+	};
+
 	return (
 		<div className="artifact-list">
 			<div className="artifact-list__header">
@@ -36,6 +56,16 @@ export function ArtifactListView({ artifacts }: Props): JSX.Element | null {
 							{artifact.summary}
 							{artifact.path ? ` (${artifact.path})` : ""}
 						</div>
+						{artifact.kind === "file_write" && artifact.path && artifact.details?.oldText && (
+							<button
+								type="button"
+								className="artifact-list__button"
+								onClick={() => handleUndo(artifact)}
+								disabled={busyId === artifact.id}
+							>
+								{busyId === artifact.id ? "Reverting..." : "Undo"}
+							</button>
+						)}
 						{artifact.details?.diff && (
 							<pre className="artifact-list__diff">{artifact.details.diff}</pre>
 						)}

--- a/client/src/components/ai-panel/StreamingMessage.tsx
+++ b/client/src/components/ai-panel/StreamingMessage.tsx
@@ -10,6 +10,7 @@ import { fileSystem } from "@/services/fileSystem";
 import type { AIMessage, CodeBlock, ToolCallLog as ToolCallLogEntry } from "@/types";
 import { classNames } from "@/utils/classNames";
 import { AIPlanCard } from "./AIPlanCard";
+import { AgentEventStream } from "./AgentEventStream";
 import { CodeBlockWithApply } from "./CodeBlockWithApply";
 import { FileAccessIndicator } from "./FileAccessIndicator";
 import { ToolCallLog } from "./ToolCallLog";
@@ -79,6 +80,7 @@ export function StreamingMessage({ message, onApplyCode }: Props): JSX.Element {
 	const hasPlan = Boolean(message.planSteps && message.planSteps.length > 0);
 	const hasTools = Boolean(message.toolLogs && message.toolLogs.length > 0);
 	const hasCodeBlocks = Boolean(message.codeBlocks && message.codeBlocks.length > 0);
+	const hasEvents = Boolean(message.events && message.events.length > 0);
 	const shouldShowLegacyCode = Boolean(message.code && !hasCodeBlocks);
 
 	// Strip patch blocks from content to avoid duplicate display
@@ -199,7 +201,11 @@ export function StreamingMessage({ message, onApplyCode }: Props): JSX.Element {
 						<FileAccessIndicator filePaths={readFilePaths} onOpenPath={handleOpenPath} />
 					)}
 
-					{hasPlan && <AIPlanCard steps={message.planSteps} />}
+					{hasEvents && (
+						<AgentEventStream events={message.events} approvals={message.approvalQueue} />
+					)}
+
+					{!hasEvents && hasPlan && <AIPlanCard steps={message.planSteps} />}
 
 					{hasTools && <ToolCallLog logs={message.toolLogs} />}
 

--- a/client/src/components/ai-panel/TaskGraphView.tsx
+++ b/client/src/components/ai-panel/TaskGraphView.tsx
@@ -1,0 +1,43 @@
+import type { TaskEvent } from "@/types";
+
+interface Props {
+	tasks: TaskEvent[];
+}
+
+const STATUS_LABEL: Record<TaskEvent["status"], string> = {
+	pending: "Pending",
+	running: "Running",
+	done: "Done",
+	error: "Error",
+	blocked: "Blocked",
+	approved: "Approved",
+	denied: "Denied",
+};
+
+export function TaskGraphView({ tasks }: Props): JSX.Element | null {
+	if (tasks.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="task-graph">
+			<div className="task-graph__header">
+				<div className="task-graph__title">Task Graph</div>
+				<div className="task-graph__count">{tasks.length}</div>
+			</div>
+			<ul className="task-graph__list">
+				{tasks.map((task) => (
+					<li key={task.id} className="task-graph__item" data-status={task.status}>
+						<div className="task-graph__meta">
+							<span className="task-graph__label">{task.label}</span>
+							<span className="task-graph__status">{STATUS_LABEL[task.status]}</span>
+						</div>
+						<div className="task-graph__deps">
+							{task.deps.length > 0 ? `Deps: ${task.deps.join(", ")}` : "Deps: none"}
+						</div>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/client/src/core/state/__tests__/aiSlice.test.ts
+++ b/client/src/core/state/__tests__/aiSlice.test.ts
@@ -28,6 +28,23 @@ describe("aiSlice streaming helpers", () => {
 		});
 		expect(store.getState().ai.messages.at(-1)?.toolLogs).toHaveLength(1);
 
+		store.getState().appendAgentEvent("msg-1", {
+			id: "event-1",
+			type: "thought",
+			status: "done",
+			timestamp: Date.now(),
+			text: "Thinking",
+		});
+		expect(store.getState().ai.messages.at(-1)?.events).toHaveLength(1);
+
+		store.getState().addApprovalRequest("msg-1", {
+			eventId: "event-1",
+			tool: "write_text_file",
+			preview: { kind: "diff" },
+			options: ["approve_once", "deny"],
+		});
+		expect(store.getState().ai.messages.at(-1)?.approvalQueue).toHaveLength(1);
+
 		store.getState().completeStreamingMessage("msg-1", "Hello world!");
 		const message = store.getState().ai.messages.at(-1);
 		expect(message?.isComplete).toBe(true);

--- a/client/src/core/state/slices/aiSlice.ts
+++ b/client/src/core/state/slices/aiSlice.ts
@@ -1,5 +1,14 @@
 import type { StateCreator } from "zustand";
-import type { AIMessage, AIMode, CodeBlock, PlanStep, ToolCallLog } from "@/types";
+import type {
+	AIMessage,
+	AIMode,
+	AgentEvent,
+	ApprovalRequest,
+	ArtifactEvent,
+	CodeBlock,
+	PlanStep,
+	ToolCallLog,
+} from "@/types";
 
 type StreamingExtras = {
 	codeBlocks?: CodeBlock[];
@@ -38,6 +47,49 @@ const upsertToolLog = (logs: ToolCallLog[] | undefined, incoming: ToolCallLog): 
 	const next = [...logs];
 	next[idx] = { ...next[idx], ...incoming };
 	return next;
+};
+
+const upsertAgentEvent = (events: AgentEvent[] | undefined, incoming: AgentEvent): AgentEvent[] => {
+	if (!events) {
+		return [incoming];
+	}
+
+	const idx = events.findIndex((event) => event.id === incoming.id);
+	if (idx === -1) {
+		return [...events, incoming];
+	}
+
+	const next = [...events];
+	next[idx] = { ...next[idx], ...incoming };
+	return next;
+};
+
+const appendArtifact = (
+	artifacts: ArtifactEvent[] | undefined,
+	incoming: ArtifactEvent,
+): ArtifactEvent[] => {
+	if (!artifacts) {
+		return [incoming];
+	}
+	return [...artifacts, incoming];
+};
+
+const appendApprovalRequest = (
+	queue: ApprovalRequest[] | undefined,
+	request: ApprovalRequest,
+): ApprovalRequest[] => {
+	if (!queue) {
+		return [request];
+	}
+	return [...queue, request];
+};
+
+const removeApprovalRequest = (
+	queue: ApprovalRequest[] | undefined,
+	eventId: string,
+): ApprovalRequest[] | undefined => {
+	if (!queue) return queue;
+	return queue.filter((request) => request.eventId !== eventId);
 };
 
 const mergePlanSteps = (current: PlanStep[] | undefined, incoming: PlanStep[]): PlanStep[] => {
@@ -79,6 +131,9 @@ export interface AIState {
 	startStreamingMessage: (streamingId: string, mode?: AIMode) => void;
 	appendStreamingChunk: (streamingId: string, chunk: string) => void;
 	updateStreamingPlan: (streamingId: string, plan: PlanStep[]) => void;
+	appendAgentEvent: (streamingId: string, event: AgentEvent) => void;
+	addApprovalRequest: (streamingId: string, request: ApprovalRequest) => void;
+	resolveApprovalRequest: (eventId: string) => void;
 	recordToolEvent: (streamingId: string, log: ToolCallLog) => void;
 	completeStreamingMessage: (
 		streamingId: string,
@@ -170,6 +225,44 @@ export const createAISlice: StateCreator<AIState> = (set) => ({
 				messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => ({
 					...message,
 					planSteps: mergePlanSteps(message.planSteps, plan),
+				})),
+			},
+		})),
+	appendAgentEvent: (streamingId, event) =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => {
+					const nextEvents = upsertAgentEvent(message.events, event);
+					const nextArtifacts =
+						event.type === "artifact"
+							? appendArtifact(message.artifacts, event as ArtifactEvent)
+							: message.artifacts;
+					return {
+						...message,
+						events: nextEvents,
+						artifacts: nextArtifacts,
+					};
+				}),
+			},
+		})),
+	addApprovalRequest: (streamingId, request) =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				messages: updateStreamingMessage(state.ai.messages, streamingId, (message) => ({
+					...message,
+					approvalQueue: appendApprovalRequest(message.approvalQueue, request),
+				})),
+			},
+		})),
+	resolveApprovalRequest: (eventId) =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				messages: state.ai.messages.map((message) => ({
+					...message,
+					approvalQueue: removeApprovalRequest(message.approvalQueue, eventId),
 				})),
 			},
 		})),

--- a/client/src/css/components/ai-panel/agent-event-stream.css
+++ b/client/src/css/components/ai-panel/agent-event-stream.css
@@ -1,0 +1,174 @@
+.agent-event-stream {
+	margin-top: 12px;
+	border-radius: 8px;
+	background: var(--bg-secondary);
+	overflow: hidden;
+}
+
+.agent-event-stream__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 10px 12px;
+}
+
+.agent-event-stream__title {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--text-secondary);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+
+.agent-event-stream__count {
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.agent-event-stream__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	font-size: 12px;
+}
+
+.agent-event-stream__approval {
+	border-bottom: 1px solid var(--border-light);
+	padding: 12px;
+	display: grid;
+	gap: 8px;
+}
+
+.agent-event-stream__approval-header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 8px;
+}
+
+.agent-event-stream__approval-title {
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	color: var(--text-secondary);
+}
+
+.agent-event-stream__approval-tool {
+	font-size: 12px;
+	color: var(--text-primary);
+	font-weight: 600;
+}
+
+.agent-event-stream__preview {
+	white-space: pre-wrap;
+	background: var(--bg-tertiary);
+	border-radius: 6px;
+	padding: 8px;
+	font-size: 11px;
+	color: var(--text-secondary);
+	max-height: 200px;
+	overflow: auto;
+}
+
+.agent-event-stream__input textarea {
+	width: 100%;
+	border-radius: 6px;
+	border: 1px solid var(--border-light);
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
+	font-size: 11px;
+	padding: 6px;
+	margin-top: 6px;
+}
+
+.agent-event-stream__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.agent-event-stream__button {
+	border-radius: 6px;
+	border: 1px solid var(--border-light);
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
+	font-size: 11px;
+	padding: 4px 10px;
+	cursor: pointer;
+}
+
+.agent-event-stream__button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.agent-event-stream__button--danger {
+	border-color: var(--phylo-error-medium);
+	color: var(--phylo-error-medium);
+}
+
+.agent-event-stream__error {
+	color: var(--phylo-error-medium);
+	font-size: 11px;
+	margin-top: 4px;
+}
+
+.agent-event-stream__item {
+	border-top: 1px solid var(--border-light);
+	padding: 10px 12px;
+	display: grid;
+	gap: 6px;
+}
+
+.agent-event-stream__meta {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+.agent-event-stream__type {
+	font-weight: 600;
+	color: var(--text-primary);
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.agent-event-stream__status {
+	padding: 2px 6px;
+	border-radius: 999px;
+	background: var(--bg-tertiary);
+	color: var(--text-secondary);
+	font-size: 11px;
+	font-weight: 600;
+}
+
+.agent-event-stream__time {
+	margin-left: auto;
+	color: var(--text-secondary);
+	font-variant-numeric: tabular-nums;
+}
+
+.agent-event-stream__details {
+	color: var(--text-secondary);
+	line-height: 1.4;
+	word-break: break-word;
+}
+
+.agent-event-stream__item[data-status="running"] .agent-event-stream__status {
+	color: var(--text-primary);
+}
+
+.agent-event-stream__item[data-status="done"] .agent-event-stream__status {
+	color: var(--text-primary);
+}
+
+.agent-event-stream__item[data-status="error"] .agent-event-stream__status,
+.agent-event-stream__item[data-status="denied"] .agent-event-stream__status {
+	color: var(--phylo-error-medium);
+}
+
+.agent-event-stream__item[data-status="blocked"] .agent-event-stream__status {
+	color: var(--phylo-warning-medium);
+}

--- a/client/src/css/components/ai-panel/artifact-list.css
+++ b/client/src/css/components/ai-panel/artifact-list.css
@@ -68,6 +68,22 @@
 	word-break: break-word;
 }
 
+.artifact-list__button {
+	border-radius: 6px;
+	border: 1px solid var(--border-light);
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
+	font-size: 11px;
+	padding: 4px 10px;
+	cursor: pointer;
+	width: fit-content;
+}
+
+.artifact-list__button:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
 .artifact-list__diff {
 	white-space: pre-wrap;
 	background: var(--bg-tertiary);

--- a/client/src/css/components/ai-panel/artifact-list.css
+++ b/client/src/css/components/ai-panel/artifact-list.css
@@ -1,0 +1,89 @@
+.artifact-list {
+	margin-top: 12px;
+	border-radius: 8px;
+	background: var(--bg-secondary);
+	overflow: hidden;
+}
+
+.artifact-list__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 10px 12px;
+}
+
+.artifact-list__title {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--text-secondary);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+
+.artifact-list__count {
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.artifact-list__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	font-size: 12px;
+}
+
+.artifact-list__item {
+	border-top: 1px solid var(--border-light);
+	padding: 10px 12px;
+	display: grid;
+	gap: 6px;
+}
+
+.artifact-list__meta {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+.artifact-list__kind {
+	font-weight: 600;
+	color: var(--text-primary);
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.artifact-list__status {
+	padding: 2px 6px;
+	border-radius: 999px;
+	background: var(--bg-tertiary);
+	color: var(--text-secondary);
+	font-size: 11px;
+	font-weight: 600;
+}
+
+.artifact-list__summary {
+	color: var(--text-secondary);
+	line-height: 1.4;
+	word-break: break-word;
+}
+
+.artifact-list__diff {
+	white-space: pre-wrap;
+	background: var(--bg-tertiary);
+	border-radius: 6px;
+	padding: 8px;
+	font-size: 11px;
+	color: var(--text-secondary);
+	max-height: 200px;
+	overflow: auto;
+}
+
+.artifact-list__item[data-status="error"] .artifact-list__status,
+.artifact-list__item[data-status="denied"] .artifact-list__status {
+	color: var(--phylo-error-medium);
+}
+
+.artifact-list__item[data-status="blocked"] .artifact-list__status {
+	color: var(--phylo-warning-medium);
+}

--- a/client/src/css/components/ai-panel/index.css
+++ b/client/src/css/components/ai-panel/index.css
@@ -2,6 +2,7 @@
 @import "./code-block.css";
 @import "./streaming.css";
 @import "./agent-event-stream.css";
+@import "./artifact-list.css";
 @import "./task-graph.css";
 @import "./plan-card.css";
 @import "./tool-log.css";

--- a/client/src/css/components/ai-panel/index.css
+++ b/client/src/css/components/ai-panel/index.css
@@ -1,5 +1,7 @@
 @import "./message.css";
 @import "./code-block.css";
 @import "./streaming.css";
+@import "./agent-event-stream.css";
+@import "./task-graph.css";
 @import "./plan-card.css";
 @import "./tool-log.css";

--- a/client/src/css/components/ai-panel/task-graph.css
+++ b/client/src/css/components/ai-panel/task-graph.css
@@ -1,0 +1,74 @@
+.task-graph {
+	margin-top: 12px;
+	border-radius: 8px;
+	background: var(--bg-secondary);
+	overflow: hidden;
+}
+
+.task-graph__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 10px 12px;
+}
+
+.task-graph__title {
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--text-secondary);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+
+.task-graph__count {
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.task-graph__list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	font-size: 12px;
+}
+
+.task-graph__item {
+	border-top: 1px solid var(--border-light);
+	padding: 10px 12px;
+	display: grid;
+	gap: 6px;
+}
+
+.task-graph__meta {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+.task-graph__label {
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.task-graph__status {
+	padding: 2px 6px;
+	border-radius: 999px;
+	background: var(--bg-tertiary);
+	color: var(--text-secondary);
+	font-size: 11px;
+	font-weight: 600;
+}
+
+.task-graph__deps {
+	color: var(--text-secondary);
+}
+
+.task-graph__item[data-status="error"] .task-graph__status,
+.task-graph__item[data-status="denied"] .task-graph__status {
+	color: var(--phylo-error-medium);
+}
+
+.task-graph__item[data-status="blocked"] .task-graph__status {
+	color: var(--phylo-warning-medium);
+}

--- a/client/src/hooks/useAIStreaming.ts
+++ b/client/src/hooks/useAIStreaming.ts
@@ -10,7 +10,8 @@ type RegisterStreamingHandlersOptions = {
 };
 
 export function useAIStreaming() {
-	const { appendChunk, finalize, recordTool, updatePlan } = useAssistantEventAdapter();
+	const { appendChunk, finalize, recordAgentEvent, recordTool, enqueueApproval } =
+		useAssistantEventAdapter();
 
 	const registerStreamingHandlers = useCallback(
 		(requestId: string, options: RegisterStreamingHandlersOptions = {}) => {
@@ -57,11 +58,20 @@ export function useAIStreaming() {
 			);
 
 			disposers.push(
-				socketService.on("ai_plan_updated", (message) => {
-					if (message.type !== "ai_plan_updated" || !shouldProcess(message.id)) {
+				socketService.on("agent_event", (message) => {
+					if (message.type !== "agent_event" || !shouldProcess(message.id)) {
 						return;
 					}
-					updatePlan(requestId, message.plan);
+					recordAgentEvent(requestId, message.event);
+				}),
+			);
+
+			disposers.push(
+				socketService.on("approval_request", (message) => {
+					if (message.type !== "approval_request" || !shouldProcess(message.id)) {
+						return;
+					}
+					enqueueApproval(requestId, message.request);
 				}),
 			);
 
@@ -137,7 +147,7 @@ export function useAIStreaming() {
 
 			return cleanup;
 		},
-		[appendChunk, finalize, recordTool, updatePlan],
+		[appendChunk, enqueueApproval, finalize, recordAgentEvent, recordTool],
 	);
 
 	return { registerStreamingHandlers };

--- a/client/src/hooks/useAssistantEventAdapter.ts
+++ b/client/src/hooks/useAssistantEventAdapter.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { useStore } from "@/core";
 import { extractCodeBlocks } from "@/core/ai/codeBlockUtils";
-import type { PlanStep, ToolCallLog } from "@/types";
+import type { AgentEvent, ApprovalRequest, PlanStep, ToolCallLog } from "@/types";
 import type { AcpPlanStep } from "@/types/generated/AcpPlanStep";
 import type { AcpSessionUpdate } from "@/types/generated/AcpSessionUpdate";
 
@@ -28,6 +28,8 @@ const toToolPayload = (value: unknown): Record<string, unknown> | undefined => {
 export const useAssistantEventAdapter = () => {
 	const appendStreamingChunk = useStore((state) => state.appendStreamingChunk);
 	const updateStreamingPlan = useStore((state) => state.updateStreamingPlan);
+	const appendAgentEvent = useStore((state) => state.appendAgentEvent);
+	const addApprovalRequest = useStore((state) => state.addApprovalRequest);
 	const recordToolEvent = useStore((state) => state.recordToolEvent);
 	const completeStreamingMessage = useStore((state) => state.completeStreamingMessage);
 	const setAILoading = useStore((state) => state.setAILoading);
@@ -51,6 +53,20 @@ export const useAssistantEventAdapter = () => {
 			recordToolEvent(streamingId, log);
 		},
 		[recordToolEvent],
+	);
+
+	const recordAgentEvent = useCallback(
+		(streamingId: string, event: AgentEvent) => {
+			appendAgentEvent(streamingId, event);
+		},
+		[appendAgentEvent],
+	);
+
+	const enqueueApproval = useCallback(
+		(streamingId: string, request: ApprovalRequest) => {
+			addApprovalRequest(streamingId, request);
+		},
+		[addApprovalRequest],
 	);
 
 	const finalize = useCallback(
@@ -112,6 +128,8 @@ export const useAssistantEventAdapter = () => {
 	return {
 		appendChunk,
 		updatePlan,
+		recordAgentEvent,
+		enqueueApproval,
 		recordTool,
 		finalize,
 		mapPlanSteps,

--- a/client/src/services/messageBuilders.ts
+++ b/client/src/services/messageBuilders.ts
@@ -9,6 +9,7 @@ import type {
 	AIMode,
 	ChatMessagePayload,
 	ClientMessage,
+	ApprovalResponse,
 	ExecutionRequestPayload,
 	ExportRMarkdownRequestPayload,
 	FileSystemAction,
@@ -73,6 +74,12 @@ export const aiMessages = {
 		request_id: options?.requestId,
 		stream: options?.stream,
 		mode: options?.mode,
+	}),
+	approvalDecision: (
+		decision: ApprovalResponse,
+	): Extract<ClientMessage, { type: "agent_approval_decision" }> => ({
+		type: "agent_approval_decision",
+		decision,
 	}),
 } as const;
 

--- a/client/src/types/ui.ts
+++ b/client/src/types/ui.ts
@@ -249,6 +249,8 @@ export interface ArtifactEvent extends AgentEvent {
 		stderr?: string;
 		testsPassed?: number;
 		testsFailed?: number;
+		oldText?: string;
+		newText?: string;
 	};
 }
 

--- a/client/src/types/ui.ts
+++ b/client/src/types/ui.ts
@@ -174,6 +174,107 @@ export interface ToolCallLog {
 	locations?: string[];
 }
 
+export type AgentEventType =
+	| "thought"
+	| "tool_request"
+	| "tool_result"
+	| "task"
+	| "artifact"
+	| "error";
+
+export type AgentEventStatus =
+	| "pending"
+	| "running"
+	| "done"
+	| "error"
+	| "blocked"
+	| "approved"
+	| "denied";
+
+export type ArtifactKind = "file_read" | "file_write" | "command" | "test_result";
+
+export interface ToolPreview {
+	kind: "diff" | "command" | "read";
+	filepath?: string;
+	diff?: string;
+	command?: string;
+	affectedLines?: number;
+}
+
+export interface AgentEvent {
+	id: string;
+	type: AgentEventType;
+	status: AgentEventStatus;
+	timestamp: number;
+	parentId?: string;
+}
+
+export interface ThoughtEvent extends AgentEvent {
+	type: "thought";
+	text: string;
+	reasoning?: string;
+}
+
+export interface ToolRequestEvent extends AgentEvent {
+	type: "tool_request";
+	tool: string;
+	input: Record<string, unknown>;
+	requiresApproval: boolean;
+	preview?: ToolPreview;
+}
+
+export interface ToolResultEvent extends AgentEvent {
+	type: "tool_result";
+	tool: string;
+	requestId: string;
+	output?: Record<string, unknown>;
+	error?: string;
+}
+
+export interface TaskEvent extends AgentEvent {
+	type: "task";
+	label: string;
+	deps: string[];
+}
+
+export interface ArtifactEvent extends AgentEvent {
+	type: "artifact";
+	kind: ArtifactKind;
+	path?: string;
+	summary: string;
+	details?: {
+		diff?: string;
+		exitCode?: number;
+		stdout?: string;
+		stderr?: string;
+		testsPassed?: number;
+		testsFailed?: number;
+	};
+}
+
+export interface ErrorEvent extends AgentEvent {
+	type: "error";
+	message: string;
+	recoverable: boolean;
+	suggestedAction?: string;
+}
+
+export type ApprovalOption = "approve_once" | "approve_session" | "edit" | "deny";
+
+export interface ApprovalRequest {
+	eventId: string;
+	tool: string;
+	preview: ToolPreview;
+	options: ApprovalOption[];
+	input?: Record<string, unknown>;
+}
+
+export interface ApprovalResponse {
+	eventId: string;
+	decision: ApprovalOption;
+	editedInput?: Record<string, unknown>;
+}
+
 // UI State Types
 export interface LayoutState {
 	editorWidth: number;
@@ -209,6 +310,9 @@ export interface AIMessage {
 	mode?: AIMode;
 	code?: string; // Deprecated: use codeBlocks instead
 	codeBlocks?: CodeBlock[];
+	events?: AgentEvent[];
+	approvalQueue?: ApprovalRequest[];
+	artifacts?: ArtifactEvent[];
 	planSteps?: PlanStep[];
 	toolLogs?: ToolCallLog[];
 	streamingId?: string;

--- a/client/src/types/ws.ts
+++ b/client/src/types/ws.ts
@@ -14,10 +14,12 @@ import type {
 	FileEntryPayload,
 	FileSystemAction,
 	FileSystemEventPayload,
-	PlanStep,
+	AgentEvent,
 	ProjectRecord,
 	RunOutputChunk,
 	RunSummary,
+	ApprovalRequest,
+	ApprovalResponse,
 	ToolCallLog,
 	ToolExecutionRequestPayload,
 } from "./ui";
@@ -103,6 +105,7 @@ export type ClientMessage =
 			stream?: boolean;
 			mode?: AIMode;
 	  }
+	| { type: "agent_approval_decision"; decision: ApprovalResponse }
 	| { type: "list_tools" }
 	| ({ type: "execute_tool" } & ToolExecutionRequestPayload)
 	| { type: "timeline_query"; query: TimelineQuery }
@@ -153,7 +156,8 @@ export type ServerMessage =
 	  }
 	| { type: "ai_response_chunk"; id: string; chunk: string }
 	| { type: "ai_response_complete"; id: string; final: string; codeBlocks?: CodeBlock[] }
-	| { type: "ai_plan_updated"; id: string; plan: PlanStep[] }
+	| { type: "agent_event"; id: string; event: AgentEvent }
+	| { type: "approval_request"; id: string; request: ApprovalRequest }
 	| { type: "ai_tool_started"; id: string; tool: ToolCallLog }
 	| { type: "ai_tool_finished"; id: string; tool: ToolCallLog }
 	| { type: "error"; message: string }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
+similar = "2.6"
 
 # Logging
 tracing = { workspace = true }

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -213,9 +213,19 @@ fn summarize_tool_result(tool_call: &reprod_core::ToolCall, outcome: &serde_json
 
 fn artifact_for_tool_result(
     tool_call: &reprod_core::ToolCall,
+    output: &serde_json::Value,
     diff_summary: &str,
     display_summary: &str,
 ) -> Option<(ArtifactKind, Option<String>, String, Option<ArtifactDetailsPayload>)> {
+    let old_text = output
+        .get("old_text")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string());
+    let new_text = output
+        .get("new_text")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string());
+
     match tool_call.name.as_str() {
         "read_text_file" => Some((
             ArtifactKind::FileRead,
@@ -234,6 +244,8 @@ fn artifact_for_tool_result(
                 stderr: None,
                 tests_passed: None,
                 tests_failed: None,
+                old_text,
+                new_text,
             }),
         )),
         "web_search" => Some((
@@ -520,6 +532,7 @@ pub(super) async fn handle_ai_message(
                                 if let Some((kind, path, summary, details)) =
                                     artifact_for_tool_result(
                                         &tool_call,
+                                        &result.output,
                                         &result.summary,
                                         &display_summary,
                                     )

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -296,10 +296,11 @@ pub(super) async fn handle_ai_message(
 
     let mut outbound = Vec::new();
     let mut event_stream = EventStream::new(&stream_id, sender.clone());
+    let thought_id = event_stream.next_event_id();
     event_stream.emit(
         &mut outbound,
         AgentEventPayload::Thought {
-            id: event_stream.next_event_id(),
+            id: thought_id,
             status: AgentEventStatus::Done,
             timestamp: now_millis(),
             text: "Analyzing request to determine next actions.".to_string(),
@@ -337,7 +338,7 @@ pub(super) async fn handle_ai_message(
 
                 for tool_call in tool_calls {
                     let mut tool_call = tool_call.clone();
-                    let mut requires_approval = tool_requires_approval(&tool_call.name)
+                    let requires_approval = tool_requires_approval(&tool_call.name)
                         && !state
                             .approvals
                             .is_allowed(&stream_id, &tool_call.name)
@@ -470,10 +471,11 @@ pub(super) async fn handle_ai_message(
                                     },
                                 );
                                 let denied_message = "User denied tool execution".to_string();
+                                let denied_event_id = event_stream.next_event_id();
                                 event_stream.emit(
                                     &mut responses,
                                     AgentEventPayload::ToolResult {
-                                        id: event_stream.next_event_id(),
+                                        id: denied_event_id,
                                         status: AgentEventStatus::Denied,
                                         timestamp: now_millis(),
                                         request_id: request_event_id.clone(),
@@ -524,10 +526,11 @@ pub(super) async fn handle_ai_message(
 
                             let display_summary =
                                 summarize_tool_result(&tool_call, &result.output);
+                            let tool_result_id = event_stream.next_event_id();
                             event_stream.emit(
                                 &mut responses,
                                 AgentEventPayload::ToolResult {
-                                    id: event_stream.next_event_id(),
+                                    id: tool_result_id,
                                     status: AgentEventStatus::Done,
                                     timestamp: now_millis(),
                                     request_id: request_event_id.clone(),
@@ -546,10 +549,11 @@ pub(super) async fn handle_ai_message(
                                     &display_summary,
                                 )
                             {
+                                let artifact_id = event_stream.next_event_id();
                                 event_stream.emit(
                                     &mut responses,
                                     AgentEventPayload::Artifact {
-                                        id: event_stream.next_event_id(),
+                                        id: artifact_id,
                                         status: AgentEventStatus::Done,
                                         timestamp: now_millis(),
                                         kind,
@@ -581,10 +585,11 @@ pub(super) async fn handle_ai_message(
 
                             let recoverable = is_recoverable_error(&err);
                             let suggested_action = suggest_recovery(&err);
+                            let tool_error_id = event_stream.next_event_id();
                             event_stream.emit(
                                 &mut responses,
                                 AgentEventPayload::ToolResult {
-                                    id: event_stream.next_event_id(),
+                                    id: tool_error_id,
                                     status: AgentEventStatus::Error,
                                     timestamp: now_millis(),
                                     request_id: request_event_id.clone(),
@@ -594,10 +599,11 @@ pub(super) async fn handle_ai_message(
                                     parent_id: None,
                                 },
                             );
+                            let error_event_id = event_stream.next_event_id();
                             event_stream.emit(
                                 &mut responses,
                                 AgentEventPayload::Error {
-                                    id: event_stream.next_event_id(),
+                                    id: error_event_id,
                                     status: AgentEventStatus::Error,
                                     timestamp: now_millis(),
                                     message: err.clone(),
@@ -606,10 +612,11 @@ pub(super) async fn handle_ai_message(
                                     parent_id: None,
                                 },
                             );
+                            let thought_event_id = event_stream.next_event_id();
                             event_stream.emit(
                                 &mut responses,
                                 AgentEventPayload::Thought {
-                                    id: event_stream.next_event_id(),
+                                    id: thought_event_id,
                                     status: AgentEventStatus::Running,
                                     timestamp: now_millis(),
                                     text: format!(
@@ -620,10 +627,11 @@ pub(super) async fn handle_ai_message(
                                     parent_id: None,
                                 },
                             );
+                            let recovery_task_id = event_stream.next_event_id();
                             event_stream.emit(
                                 &mut responses,
                                 AgentEventPayload::Task {
-                                    id: event_stream.next_event_id(),
+                                    id: recovery_task_id,
                                     status: AgentEventStatus::Pending,
                                     timestamp: now_millis(),
                                     label: format!(
@@ -678,10 +686,11 @@ pub(super) async fn handle_ai_message(
 
                 loop_count += 1;
                 if loop_count >= MAX_TOOL_LOOPS {
+                    let loop_error_id = event_stream.next_event_id();
                     event_stream.emit(
                         &mut responses,
                         AgentEventPayload::Error {
-                            id: event_stream.next_event_id(),
+                            id: loop_error_id,
                             status: AgentEventStatus::Error,
                             timestamp: now_millis(),
                             message: "Tool loop limit reached".to_string(),

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -6,62 +6,262 @@ use reprod_core::{
         self,
         tools::{
             get_console_tools, get_filesystem_tools, get_r_context_tools, get_web_search_tools,
+            WriteTextFileRequest,
         },
     },
+    edit::{EditOperation, EditTextFileRequest, TextEdit},
     ChatMessage,
 };
+use similar::TextDiff;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::time::{timeout, Duration};
 
 use super::{
     common::{
-        build_streaming_payload, error_response, now_millis, tool_log_from_call,
-        with_system_prompts, AIMode, AppState, PlanStepPayload, PlanStepStatus, ToolLogStatus,
-        WSResponse,
+        build_streaming_payload, error_response, now_millis, tool_log_from_call, with_system_prompts,
+        AgentEventPayload, AgentEventStatus, AIMode, AppState, ApprovalDecisionPayload,
+        ApprovalOption, ApprovalRequestPayload, ArtifactDetailsPayload, ArtifactKind, ToolLogStatus,
+        ToolPreviewPayload, WSResponse,
     },
     tool_handler::execute_ai_tool_call,
 };
 
-const PLAN_STEP_DISPATCH: &str = "plan-dispatch";
-const PLAN_STEP_FETCH: &str = "locate-data";
-const PLAN_STEP_INSPECT: &str = "inspect-data";
-const PLAN_STEP_EXECUTE: &str = "execute-task";
-const PLAN_STEP_SUMMARIZE: &str = "summarize";
+type ResponseSender = Option<UnboundedSender<WSResponse>>;
 
-fn build_initial_plan() -> Vec<PlanStepPayload> {
-    let steps = vec![
-        PlanStepPayload::new(PLAN_STEP_DISPATCH, "Plan request", Some("plan".to_string())),
-        PlanStepPayload::new(
-            PLAN_STEP_FETCH,
-            "Fetch or locate data (download/path check)",
-            Some("exec".to_string()),
-        ),
-        PlanStepPayload {
-            waiting_reason: Some("Waiting for data or permission; resume once available".into()),
-            ..PlanStepPayload::new(
-                PLAN_STEP_INSPECT,
-                "Inspect data structure (head/sample)",
-                Some("peek".to_string()),
-            )
-        },
-        PlanStepPayload::new(
-            PLAN_STEP_EXECUTE,
-            "Execute requested task (analysis/plots)",
-            Some("exec".to_string()),
-        ),
-        PlanStepPayload::new(
-            PLAN_STEP_SUMMARIZE,
-            "Summarize results and next steps",
-            Some("exec".to_string()),
-        ),
-    ];
-
-    steps
+fn push_response(responses: &mut Vec<WSResponse>, sender: &ResponseSender, response: WSResponse) {
+    if let Some(sender) = sender {
+        let _ = sender.send(response);
+    } else {
+        responses.push(response);
+    }
 }
 
-fn push_plan_update(responses: &mut Vec<WSResponse>, request_id: &str, plan: &[PlanStepPayload]) {
-    responses.push(WSResponse::AIPlanUpdated {
-        id: request_id.to_string(),
-        plan: plan.to_vec(),
+fn push_responses(responses: &mut Vec<WSResponse>, sender: &ResponseSender, next: Vec<WSResponse>) {
+    for response in next {
+        push_response(responses, sender, response);
+    }
+}
+
+struct EventStream {
+    stream_id: String,
+    counter: u64,
+    sender: ResponseSender,
+}
+
+impl EventStream {
+    fn new(stream_id: &str, sender: ResponseSender) -> Self {
+        Self {
+            stream_id: stream_id.to_string(),
+            counter: 0,
+            sender,
+        }
+    }
+
+    fn next_event_id(&mut self) -> String {
+        self.counter += 1;
+        format!("{}-event-{}", self.stream_id, self.counter)
+    }
+
+    fn emit(&self, responses: &mut Vec<WSResponse>, event: AgentEventPayload) {
+        push_response(
+            responses,
+            &self.sender,
+            WSResponse::AgentEvent {
+                id: self.stream_id.clone(),
+                event,
+            },
+        );
+    }
+}
+
+fn tool_requires_approval(name: &str) -> bool {
+    matches!(name, "write_text_file" | "edit_text_file")
+}
+
+fn extract_path_from_input(input: &serde_json::Value) -> Option<String> {
+    input
+        .get("path")
+        .and_then(|value| value.as_str())
+        .map(|value| value.to_string())
+}
+
+fn build_diff(path: &str, old_text: &str, new_text: &str) -> String {
+    TextDiff::from_lines(old_text, new_text)
+        .unified_diff()
+        .header(path, path)
+        .to_string()
+}
+
+fn apply_edits_preview(original: &str, edits: &[TextEdit]) -> Result<String, String> {
+    let mut result = original.to_string();
+    let mut sorted = edits.to_vec();
+    sorted.sort_by(|a, b| {
+        (
+            b.range.start_line,
+            b.range.start_col,
+            b.range.end_line,
+            b.range.end_col,
+        )
+            .cmp(&(
+                a.range.start_line,
+                a.range.start_col,
+                a.range.end_line,
+                a.range.end_col,
+            ))
     });
+
+    for edit in sorted {
+        let start = line_col_to_index(&result, edit.range.start_line, edit.range.start_col)?;
+        let end = line_col_to_index(&result, edit.range.end_line, edit.range.end_col)?;
+        if start > end {
+            return Err("Edit range start is after end".to_string());
+        }
+        result.replace_range(start..end, &edit.text);
+    }
+
+    Ok(result)
+}
+
+fn line_col_to_index(text: &str, line: u32, col: u32) -> Result<usize, String> {
+    if line == 0 || col == 0 {
+        return Err("Line/column indices must be 1-based".to_string());
+    }
+    let mut current_line = 1u32;
+    let mut current_col = 1u32;
+    for (idx, ch) in text.char_indices() {
+        if current_line == line && current_col == col {
+            return Ok(idx);
+        }
+        if ch == '\n' {
+            current_line += 1;
+            current_col = 1;
+        } else {
+            current_col += 1;
+        }
+    }
+    if current_line == line && current_col == col {
+        return Ok(text.len());
+    }
+    Err("Line/column out of range".to_string())
+}
+
+async fn build_tool_preview(
+    tool_call: &reprod_core::ToolCall,
+    runtime: &Arc<ProjectRuntime>,
+) -> Option<ToolPreviewPayload> {
+    match tool_call.name.as_str() {
+        "read_text_file" => Some(ToolPreviewPayload {
+            kind: "read".to_string(),
+            filepath: extract_path_from_input(&tool_call.input),
+            diff: None,
+            command: None,
+            affected_lines: None,
+        }),
+        "write_text_file" => {
+            let request: WriteTextFileRequest =
+                serde_json::from_value(tool_call.input.clone()).ok()?;
+            let read_result = runtime.edit_service.read_text_file(&request.path).await;
+            let old_text = read_result.map(|result| result.text).unwrap_or_default();
+            let diff = build_diff(&request.path, &old_text, &request.content);
+            Some(ToolPreviewPayload {
+                kind: "diff".to_string(),
+                filepath: Some(request.path),
+                diff: Some(diff),
+                command: None,
+                affected_lines: None,
+            })
+        }
+        "edit_text_file" => {
+            let request: EditTextFileRequest =
+                serde_json::from_value(tool_call.input.clone()).ok()?;
+            let read_result = runtime.edit_service.read_text_file(&request.path).await;
+            let old_text = read_result.map(|result| result.text).unwrap_or_default();
+            let new_text = match request.operation {
+                EditOperation::Delete => String::new(),
+                EditOperation::Create | EditOperation::Replace => {
+                    request.new_text.clone().unwrap_or_default()
+                }
+                EditOperation::ApplyEdits => {
+                    let edits = request.edits.clone().unwrap_or_default();
+                    apply_edits_preview(&old_text, &edits).ok()?
+                }
+            };
+            let diff = build_diff(&request.path, &old_text, &new_text);
+            Some(ToolPreviewPayload {
+                kind: "diff".to_string(),
+                filepath: Some(request.path),
+                diff: Some(diff),
+                command: None,
+                affected_lines: None,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn summarize_tool_result(tool_call: &reprod_core::ToolCall, outcome: &serde_json::Value) -> String {
+    match tool_call.name.as_str() {
+        "read_text_file" => extract_path_from_input(&tool_call.input)
+            .map(|path| format!("Read file {}", path))
+            .unwrap_or_else(|| "Read file".to_string()),
+        "write_text_file" | "edit_text_file" => extract_path_from_input(&tool_call.input)
+            .map(|path| format!("Updated file {}", path))
+            .unwrap_or_else(|| "Updated file".to_string()),
+        _ => outcome.to_string(),
+    }
+}
+
+fn artifact_for_tool_result(
+    tool_call: &reprod_core::ToolCall,
+    diff_summary: &str,
+    display_summary: &str,
+) -> Option<(ArtifactKind, Option<String>, String, Option<ArtifactDetailsPayload>)> {
+    match tool_call.name.as_str() {
+        "read_text_file" => Some((
+            ArtifactKind::FileRead,
+            extract_path_from_input(&tool_call.input),
+            display_summary.to_string(),
+            None,
+        )),
+        "write_text_file" | "edit_text_file" => Some((
+            ArtifactKind::FileWrite,
+            extract_path_from_input(&tool_call.input),
+            display_summary.to_string(),
+            Some(ArtifactDetailsPayload {
+                diff: Some(diff_summary.to_string()),
+                exit_code: None,
+                stdout: None,
+                stderr: None,
+                tests_passed: None,
+                tests_failed: None,
+            }),
+        )),
+        "web_search" => Some((
+            ArtifactKind::Command,
+            None,
+            "Web search".to_string(),
+            None,
+        )),
+        _ => None,
+    }
+}
+
+fn is_recoverable_error(message: &str) -> bool {
+    !(message.contains("permission denied") || message.contains("not found"))
+}
+
+fn suggest_recovery(message: &str) -> Option<String> {
+    let lowered = message.to_lowercase();
+    if lowered.contains("not found") {
+        return Some("Verify the path and retry".to_string());
+    }
+    if lowered.contains("permission denied") {
+        return Some("Request permission or choose a different location".to_string());
+    }
+    if lowered.contains("syntax") {
+        return Some("Check syntax and try again".to_string());
+    }
+    None
 }
 
 pub(super) async fn handle_ai_message(
@@ -72,6 +272,7 @@ pub(super) async fn handle_ai_message(
     request_id: Option<String>,
     stream: bool,
     mode: AIMode,
+    sender: ResponseSender,
 ) -> Vec<WSResponse> {
     let cfg = state.config.lock().await.clone();
     let provider = ai::from_config(&cfg);
@@ -81,12 +282,19 @@ pub(super) async fn handle_ai_message(
     });
     let messages_with_prompts = with_system_prompts(&messages, mode);
 
-    let mut plan = build_initial_plan();
     let mut outbound = Vec::new();
-    if let Some(dispatch) = plan.iter_mut().find(|s| s.id == PLAN_STEP_DISPATCH) {
-        dispatch.mark_status(PlanStepStatus::Running);
-    }
-    push_plan_update(&mut outbound, &stream_id, &plan);
+    let mut event_stream = EventStream::new(&stream_id, sender.clone());
+    event_stream.emit(
+        &mut outbound,
+        AgentEventPayload::Thought {
+            id: event_stream.next_event_id(),
+            status: AgentEventStatus::Done,
+            timestamp: now_millis(),
+            text: "Analyzing request to determine next actions.".to_string(),
+            reasoning: Some("Establish context before acting.".to_string()),
+            parent_id: None,
+        },
+    );
 
     let responses = if enable_tools {
         let mut tools = get_filesystem_tools();
@@ -94,19 +302,6 @@ pub(super) async fn handle_ai_message(
         tools.extend(get_console_tools());
         tools.extend(get_web_search_tools());
         let mut responses = Vec::new();
-
-        // Mark fetch/inspect/execute phases as running in order as we start tool processing.
-        if let Some(fetch) = plan.iter_mut().find(|s| s.id == PLAN_STEP_FETCH) {
-            fetch.mark_status(PlanStepStatus::Running);
-        }
-        if let Some(inspect) = plan.iter_mut().find(|s| s.id == PLAN_STEP_INSPECT) {
-            inspect.mark_status(PlanStepStatus::Running);
-            inspect.waiting_reason = None;
-        }
-        if let Some(exec) = plan.iter_mut().find(|s| s.id == PLAN_STEP_EXECUTE) {
-            exec.mark_status(PlanStepStatus::Running);
-        }
-        push_plan_update(&mut responses, &stream_id, &plan);
 
         match provider
             .send_message_with_tools(messages_with_prompts.clone(), tools.clone())
@@ -117,41 +312,315 @@ pub(super) async fn handle_ai_message(
                     let mut tool_results = Vec::new();
 
                     for tool_call in tool_calls {
-                        let mut log = tool_log_from_call(tool_call);
-                        responses.push(WSResponse::AIToolStarted {
-                            id: stream_id.clone(),
-                            tool: log.clone(),
-                        });
+                        let mut tool_call = tool_call.clone();
+                        let mut requires_approval = tool_requires_approval(&tool_call.name)
+                            && !state
+                                .approvals
+                                .is_allowed(&stream_id, &tool_call.name)
+                                .await;
+                        let request_event_id = event_stream.next_event_id();
+                        let task_event_id = event_stream.next_event_id();
+                        let preview = build_tool_preview(&tool_call, runtime).await;
+                        event_stream.emit(
+                            &mut responses,
+                            AgentEventPayload::ToolRequest {
+                                id: request_event_id.clone(),
+                                status: if requires_approval {
+                                    AgentEventStatus::Blocked
+                                } else {
+                                    AgentEventStatus::Running
+                                },
+                                timestamp: now_millis(),
+                                tool: tool_call.name.clone(),
+                                input: tool_call.input.clone(),
+                                requires_approval,
+                                preview: preview.clone(),
+                                parent_id: None,
+                            },
+                        );
 
-                        let tool_result = execute_ai_tool_call(tool_call, runtime).await;
+                        let mut approved_input = tool_call.input.clone();
+                        if requires_approval {
+                            let approval_preview = preview.unwrap_or(ToolPreviewPayload {
+                                kind: "diff".to_string(),
+                                filepath: extract_path_from_input(&tool_call.input),
+                                diff: None,
+                                command: None,
+                                affected_lines: None,
+                            });
+                            push_response(
+                                &mut responses,
+                                &sender,
+                                WSResponse::ApprovalRequest {
+                                    id: stream_id.clone(),
+                                    request: ApprovalRequestPayload {
+                                        event_id: request_event_id.clone(),
+                                        tool: tool_call.name.clone(),
+                                        preview: approval_preview,
+                                        options: vec![
+                                            ApprovalOption::ApproveOnce,
+                                            ApprovalOption::ApproveSession,
+                                            ApprovalOption::Edit,
+                                            ApprovalOption::Deny,
+                                        ],
+                                        input: Some(tool_call.input.clone()),
+                                    },
+                                },
+                            );
+
+                            let receiver = state
+                                .approvals
+                                .register(request_event_id.clone())
+                                .await;
+                            let decision = match timeout(Duration::from_secs(300), receiver).await {
+                                Ok(Ok(decision)) => decision,
+                                _ => ApprovalDecisionPayload {
+                                    event_id: request_event_id.clone(),
+                                    decision: ApprovalOption::Deny,
+                                    edited_input: None,
+                                },
+                            };
+
+                            match decision.decision {
+                                ApprovalOption::ApproveOnce => {
+                                    event_stream.emit(
+                                        &mut responses,
+                                        AgentEventPayload::ToolRequest {
+                                            id: request_event_id.clone(),
+                                            status: AgentEventStatus::Approved,
+                                            timestamp: now_millis(),
+                                            tool: tool_call.name.clone(),
+                                            input: tool_call.input.clone(),
+                                            requires_approval: true,
+                                            preview: None,
+                                            parent_id: None,
+                                        },
+                                    );
+                                }
+                                ApprovalOption::ApproveSession => {
+                                    state
+                                        .approvals
+                                        .allow_for_session(&stream_id, &tool_call.name)
+                                        .await;
+                                    event_stream.emit(
+                                        &mut responses,
+                                        AgentEventPayload::ToolRequest {
+                                            id: request_event_id.clone(),
+                                            status: AgentEventStatus::Approved,
+                                            timestamp: now_millis(),
+                                            tool: tool_call.name.clone(),
+                                            input: tool_call.input.clone(),
+                                            requires_approval: true,
+                                            preview: None,
+                                            parent_id: None,
+                                        },
+                                    );
+                                }
+                                ApprovalOption::Edit => {
+                                    if let Some(input) = decision.edited_input.clone() {
+                                        approved_input = input;
+                                    }
+                                    event_stream.emit(
+                                        &mut responses,
+                                        AgentEventPayload::ToolRequest {
+                                            id: request_event_id.clone(),
+                                            status: AgentEventStatus::Approved,
+                                            timestamp: now_millis(),
+                                            tool: tool_call.name.clone(),
+                                            input: approved_input.clone(),
+                                            requires_approval: true,
+                                            preview: None,
+                                            parent_id: None,
+                                        },
+                                    );
+                                }
+                                ApprovalOption::Deny => {
+                                    event_stream.emit(
+                                        &mut responses,
+                                        AgentEventPayload::ToolRequest {
+                                            id: request_event_id.clone(),
+                                            status: AgentEventStatus::Denied,
+                                            timestamp: now_millis(),
+                                            tool: tool_call.name.clone(),
+                                            input: tool_call.input.clone(),
+                                            requires_approval: true,
+                                            preview: None,
+                                            parent_id: None,
+                                        },
+                                    );
+                                    let denied_message = "User denied tool execution".to_string();
+                                    event_stream.emit(
+                                        &mut responses,
+                                        AgentEventPayload::ToolResult {
+                                            id: event_stream.next_event_id(),
+                                            status: AgentEventStatus::Denied,
+                                            timestamp: now_millis(),
+                                            request_id: request_event_id.clone(),
+                                            tool: tool_call.name.clone(),
+                                            output: None,
+                                            error: Some(denied_message.clone()),
+                                            parent_id: None,
+                                        },
+                                    );
+                                    tool_results.push((
+                                        tool_call.id.clone(),
+                                        format!("Denied: {}", denied_message),
+                                    ));
+                                    continue;
+                                }
+                            }
+                        }
+                        event_stream.emit(
+                            &mut responses,
+                            AgentEventPayload::Task {
+                                id: task_event_id.clone(),
+                                status: AgentEventStatus::Running,
+                                timestamp: now_millis(),
+                                label: format!("Run tool: {}", tool_call.name),
+                                deps: Vec::new(),
+                                parent_id: None,
+                            },
+                        );
+
+                        tool_call.input = approved_input;
+                        let mut log = tool_log_from_call(&tool_call);
+                        push_response(
+                            &mut responses,
+                            &sender,
+                            WSResponse::AIToolStarted {
+                                id: stream_id.clone(),
+                                tool: log.clone(),
+                            },
+                        );
+
+                        let tool_result = execute_ai_tool_call(&tool_call, runtime).await;
                         match tool_result {
                             Ok(result) => {
                                 log.status = ToolLogStatus::Done;
                                 log.output = Some(result.output.clone());
-                                tool_results.push((tool_call.id.clone(), result.summary));
+                                tool_results
+                                    .push((tool_call.id.clone(), result.summary.clone()));
+
+                                let display_summary =
+                                    summarize_tool_result(&tool_call, &result.output);
+                                event_stream.emit(
+                                    &mut responses,
+                                    AgentEventPayload::ToolResult {
+                                        id: event_stream.next_event_id(),
+                                        status: AgentEventStatus::Done,
+                                        timestamp: now_millis(),
+                                        request_id: request_event_id.clone(),
+                                        tool: tool_call.name.clone(),
+                                        output: Some(result.output.clone()),
+                                        error: None,
+                                        parent_id: None,
+                                    },
+                                );
+
+                                if let Some((kind, path, summary, details)) =
+                                    artifact_for_tool_result(
+                                        &tool_call,
+                                        &result.summary,
+                                        &display_summary,
+                                    )
+                                {
+                                    event_stream.emit(
+                                        &mut responses,
+                                        AgentEventPayload::Artifact {
+                                            id: event_stream.next_event_id(),
+                                            status: AgentEventStatus::Done,
+                                            timestamp: now_millis(),
+                                            kind,
+                                            path,
+                                            summary,
+                                            details,
+                                            parent_id: None,
+                                        },
+                                    );
+                                }
+
+                                event_stream.emit(
+                                    &mut responses,
+                                    AgentEventPayload::Task {
+                                        id: task_event_id,
+                                        status: AgentEventStatus::Done,
+                                        timestamp: now_millis(),
+                                        label: format!("Run tool: {}", tool_call.name),
+                                        deps: Vec::new(),
+                                        parent_id: None,
+                                    },
+                                );
                             }
                             Err(err) => {
                                 log.status = ToolLogStatus::Error;
                                 log.error = Some(err.clone());
                                 tool_results
                                     .push((tool_call.id.clone(), format!("Error: {}", err)));
+
+                                let recoverable = is_recoverable_error(&err);
+                                let suggested_action = suggest_recovery(&err);
+                                event_stream.emit(
+                                    &mut responses,
+                                    AgentEventPayload::ToolResult {
+                                        id: event_stream.next_event_id(),
+                                        status: AgentEventStatus::Error,
+                                        timestamp: now_millis(),
+                                        request_id: request_event_id.clone(),
+                                        tool: tool_call.name.clone(),
+                                        output: None,
+                                        error: Some(err.clone()),
+                                        parent_id: None,
+                                    },
+                                );
+                                event_stream.emit(
+                                    &mut responses,
+                                    AgentEventPayload::Error {
+                                        id: event_stream.next_event_id(),
+                                        status: AgentEventStatus::Error,
+                                        timestamp: now_millis(),
+                                        message: err.clone(),
+                                        recoverable,
+                                        suggested_action: suggested_action.clone(),
+                                        parent_id: None,
+                                    },
+                                );
+                                event_stream.emit(
+                                    &mut responses,
+                                    AgentEventPayload::Thought {
+                                        id: event_stream.next_event_id(),
+                                        status: AgentEventStatus::Running,
+                                        timestamp: now_millis(),
+                                        text: format!(
+                                            "Tool failed: {}. Considering alternative.",
+                                            err
+                                        ),
+                                        reasoning: suggested_action,
+                                        parent_id: None,
+                                    },
+                                );
+                                event_stream.emit(
+                                    &mut responses,
+                                    AgentEventPayload::Task {
+                                        id: task_event_id,
+                                        status: AgentEventStatus::Error,
+                                        timestamp: now_millis(),
+                                        label: format!("Run tool: {}", tool_call.name),
+                                        deps: Vec::new(),
+                                        parent_id: None,
+                                    },
+                                );
                             }
                         }
                         log.finished_at = Some(now_millis());
-                        responses.push(WSResponse::AIToolFinished {
-                            id: stream_id.clone(),
-                            tool: log,
-                        });
+                        push_response(
+                            &mut responses,
+                            &sender,
+                            WSResponse::AIToolFinished {
+                                id: stream_id.clone(),
+                                tool: log,
+                            },
+                        );
                     }
-
-                    // Mark fetch/inspect done after tool calls finish.
-                    if let Some(fetch) = plan.iter_mut().find(|s| s.id == PLAN_STEP_FETCH) {
-                        fetch.mark_status(PlanStepStatus::Done);
-                    }
-                    if let Some(inspect) = plan.iter_mut().find(|s| s.id == PLAN_STEP_INSPECT) {
-                        inspect.mark_status(PlanStepStatus::Done);
-                    }
-                    push_plan_update(&mut responses, &stream_id, &plan);
 
                     let mut follow_up_messages = messages.clone();
                     follow_up_messages.push(ChatMessage {
@@ -169,75 +638,71 @@ pub(super) async fn handle_ai_message(
                     let follow_up_with_prompts = with_system_prompts(&follow_up_messages, mode);
                     match provider.send_message(follow_up_with_prompts).await {
                         Ok(final_response) => {
-                            responses.extend(build_streaming_payload(
-                                stream,
-                                &stream_id,
-                                final_response,
-                            ));
-                            if let Some(exec) = plan.iter_mut().find(|s| s.id == PLAN_STEP_EXECUTE)
-                            {
-                                exec.mark_status(PlanStepStatus::Done);
-                            }
-                            if let Some(sum) = plan.iter_mut().find(|s| s.id == PLAN_STEP_SUMMARIZE)
-                            {
-                                sum.mark_status(PlanStepStatus::Done);
-                            }
-                            push_plan_update(&mut responses, &stream_id, &plan);
+                            push_responses(
+                                &mut responses,
+                                &sender,
+                                build_streaming_payload(stream, &stream_id, final_response),
+                            );
                             responses
                         }
                         Err(e) => {
-                            responses.push(WSResponse::Error {
-                                message: format!("Failed to get final response: {}", e),
-                            });
-                            if let Some(exec) = plan.iter_mut().find(|s| s.id == PLAN_STEP_EXECUTE)
-                            {
-                                exec.error = Some(format!("Failed to get final response: {}", e));
-                                exec.mark_status(PlanStepStatus::Error);
-                            }
+                            push_response(
+                                &mut responses,
+                                &sender,
+                                WSResponse::Error {
+                                    message: format!("Failed to get final response: {}", e),
+                                },
+                            );
                             responses
                         }
                     }
                 } else {
-                    let mut responses =
-                        build_streaming_payload(stream, &stream_id, response.content.clone());
-                    responses.push(WSResponse::AIResponseWithTools { response });
-                    if let Some(exec) = plan.iter_mut().find(|s| s.id == PLAN_STEP_EXECUTE) {
-                        exec.mark_status(PlanStepStatus::Done);
-                    }
-                    if let Some(sum) = plan.iter_mut().find(|s| s.id == PLAN_STEP_SUMMARIZE) {
-                        sum.mark_status(PlanStepStatus::Done);
-                    }
-                    push_plan_update(&mut responses, &stream_id, &plan);
+                    let mut responses = Vec::new();
+                    push_responses(
+                        &mut responses,
+                        &sender,
+                        build_streaming_payload(stream, &stream_id, response.content.clone()),
+                    );
+                    push_response(
+                        &mut responses,
+                        &sender,
+                        WSResponse::AIResponseWithTools { response },
+                    );
                     responses
                 }
             }
-            Err(e) => error_response(e.to_string()),
+            Err(e) => {
+                let mut responses = Vec::new();
+                push_responses(&mut responses, &sender, error_response(e.to_string()));
+                responses
+            }
         }
     } else {
         match provider.send_message(messages_with_prompts).await {
-            Ok(response) => build_streaming_payload(stream, &stream_id, response),
-            Err(e) => error_response(e.to_string()),
+            Ok(response) => {
+                let mut responses = Vec::new();
+                push_responses(&mut responses, &sender, build_streaming_payload(stream, &stream_id, response));
+                responses
+            }
+            Err(e) => {
+                let mut responses = Vec::new();
+                push_responses(&mut responses, &sender, error_response(e.to_string()));
+                responses
+            }
         }
     };
 
-    let first_error_message = responses.iter().find_map(|response| {
-        if let WSResponse::Error { message } = response {
-            Some(message.clone())
-        } else {
-            None
-        }
-    });
-
-    if let Some(step) = plan.iter_mut().find(|step| step.id == PLAN_STEP_DISPATCH) {
-        if let Some(error_message) = first_error_message {
-            step.error = Some(error_message);
-            step.mark_status(PlanStepStatus::Error);
-        } else {
-            step.mark_status(PlanStepStatus::Done);
-        }
-    }
     outbound.extend(responses);
-    push_plan_update(&mut outbound, &stream_id, &plan);
-
     outbound
+}
+
+pub(super) async fn handle_agent_approval_decision(
+    state: &AppState,
+    decision: ApprovalDecisionPayload,
+) -> Vec<WSResponse> {
+    if state.approvals.resolve(decision).await {
+        Vec::new()
+    } else {
+        error_response("No pending approval for decision")
+    }
 }

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -314,382 +314,408 @@ pub(super) async fn handle_ai_message(
         tools.extend(get_console_tools());
         tools.extend(get_web_search_tools());
         let mut responses = Vec::new();
+        let mut conversation = messages.clone();
+        let mut loop_count = 0;
+        const MAX_TOOL_LOOPS: usize = 5;
 
-        match provider
-            .send_message_with_tools(messages_with_prompts.clone(), tools.clone())
-            .await
-        {
-            Ok(response) => {
-                if let Some(ref tool_calls) = response.tool_calls {
-                    let mut tool_results = Vec::new();
+        loop {
+            let messages_with_prompts = with_system_prompts(&conversation, mode);
+            let response = match provider
+                .send_message_with_tools(messages_with_prompts.clone(), tools.clone())
+                .await
+            {
+                Ok(response) => response,
+                Err(e) => {
+                    push_responses(&mut responses, &sender, error_response(e.to_string()));
+                    break;
+                }
+            };
 
-                    for tool_call in tool_calls {
-                        let mut tool_call = tool_call.clone();
-                        let mut requires_approval = tool_requires_approval(&tool_call.name)
-                            && !state
-                                .approvals
-                                .is_allowed(&stream_id, &tool_call.name)
-                                .await;
-                        let request_event_id = event_stream.next_event_id();
-                        let task_event_id = event_stream.next_event_id();
-                        let preview = build_tool_preview(&tool_call, runtime).await;
-                        event_stream.emit(
-                            &mut responses,
-                            AgentEventPayload::ToolRequest {
-                                id: request_event_id.clone(),
-                                status: if requires_approval {
-                                    AgentEventStatus::Blocked
-                                } else {
-                                    AgentEventStatus::Running
-                                },
-                                timestamp: now_millis(),
-                                tool: tool_call.name.clone(),
-                                input: tool_call.input.clone(),
-                                requires_approval,
-                                preview: preview.clone(),
-                                parent_id: None,
+            if let Some(ref tool_calls) = response.tool_calls {
+                let mut tool_results = Vec::new();
+                let mut saw_error = false;
+
+                for tool_call in tool_calls {
+                    let mut tool_call = tool_call.clone();
+                    let mut requires_approval = tool_requires_approval(&tool_call.name)
+                        && !state
+                            .approvals
+                            .is_allowed(&stream_id, &tool_call.name)
+                            .await;
+                    let request_event_id = event_stream.next_event_id();
+                    let task_event_id = event_stream.next_event_id();
+                    let preview = build_tool_preview(&tool_call, runtime).await;
+                    event_stream.emit(
+                        &mut responses,
+                        AgentEventPayload::ToolRequest {
+                            id: request_event_id.clone(),
+                            status: if requires_approval {
+                                AgentEventStatus::Blocked
+                            } else {
+                                AgentEventStatus::Running
                             },
-                        );
+                            timestamp: now_millis(),
+                            tool: tool_call.name.clone(),
+                            input: tool_call.input.clone(),
+                            requires_approval,
+                            preview: preview.clone(),
+                            parent_id: None,
+                        },
+                    );
 
-                        let mut approved_input = tool_call.input.clone();
-                        if requires_approval {
-                            let approval_preview = preview.unwrap_or(ToolPreviewPayload {
-                                kind: "diff".to_string(),
-                                filepath: extract_path_from_input(&tool_call.input),
-                                diff: None,
-                                command: None,
-                                affected_lines: None,
-                            });
-                            push_response(
-                                &mut responses,
-                                &sender,
-                                WSResponse::ApprovalRequest {
-                                    id: stream_id.clone(),
-                                    request: ApprovalRequestPayload {
-                                        event_id: request_event_id.clone(),
-                                        tool: tool_call.name.clone(),
-                                        preview: approval_preview,
-                                        options: vec![
-                                            ApprovalOption::ApproveOnce,
-                                            ApprovalOption::ApproveSession,
-                                            ApprovalOption::Edit,
-                                            ApprovalOption::Deny,
-                                        ],
-                                        input: Some(tool_call.input.clone()),
-                                    },
-                                },
-                            );
-
-                            let receiver = state
-                                .approvals
-                                .register(request_event_id.clone())
-                                .await;
-                            let decision = match timeout(Duration::from_secs(300), receiver).await {
-                                Ok(Ok(decision)) => decision,
-                                _ => ApprovalDecisionPayload {
-                                    event_id: request_event_id.clone(),
-                                    decision: ApprovalOption::Deny,
-                                    edited_input: None,
-                                },
-                            };
-
-                            match decision.decision {
-                                ApprovalOption::ApproveOnce => {
-                                    event_stream.emit(
-                                        &mut responses,
-                                        AgentEventPayload::ToolRequest {
-                                            id: request_event_id.clone(),
-                                            status: AgentEventStatus::Approved,
-                                            timestamp: now_millis(),
-                                            tool: tool_call.name.clone(),
-                                            input: tool_call.input.clone(),
-                                            requires_approval: true,
-                                            preview: None,
-                                            parent_id: None,
-                                        },
-                                    );
-                                }
-                                ApprovalOption::ApproveSession => {
-                                    state
-                                        .approvals
-                                        .allow_for_session(&stream_id, &tool_call.name)
-                                        .await;
-                                    event_stream.emit(
-                                        &mut responses,
-                                        AgentEventPayload::ToolRequest {
-                                            id: request_event_id.clone(),
-                                            status: AgentEventStatus::Approved,
-                                            timestamp: now_millis(),
-                                            tool: tool_call.name.clone(),
-                                            input: tool_call.input.clone(),
-                                            requires_approval: true,
-                                            preview: None,
-                                            parent_id: None,
-                                        },
-                                    );
-                                }
-                                ApprovalOption::Edit => {
-                                    if let Some(input) = decision.edited_input.clone() {
-                                        approved_input = input;
-                                    }
-                                    event_stream.emit(
-                                        &mut responses,
-                                        AgentEventPayload::ToolRequest {
-                                            id: request_event_id.clone(),
-                                            status: AgentEventStatus::Approved,
-                                            timestamp: now_millis(),
-                                            tool: tool_call.name.clone(),
-                                            input: approved_input.clone(),
-                                            requires_approval: true,
-                                            preview: None,
-                                            parent_id: None,
-                                        },
-                                    );
-                                }
-                                ApprovalOption::Deny => {
-                                    event_stream.emit(
-                                        &mut responses,
-                                        AgentEventPayload::ToolRequest {
-                                            id: request_event_id.clone(),
-                                            status: AgentEventStatus::Denied,
-                                            timestamp: now_millis(),
-                                            tool: tool_call.name.clone(),
-                                            input: tool_call.input.clone(),
-                                            requires_approval: true,
-                                            preview: None,
-                                            parent_id: None,
-                                        },
-                                    );
-                                    let denied_message = "User denied tool execution".to_string();
-                                    event_stream.emit(
-                                        &mut responses,
-                                        AgentEventPayload::ToolResult {
-                                            id: event_stream.next_event_id(),
-                                            status: AgentEventStatus::Denied,
-                                            timestamp: now_millis(),
-                                            request_id: request_event_id.clone(),
-                                            tool: tool_call.name.clone(),
-                                            output: None,
-                                            error: Some(denied_message.clone()),
-                                            parent_id: None,
-                                        },
-                                    );
-                                    tool_results.push((
-                                        tool_call.id.clone(),
-                                        format!("Denied: {}", denied_message),
-                                    ));
-                                    continue;
-                                }
-                            }
-                        }
-                        event_stream.emit(
-                            &mut responses,
-                            AgentEventPayload::Task {
-                                id: task_event_id.clone(),
-                                status: AgentEventStatus::Running,
-                                timestamp: now_millis(),
-                                label: format!("Run tool: {}", tool_call.name),
-                                deps: Vec::new(),
-                                parent_id: None,
-                            },
-                        );
-
-                        tool_call.input = approved_input;
-                        let mut log = tool_log_from_call(&tool_call);
+                    let mut approved_input = tool_call.input.clone();
+                    if requires_approval {
+                        let approval_preview = preview.unwrap_or(ToolPreviewPayload {
+                            kind: "diff".to_string(),
+                            filepath: extract_path_from_input(&tool_call.input),
+                            diff: None,
+                            command: None,
+                            affected_lines: None,
+                        });
                         push_response(
                             &mut responses,
                             &sender,
-                            WSResponse::AIToolStarted {
+                            WSResponse::ApprovalRequest {
                                 id: stream_id.clone(),
-                                tool: log.clone(),
+                                request: ApprovalRequestPayload {
+                                    event_id: request_event_id.clone(),
+                                    tool: tool_call.name.clone(),
+                                    preview: approval_preview,
+                                    options: vec![
+                                        ApprovalOption::ApproveOnce,
+                                        ApprovalOption::ApproveSession,
+                                        ApprovalOption::Edit,
+                                        ApprovalOption::Deny,
+                                    ],
+                                    input: Some(tool_call.input.clone()),
+                                },
                             },
                         );
 
-                        let tool_result = execute_ai_tool_call(&tool_call, runtime).await;
-                        match tool_result {
-                            Ok(result) => {
-                                log.status = ToolLogStatus::Done;
-                                log.output = Some(result.output.clone());
-                                tool_results
-                                    .push((tool_call.id.clone(), result.summary.clone()));
+                        let receiver = state.approvals.register(request_event_id.clone()).await;
+                        let decision = match timeout(Duration::from_secs(300), receiver).await {
+                            Ok(Ok(decision)) => decision,
+                            _ => ApprovalDecisionPayload {
+                                event_id: request_event_id.clone(),
+                                decision: ApprovalOption::Deny,
+                                edited_input: None,
+                            },
+                        };
 
-                                let display_summary =
-                                    summarize_tool_result(&tool_call, &result.output);
+                        match decision.decision {
+                            ApprovalOption::ApproveOnce => {
                                 event_stream.emit(
                                     &mut responses,
-                                    AgentEventPayload::ToolResult {
-                                        id: event_stream.next_event_id(),
-                                        status: AgentEventStatus::Done,
+                                    AgentEventPayload::ToolRequest {
+                                        id: request_event_id.clone(),
+                                        status: AgentEventStatus::Approved,
                                         timestamp: now_millis(),
-                                        request_id: request_event_id.clone(),
                                         tool: tool_call.name.clone(),
-                                        output: Some(result.output.clone()),
-                                        error: None,
-                                        parent_id: None,
-                                    },
-                                );
-
-                                if let Some((kind, path, summary, details)) =
-                                    artifact_for_tool_result(
-                                        &tool_call,
-                                        &result.output,
-                                        &result.summary,
-                                        &display_summary,
-                                    )
-                                {
-                                    event_stream.emit(
-                                        &mut responses,
-                                        AgentEventPayload::Artifact {
-                                            id: event_stream.next_event_id(),
-                                            status: AgentEventStatus::Done,
-                                            timestamp: now_millis(),
-                                            kind,
-                                            path,
-                                            summary,
-                                            details,
-                                            parent_id: None,
-                                        },
-                                    );
-                                }
-
-                                event_stream.emit(
-                                    &mut responses,
-                                    AgentEventPayload::Task {
-                                        id: task_event_id,
-                                        status: AgentEventStatus::Done,
-                                        timestamp: now_millis(),
-                                        label: format!("Run tool: {}", tool_call.name),
-                                        deps: Vec::new(),
+                                        input: tool_call.input.clone(),
+                                        requires_approval: true,
+                                        preview: None,
                                         parent_id: None,
                                     },
                                 );
                             }
-                            Err(err) => {
-                                log.status = ToolLogStatus::Error;
-                                log.error = Some(err.clone());
-                                tool_results
-                                    .push((tool_call.id.clone(), format!("Error: {}", err)));
-
-                                let recoverable = is_recoverable_error(&err);
-                                let suggested_action = suggest_recovery(&err);
+                            ApprovalOption::ApproveSession => {
+                                state
+                                    .approvals
+                                    .allow_for_session(&stream_id, &tool_call.name)
+                                    .await;
+                                event_stream.emit(
+                                    &mut responses,
+                                    AgentEventPayload::ToolRequest {
+                                        id: request_event_id.clone(),
+                                        status: AgentEventStatus::Approved,
+                                        timestamp: now_millis(),
+                                        tool: tool_call.name.clone(),
+                                        input: tool_call.input.clone(),
+                                        requires_approval: true,
+                                        preview: None,
+                                        parent_id: None,
+                                    },
+                                );
+                            }
+                            ApprovalOption::Edit => {
+                                if let Some(input) = decision.edited_input.clone() {
+                                    approved_input = input;
+                                }
+                                event_stream.emit(
+                                    &mut responses,
+                                    AgentEventPayload::ToolRequest {
+                                        id: request_event_id.clone(),
+                                        status: AgentEventStatus::Approved,
+                                        timestamp: now_millis(),
+                                        tool: tool_call.name.clone(),
+                                        input: approved_input.clone(),
+                                        requires_approval: true,
+                                        preview: None,
+                                        parent_id: None,
+                                    },
+                                );
+                            }
+                            ApprovalOption::Deny => {
+                                event_stream.emit(
+                                    &mut responses,
+                                    AgentEventPayload::ToolRequest {
+                                        id: request_event_id.clone(),
+                                        status: AgentEventStatus::Denied,
+                                        timestamp: now_millis(),
+                                        tool: tool_call.name.clone(),
+                                        input: tool_call.input.clone(),
+                                        requires_approval: true,
+                                        preview: None,
+                                        parent_id: None,
+                                    },
+                                );
+                                let denied_message = "User denied tool execution".to_string();
                                 event_stream.emit(
                                     &mut responses,
                                     AgentEventPayload::ToolResult {
                                         id: event_stream.next_event_id(),
-                                        status: AgentEventStatus::Error,
+                                        status: AgentEventStatus::Denied,
                                         timestamp: now_millis(),
                                         request_id: request_event_id.clone(),
                                         tool: tool_call.name.clone(),
                                         output: None,
-                                        error: Some(err.clone()),
+                                        error: Some(denied_message.clone()),
                                         parent_id: None,
                                     },
                                 );
+                                tool_results.push((
+                                    tool_call.id.clone(),
+                                    format!("Denied: {}", denied_message),
+                                ));
+                                saw_error = true;
+                                continue;
+                            }
+                        }
+                    }
+                    event_stream.emit(
+                        &mut responses,
+                        AgentEventPayload::Task {
+                            id: task_event_id.clone(),
+                            status: AgentEventStatus::Running,
+                            timestamp: now_millis(),
+                            label: format!("Run tool: {}", tool_call.name),
+                            deps: Vec::new(),
+                            parent_id: None,
+                        },
+                    );
+
+                    tool_call.input = approved_input;
+                    let mut log = tool_log_from_call(&tool_call);
+                    push_response(
+                        &mut responses,
+                        &sender,
+                        WSResponse::AIToolStarted {
+                            id: stream_id.clone(),
+                            tool: log.clone(),
+                        },
+                    );
+
+                    let tool_result = execute_ai_tool_call(&tool_call, runtime).await;
+                    match tool_result {
+                        Ok(result) => {
+                            log.status = ToolLogStatus::Done;
+                            log.output = Some(result.output.clone());
+                            tool_results.push((tool_call.id.clone(), result.summary.clone()));
+
+                            let display_summary =
+                                summarize_tool_result(&tool_call, &result.output);
+                            event_stream.emit(
+                                &mut responses,
+                                AgentEventPayload::ToolResult {
+                                    id: event_stream.next_event_id(),
+                                    status: AgentEventStatus::Done,
+                                    timestamp: now_millis(),
+                                    request_id: request_event_id.clone(),
+                                    tool: tool_call.name.clone(),
+                                    output: Some(result.output.clone()),
+                                    error: None,
+                                    parent_id: None,
+                                },
+                            );
+
+                            if let Some((kind, path, summary, details)) =
+                                artifact_for_tool_result(
+                                    &tool_call,
+                                    &result.output,
+                                    &result.summary,
+                                    &display_summary,
+                                )
+                            {
                                 event_stream.emit(
                                     &mut responses,
-                                    AgentEventPayload::Error {
+                                    AgentEventPayload::Artifact {
                                         id: event_stream.next_event_id(),
-                                        status: AgentEventStatus::Error,
+                                        status: AgentEventStatus::Done,
                                         timestamp: now_millis(),
-                                        message: err.clone(),
-                                        recoverable,
-                                        suggested_action: suggested_action.clone(),
-                                        parent_id: None,
-                                    },
-                                );
-                                event_stream.emit(
-                                    &mut responses,
-                                    AgentEventPayload::Thought {
-                                        id: event_stream.next_event_id(),
-                                        status: AgentEventStatus::Running,
-                                        timestamp: now_millis(),
-                                        text: format!(
-                                            "Tool failed: {}. Considering alternative.",
-                                            err
-                                        ),
-                                        reasoning: suggested_action,
-                                        parent_id: None,
-                                    },
-                                );
-                                event_stream.emit(
-                                    &mut responses,
-                                    AgentEventPayload::Task {
-                                        id: task_event_id,
-                                        status: AgentEventStatus::Error,
-                                        timestamp: now_millis(),
-                                        label: format!("Run tool: {}", tool_call.name),
-                                        deps: Vec::new(),
+                                        kind,
+                                        path,
+                                        summary,
+                                        details,
                                         parent_id: None,
                                     },
                                 );
                             }
-                        }
-                        log.finished_at = Some(now_millis());
-                        push_response(
-                            &mut responses,
-                            &sender,
-                            WSResponse::AIToolFinished {
-                                id: stream_id.clone(),
-                                tool: log,
-                            },
-                        );
-                    }
 
-                    let mut follow_up_messages = messages.clone();
-                    follow_up_messages.push(ChatMessage {
-                        role: "assistant".to_string(),
-                        content: response.content.clone(),
-                    });
-
-                    for (tool_id, result) in tool_results {
-                        follow_up_messages.push(ChatMessage {
-                            role: "user".to_string(),
-                            content: format!("Tool '{}' result: {}", tool_id, result),
-                        });
-                    }
-
-                    let follow_up_with_prompts = with_system_prompts(&follow_up_messages, mode);
-                    match provider.send_message(follow_up_with_prompts).await {
-                        Ok(final_response) => {
-                            push_responses(
+                            event_stream.emit(
                                 &mut responses,
-                                &sender,
-                                build_streaming_payload(stream, &stream_id, final_response),
-                            );
-                            responses
-                        }
-                        Err(e) => {
-                            push_response(
-                                &mut responses,
-                                &sender,
-                                WSResponse::Error {
-                                    message: format!("Failed to get final response: {}", e),
+                                AgentEventPayload::Task {
+                                    id: task_event_id,
+                                    status: AgentEventStatus::Done,
+                                    timestamp: now_millis(),
+                                    label: format!("Run tool: {}", tool_call.name),
+                                    deps: Vec::new(),
+                                    parent_id: None,
                                 },
                             );
-                            responses
+                        }
+                        Err(err) => {
+                            log.status = ToolLogStatus::Error;
+                            log.error = Some(err.clone());
+                            tool_results.push((tool_call.id.clone(), format!("Error: {}", err)));
+                            saw_error = true;
+
+                            let recoverable = is_recoverable_error(&err);
+                            let suggested_action = suggest_recovery(&err);
+                            event_stream.emit(
+                                &mut responses,
+                                AgentEventPayload::ToolResult {
+                                    id: event_stream.next_event_id(),
+                                    status: AgentEventStatus::Error,
+                                    timestamp: now_millis(),
+                                    request_id: request_event_id.clone(),
+                                    tool: tool_call.name.clone(),
+                                    output: None,
+                                    error: Some(err.clone()),
+                                    parent_id: None,
+                                },
+                            );
+                            event_stream.emit(
+                                &mut responses,
+                                AgentEventPayload::Error {
+                                    id: event_stream.next_event_id(),
+                                    status: AgentEventStatus::Error,
+                                    timestamp: now_millis(),
+                                    message: err.clone(),
+                                    recoverable,
+                                    suggested_action: suggested_action.clone(),
+                                    parent_id: None,
+                                },
+                            );
+                            event_stream.emit(
+                                &mut responses,
+                                AgentEventPayload::Thought {
+                                    id: event_stream.next_event_id(),
+                                    status: AgentEventStatus::Running,
+                                    timestamp: now_millis(),
+                                    text: format!(
+                                        "Tool failed: {}. Considering alternative.",
+                                        err
+                                    ),
+                                    reasoning: suggested_action.clone(),
+                                    parent_id: None,
+                                },
+                            );
+                            event_stream.emit(
+                                &mut responses,
+                                AgentEventPayload::Task {
+                                    id: event_stream.next_event_id(),
+                                    status: AgentEventStatus::Pending,
+                                    timestamp: now_millis(),
+                                    label: format!(
+                                        "Recover from {} failure",
+                                        tool_call.name
+                                    ),
+                                    deps: Vec::new(),
+                                    parent_id: None,
+                                },
+                            );
+                            event_stream.emit(
+                                &mut responses,
+                                AgentEventPayload::Task {
+                                    id: task_event_id,
+                                    status: AgentEventStatus::Error,
+                                    timestamp: now_millis(),
+                                    label: format!("Run tool: {}", tool_call.name),
+                                    deps: Vec::new(),
+                                    parent_id: None,
+                                },
+                            );
                         }
                     }
-                } else {
-                    let mut responses = Vec::new();
-                    push_responses(
+                    log.finished_at = Some(now_millis());
+                    push_response(
                         &mut responses,
                         &sender,
-                        build_streaming_payload(stream, &stream_id, response.content.clone()),
+                        WSResponse::AIToolFinished {
+                            id: stream_id.clone(),
+                            tool: log,
+                        },
+                    );
+                }
+
+                conversation.push(ChatMessage {
+                    role: "assistant".to_string(),
+                    content: response.content.clone(),
+                });
+                for (tool_id, result) in tool_results {
+                    conversation.push(ChatMessage {
+                        role: "user".to_string(),
+                        content: format!("Tool '{}' result: {}", tool_id, result),
+                    });
+                }
+                if saw_error {
+                    conversation.push(ChatMessage {
+                        role: "user".to_string(),
+                        content: "One or more tools failed. Please adapt and continue."
+                            .to_string(),
+                    });
+                }
+
+                loop_count += 1;
+                if loop_count >= MAX_TOOL_LOOPS {
+                    event_stream.emit(
+                        &mut responses,
+                        AgentEventPayload::Error {
+                            id: event_stream.next_event_id(),
+                            status: AgentEventStatus::Error,
+                            timestamp: now_millis(),
+                            message: "Tool loop limit reached".to_string(),
+                            recoverable: false,
+                            suggested_action: None,
+                            parent_id: None,
+                        },
                     );
                     push_response(
                         &mut responses,
                         &sender,
-                        WSResponse::AIResponseWithTools { response },
+                        WSResponse::Error {
+                            message: "Tool loop limit reached".to_string(),
+                        },
                     );
-                    responses
+                    break;
                 }
+                continue;
             }
-            Err(e) => {
-                let mut responses = Vec::new();
-                push_responses(&mut responses, &sender, error_response(e.to_string()));
-                responses
-            }
+
+            push_responses(
+                &mut responses,
+                &sender,
+                build_streaming_payload(stream, &stream_id, response.content.clone()),
+            );
+            push_response(
+                &mut responses,
+                &sender,
+                WSResponse::AIResponseWithTools { response },
+            );
+            break;
         }
+
+        responses
     } else {
         match provider.send_message(messages_with_prompts).await {
             Ok(response) => {

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -381,13 +381,13 @@ pub(super) struct ApprovalDecisionPayload {
     pub edited_input: Option<Value>,
 }
 
-pub(super) struct ApprovalManager {
+pub struct ApprovalManager {
     pending: Mutex<HashMap<String, oneshot::Sender<ApprovalDecisionPayload>>>,
     session_allowlist: Mutex<HashMap<String, HashSet<String>>>,
 }
 
 impl ApprovalManager {
-    pub(super) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             pending: Mutex::new(HashMap::new()),
             session_allowlist: Mutex::new(HashMap::new()),
@@ -453,7 +453,7 @@ pub(super) enum ArtifactKind {
     TestResult,
 }
 
-#[derive(serde::Serialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub(super) struct ToolPreviewPayload {
     pub kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -1,4 +1,7 @@
-use std::sync::{atomic::AtomicU64, Arc, OnceLock};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{atomic::AtomicU64, Arc, OnceLock},
+};
 
 use crate::projects::ProjectController;
 use reprod_core::acp::types::{
@@ -17,7 +20,7 @@ use reprod_core::{
 };
 use serde::Deserialize;
 use serde_json::Value;
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex};
 
 #[derive(Debug, Deserialize)]
 struct SystemPrompts {
@@ -57,6 +60,7 @@ pub struct AppState {
     pub tool_executor: Arc<ToolExecutor>,
     pub request_counter: Arc<AtomicU64>,
     pub projects: Arc<ProjectController>,
+    pub approvals: Arc<ApprovalManager>,
 }
 
 pub(super) fn with_system_prompts(messages: &[ChatMessage], mode: AIMode) -> Vec<ChatMessage> {
@@ -101,6 +105,8 @@ pub(super) enum WSRequest {
         #[serde(default)]
         mode: AIMode,
     },
+    #[serde(rename = "agent_approval_decision")]
+    AgentApprovalDecision { decision: ApprovalDecisionPayload },
     #[serde(rename = "list_tools")]
     ListTools,
     #[serde(rename = "execute_tool")]
@@ -200,11 +206,12 @@ pub(super) enum WSResponse {
         #[serde(rename = "codeBlocks", skip_serializing_if = "Option::is_none")]
         code_blocks: Option<Vec<Value>>,
     },
-    #[allow(dead_code)] // Reserved for future AI planning feature
-    #[serde(rename = "ai_plan_updated")]
-    AIPlanUpdated {
+    #[serde(rename = "agent_event")]
+    AgentEvent { id: String, event: AgentEventPayload },
+    #[serde(rename = "approval_request")]
+    ApprovalRequest {
         id: String,
-        plan: Vec<PlanStepPayload>,
+        request: ApprovalRequestPayload,
     },
     #[serde(rename = "ai_tool_started")]
     AIToolStarted { id: String, tool: ToolLogPayload },
@@ -345,70 +352,217 @@ pub(super) enum WSResponse {
     },
 }
 
-#[allow(dead_code)] // Reserved for future AI planning feature
-#[derive(serde::Serialize, Clone)]
-pub(super) struct PlanStepPayload {
-    pub(super) id: String,
-    pub(super) title: String,
-    pub(super) status: PlanStepStatus,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) kind: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) error: Option<String>,
-    #[serde(rename = "startedAt", skip_serializing_if = "Option::is_none")]
-    pub(super) started_at: Option<i64>,
-    #[serde(rename = "finishedAt", skip_serializing_if = "Option::is_none")]
-    pub(super) finished_at: Option<i64>,
-    #[serde(rename = "waitingReason", skip_serializing_if = "Option::is_none")]
-    pub(super) waiting_reason: Option<String>,
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ApprovalOption {
+    ApproveOnce,
+    ApproveSession,
+    Edit,
+    Deny,
 }
 
-#[allow(dead_code)] // Reserved for future AI planning feature
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
+pub(super) struct ApprovalRequestPayload {
+    #[serde(rename = "eventId")]
+    pub event_id: String,
+    pub tool: String,
+    pub preview: ToolPreviewPayload,
+    pub options: Vec<ApprovalOption>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<Value>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
+pub(super) struct ApprovalDecisionPayload {
+    #[serde(rename = "eventId")]
+    pub event_id: String,
+    pub decision: ApprovalOption,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "editedInput")]
+    pub edited_input: Option<Value>,
+}
+
+pub(super) struct ApprovalManager {
+    pending: Mutex<HashMap<String, oneshot::Sender<ApprovalDecisionPayload>>>,
+    session_allowlist: Mutex<HashMap<String, HashSet<String>>>,
+}
+
+impl ApprovalManager {
+    pub(super) fn new() -> Self {
+        Self {
+            pending: Mutex::new(HashMap::new()),
+            session_allowlist: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(super) async fn register(
+        &self,
+        event_id: String,
+    ) -> oneshot::Receiver<ApprovalDecisionPayload> {
+        let (tx, rx) = oneshot::channel();
+        let mut pending = self.pending.lock().await;
+        pending.insert(event_id, tx);
+        rx
+    }
+
+    pub(super) async fn resolve(&self, decision: ApprovalDecisionPayload) -> bool {
+        let tx = {
+            let mut pending = self.pending.lock().await;
+            pending.remove(&decision.event_id)
+        };
+        match tx {
+            Some(sender) => sender.send(decision).is_ok(),
+            None => false,
+        }
+    }
+
+    pub(super) async fn is_allowed(&self, stream_id: &str, tool: &str) -> bool {
+        let allowlist = self.session_allowlist.lock().await;
+        allowlist
+            .get(stream_id)
+            .map(|tools| tools.contains(tool))
+            .unwrap_or(false)
+    }
+
+    pub(super) async fn allow_for_session(&self, stream_id: &str, tool: &str) {
+        let mut allowlist = self.session_allowlist.lock().await;
+        allowlist
+            .entry(stream_id.to_string())
+            .or_default()
+            .insert(tool.to_string());
+    }
+}
+
 #[derive(serde::Serialize, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
-pub(super) enum PlanStepStatus {
+pub(super) enum AgentEventStatus {
     Pending,
     Running,
     Done,
     Error,
+    Blocked,
+    Approved,
+    Denied,
 }
 
-impl PlanStepPayload {
-    pub(super) fn new(
-        id: impl Into<String>,
-        title: impl Into<String>,
-        kind: Option<String>,
-    ) -> Self {
-        Self {
-            id: id.into(),
-            title: title.into(),
-            status: PlanStepStatus::Pending,
-            kind,
-            error: None,
-            started_at: None,
-            finished_at: None,
-            waiting_reason: None,
-        }
-    }
-
-    pub(super) fn mark_status(&mut self, status: PlanStepStatus) {
-        self.status = status;
-        match status {
-            PlanStepStatus::Running => {
-                if self.started_at.is_none() {
-                    self.started_at = Some(now_millis());
-                }
-            }
-            PlanStepStatus::Done | PlanStepStatus::Error => {
-                if self.started_at.is_none() {
-                    self.started_at = Some(now_millis());
-                }
-                self.finished_at = Some(now_millis());
-            }
-            PlanStepStatus::Pending => {}
-        }
-    }
+#[derive(serde::Serialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ArtifactKind {
+    FileRead,
+    FileWrite,
+    Command,
+    TestResult,
 }
+
+#[derive(serde::Serialize, Clone)]
+pub(super) struct ToolPreviewPayload {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filepath: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "affectedLines")]
+    pub affected_lines: Option<u32>,
+}
+
+#[derive(serde::Serialize, Clone)]
+pub(super) struct ArtifactDetailsPayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "exitCode")]
+    pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "testsPassed")]
+    pub tests_passed: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "testsFailed")]
+    pub tests_failed: Option<u32>,
+}
+
+#[derive(serde::Serialize, Clone)]
+#[serde(tag = "type")]
+pub(super) enum AgentEventPayload {
+    #[serde(rename = "thought")]
+    Thought {
+        id: String,
+        status: AgentEventStatus,
+        timestamp: i64,
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reasoning: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "parentId")]
+        parent_id: Option<String>,
+    },
+    #[serde(rename = "tool_request")]
+    ToolRequest {
+        id: String,
+        status: AgentEventStatus,
+        timestamp: i64,
+        tool: String,
+        input: Value,
+        #[serde(rename = "requiresApproval")]
+        requires_approval: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        preview: Option<ToolPreviewPayload>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "parentId")]
+        parent_id: Option<String>,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        id: String,
+        status: AgentEventStatus,
+        timestamp: i64,
+        #[serde(rename = "requestId")]
+        request_id: String,
+        tool: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        output: Option<Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "parentId")]
+        parent_id: Option<String>,
+    },
+    #[serde(rename = "task")]
+    Task {
+        id: String,
+        status: AgentEventStatus,
+        timestamp: i64,
+        label: String,
+        deps: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "parentId")]
+        parent_id: Option<String>,
+    },
+    #[serde(rename = "artifact")]
+    Artifact {
+        id: String,
+        status: AgentEventStatus,
+        timestamp: i64,
+        kind: ArtifactKind,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+        summary: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        details: Option<ArtifactDetailsPayload>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "parentId")]
+        parent_id: Option<String>,
+    },
+    #[serde(rename = "error")]
+    Error {
+        id: String,
+        status: AgentEventStatus,
+        timestamp: i64,
+        message: String,
+        recoverable: bool,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "suggestedAction")]
+        suggested_action: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", rename = "parentId")]
+        parent_id: Option<String>,
+    },
+}
+
 
 #[derive(serde::Serialize, Clone)]
 pub(super) struct ToolLogPayload {

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -480,6 +480,10 @@ pub(super) struct ArtifactDetailsPayload {
     pub tests_passed: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "testsFailed")]
     pub tests_failed: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "oldText")]
+    pub old_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "newText")]
+    pub new_text: Option<String>,
 }
 
 #[derive(serde::Serialize, Clone)]

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -33,7 +33,7 @@ pub mod stream_buffer;
 mod timeline_handler;
 mod tool_handler;
 
-pub use common::AppState;
+pub use common::{AppState, ApprovalManager};
 
 use crate::projects::RuntimeBroadcastEvent;
 use acp_handler::{
@@ -41,7 +41,7 @@ use acp_handler::{
     handle_acp_permission_decision, handle_acp_session_cancel, handle_acp_session_create,
     handle_acp_session_prompt,
 };
-use ai_handler::handle_ai_message;
+use ai_handler::{handle_agent_approval_decision, handle_ai_message};
 use common::{error_response, WSRequest, WSResponse};
 use export_handler::handle_export_request;
 use plot_history_handler::{
@@ -69,6 +69,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
     let mut run_event_rx: broadcast::Receiver<RuntimeBroadcastEvent> =
         current_runtime.run_events.subscribe();
     let (fs_event_tx, mut fs_event_rx) = tokio_mpsc::unbounded_channel::<FileSystemEvent>();
+    let (ai_event_tx, mut ai_event_rx) = tokio_mpsc::unbounded_channel::<WSResponse>();
     let mut fs_watcher = Some(spawn_fs_watcher(
         current_runtime.descriptor.root_path.clone(),
         fs_event_tx.clone(),
@@ -147,6 +148,13 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                     }
                 }
             }
+            ai_event = ai_event_rx.recv() => {
+                if let Some(response) = ai_event {
+                    if !send_responses(&mut socket, vec![response]).await {
+                        break 'ws_loop;
+                    }
+                }
+            }
             msg = socket.recv() => {
                 if !handle_ws_text(
                     msg,
@@ -158,6 +166,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                     &mut fs_watcher,
                     &fs_event_tx,
                     &mut fs_events_closed,
+                    &ai_event_tx,
                     &mut socket,
                 )
                 .await {
@@ -182,6 +191,7 @@ async fn handle_ws_text(
     fs_watcher: &mut Option<FsWatcherHandle>,
     fs_event_tx: &tokio_mpsc::UnboundedSender<FileSystemEvent>,
     fs_events_closed: &mut bool,
+    ai_event_tx: &tokio_mpsc::UnboundedSender<WSResponse>,
     socket: &mut WebSocket,
 ) -> bool {
     match msg {
@@ -205,6 +215,31 @@ async fn handle_ws_text(
                 }
 
                 match request {
+                    WSRequest::AIMessage {
+                        messages,
+                        enable_tools,
+                        request_id,
+                        stream,
+                        mode,
+                    } => {
+                        let state = state.clone();
+                        let runtime = current_runtime.clone();
+                        let sender = ai_event_tx.clone();
+                        tokio::spawn(async move {
+                            let _ = handle_ai_message(
+                                &state,
+                                &runtime,
+                                messages,
+                                enable_tools,
+                                request_id,
+                                stream,
+                                mode,
+                                Some(sender),
+                            )
+                            .await;
+                        });
+                        true
+                    }
                     WSRequest::Execute { request } => {
                         handle_execution_request_streaming(socket, current_runtime, request).await
                     }
@@ -249,8 +284,12 @@ async fn handle_ws_request(
                 request_id,
                 stream,
                 mode,
+                None,
             )
             .await
+        }
+        WSRequest::AgentApprovalDecision { decision } => {
+            handle_agent_approval_decision(state, decision).await
         }
         WSRequest::ListTools => handle_list_tools(state),
         WSRequest::ExecuteTool {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -102,6 +102,7 @@ async fn main() {
             tool_executor: tool_executor.clone(),
             request_counter: Arc::new(AtomicU64::new(0)),
             projects: projects.clone(),
+            approvals: Arc::new(handlers::ApprovalManager::new()),
         });
 
     let port = reprod_core::config::server_port_override().unwrap_or(3001);


### PR DESCRIPTION
## Description

This replaces the fixed five-step AI plan stream with an event-based stream that supports per-tool approvals, dynamic tasks, and artifact tracking. It also adds UI surfaces for the event timeline, task graph, and artifact list with undo for file edits. The server now adapts on tool errors by emitting recovery tasks and continuing a bounded tool loop.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `pnpm --filter client test -- src/core/state/__tests__/aiSlice.test.ts`
- `cargo test -p reprod-server`

## Screenshots (if applicable)

```
Before:
┌─────────────────────────────┐
│ AI Response                 │
├─────────────────────────────┤
│ Plan Card (5 fixed steps)   │
│ Tool Log                    │
└─────────────────────────────┘

After:
┌─────────────────────────────┐
│ AI Response                 │
├─────────────────────────────┤
│ Approval (if needed)        │
│ Task Graph                  │
│ Event Stream Timeline       │
│ Artifact List + Undo        │
└─────────────────────────────┘
```

## Related Issues

Closes #206
