### PR TITLE
feat: enable native headed mode for visual E2E debugging (#377)

### DIFF
--- a/desktop/e2e/README.md
+++ b/desktop/e2e/README.md
@@ -148,6 +148,39 @@ pnpm --filter @reprod/e2e test:docker -- LOG_LEVEL=debug pnpm tauri build --debu
 pnpm --filter @reprod/e2e test:docker -- pnpm tauri build --debug && xvfb-run --auto-servernum pnpm --filter @reprod/e2e test:webdriver:debug
 ```
 
+### Visual Debugging on macOS/Windows (Native Headed Mode)
+
+For visual debugging where you need to see the browser, run Playwright natively on your host machine instead of Docker.
+
+**macOS:**
+
+```bash
+# Run all tests in headed mode (browser visible)
+pnpm --filter @reprod/e2e test:playwright:headed
+
+# Run specific test file
+pnpm --filter @reprod/e2e test:playwright:headed -- tests/r-execution.spec.ts
+
+# Run with Playwright UI mode (interactive)
+pnpm --filter @reprod/e2e test:playwright:ui
+```
+
+**Windows:**
+
+```bash
+# Run all tests in headed mode
+pnpm --filter @reprod/e2e test:playwright:headed
+
+# Run specific test file
+pnpm --filter @reprod/e2e test:playwright:headed -- tests/r-execution.spec.ts
+```
+
+**Notes:**
+
+- A warning will be shown reminding you to use Docker for consistent results
+- macOS automatically uses headed mode with Crashpad disabled for stability
+- For CI/consistent results, always use Docker: `pnpm --filter @reprod/e2e test:docker`
+
 ## Test Structure
 
 ```

--- a/desktop/e2e/playwright.config.ts
+++ b/desktop/e2e/playwright.config.ts
@@ -58,8 +58,8 @@ const projects =
 		: [projectMap.chromium];
 
 if (!process.env.CI && !isDocker) {
-	throw new Error(
-		"E2E tests are disabled on local machines. Use the Docker setup in desktop/e2e/Dockerfile.",
+	console.warn(
+		"⚠️  Running E2E locally. Use Docker (pnpm --filter @reprod/e2e test:docker) for consistent results.",
 	);
 }
 


### PR DESCRIPTION
## Summary

- Enable native headed mode for visual E2E debugging on macOS/Windows
- Change local E2E execution from blocking error to warning
- Add documentation for native headed mode

## Changes

1. **playwright.config.ts**: Changed `throw new Error()` to `console.warn()` for non-Docker/non-CI runs
2. **README.md**: Added "Visual Debugging on macOS/Windows" section with usage examples

## Why This Approach?

- X11 forwarding from Docker Desktop on macOS is complex due to VM architecture
- Native headed mode works reliably with existing Crashpad workarounds
- No Docker image size increase needed
- Simpler developer experience

## Testing

Verified on macOS:
```bash
pnpm --filter @reprod/e2e test:playwright:headed -- tests/r-execution.spec.ts
# Result: 3 passed (32.5s)
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Documentation updated
- [x] Tests pass locally

Closes #377