### PR TITLE
fix: remove unused PendingEdit.status field (#340)

### DIFF
--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -74,7 +74,6 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	);
 	const pendingEdit = useStore((state) => state.pendingEdits[normalizedEditorPath]);
 	const clearPendingEdit = useStore((state) => state.clearPendingEdit);
-	const updatePendingEditStatus = useStore((state) => state.updatePendingEditStatus);
 	const updatePendingEditReview = useStore((state) => state.updatePendingEditReview);
 	const setPendingEditReviewMap = useStore((state) => state.setPendingEditReviewMap);
 	const editorMethodsRef = useRef<EditorRef | null>(null);
@@ -257,7 +256,6 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 				await updatePendingEdit(pendingEdit, resolvedContent);
 			}
 			await acceptPendingEdit(pendingEdit);
-			updatePendingEditStatus(pendingEdit.filePath, "accepted");
 			clearPendingEdit(pendingEdit.filePath);
 			setPendingNotice(null);
 		} catch (error) {
@@ -269,14 +267,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 					: message,
 			});
 		}
-	}, [
-		clearPendingEdit,
-		editorContent,
-		pendingEdit,
-		reviewedContent,
-		updatePendingEdit,
-		updatePendingEditStatus,
-	]);
+	}, [clearPendingEdit, editorContent, pendingEdit, reviewedContent, updatePendingEdit]);
 
 	const handlePendingReject = useCallback(async () => {
 		if (!pendingEdit) return;
@@ -285,7 +276,6 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 			if (activeBufferId) {
 				updateBuffer(activeBufferId, { content: pendingEdit.oldContent, isDirty: true });
 			}
-			updatePendingEditStatus(pendingEdit.filePath, "rejected");
 			clearPendingEdit(pendingEdit.filePath);
 			setPendingNotice(null);
 		} catch (error) {
@@ -297,7 +287,7 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 					: message,
 			});
 		}
-	}, [activeBufferId, clearPendingEdit, pendingEdit, updateBuffer, updatePendingEditStatus]);
+	}, [activeBufferId, clearPendingEdit, pendingEdit, updateBuffer]);
 
 	const navigateToLine = useCallback((lineNumber: number): void => {
 		const monacoEditor = monacoEditorRef.current;

--- a/client/src/core/state/slices/__tests__/pendingEditSlice.test.ts
+++ b/client/src/core/state/slices/__tests__/pendingEditSlice.test.ts
@@ -15,7 +15,6 @@ const makeEdit = (filePath: string): PendingEdit => ({
 	unifiedDiff: "",
 	baseHash: "",
 	expectedSha: null,
-	status: "pending",
 	createdAt: 0,
 });
 
@@ -34,14 +33,11 @@ describe("pendingEditSlice", () => {
 		expect(store.getState().pendingEdits["foo/bar.R"]?.filePath).toBe("foo/bar.R");
 	});
 
-	it("normalizes file paths on update and clear", () => {
+	it("normalizes file paths on clear", () => {
 		const store = createTestStore();
 		const edit = makeEdit("foo/bar.R");
 
 		store.getState().registerPendingEdit(edit);
-		store.getState().updatePendingEditStatus("/foo/bar.R", "accepted");
-		expect(store.getState().pendingEdits["foo/bar.R"]?.status).toBe("accepted");
-
 		store.getState().clearPendingEdit("/foo/bar.R");
 		expect(store.getState().pendingEdits["foo/bar.R"]).toBeUndefined();
 	});

--- a/client/src/core/state/slices/pendingEditSlice.ts
+++ b/client/src/core/state/slices/pendingEditSlice.ts
@@ -3,14 +3,12 @@ import type {
 	PendingEdit,
 	PendingEditReviewMap,
 	PendingEditReviewStatus,
-	PendingEditStatus,
 } from "@/types/pendingEdit";
 import { normalizeRelativePath } from "@/core/pathUtils";
 
 export interface PendingEditState {
 	pendingEdits: Record<string, PendingEdit>;
 	registerPendingEdit: (edit: PendingEdit) => boolean;
-	updatePendingEditStatus: (filePath: string, status: PendingEditStatus) => void;
 	updatePendingEditReview: (
 		filePath: string,
 		changeId: string,
@@ -40,22 +38,6 @@ export const createPendingEditSlice: StateCreator<PendingEditState> = (set, get)
 			},
 		});
 		return true;
-	},
-	updatePendingEditStatus: (filePath, status) => {
-		const normalizedPath = normalizeRelativePath(filePath, { keepRootEmpty: true });
-		set((state) => {
-			const existing = state.pendingEdits[normalizedPath];
-			if (!existing) return state;
-			return {
-				pendingEdits: {
-					...state.pendingEdits,
-					[normalizedPath]: {
-						...existing,
-						status,
-					},
-				},
-			};
-		});
 	},
 	updatePendingEditReview: (filePath, changeId, status) => {
 		const normalizedPath = normalizeRelativePath(filePath, { keepRootEmpty: true });

--- a/client/src/hooks/useAICodeApplication.ts
+++ b/client/src/hooks/useAICodeApplication.ts
@@ -56,7 +56,6 @@ export function useAICodeApplication(postAssistantMessage: PostAssistantMessage)
 								unifiedDiff: "",
 								baseHash,
 								expectedSha: null,
-								status: "pending",
 								createdAt: Date.now(),
 							};
 

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -275,7 +275,6 @@ export function useAIConversation() {
 							unifiedDiff: String(editPayload.unified_diff ?? ""),
 							baseHash: String(editPayload.base_sha256 ?? ""),
 							expectedSha: editPayload.expected_sha256 ?? null,
-							status: "pending",
 							createdAt: Date.now(),
 						};
 

--- a/client/src/types/pendingEdit.ts
+++ b/client/src/types/pendingEdit.ts
@@ -2,8 +2,6 @@ export type PendingEditSource =
 	| { type: "acp"; sessionId: string }
 	| { type: "api-key"; codeBlockId: string };
 
-export type PendingEditStatus = "pending" | "accepted" | "rejected";
-
 export type PendingEditReviewStatus = "keep" | "reject";
 export type PendingEditReviewMap = Record<string, PendingEditReviewStatus>;
 
@@ -16,7 +14,6 @@ export interface PendingEdit {
 	unifiedDiff: string;
 	baseHash: string;
 	expectedSha?: string | null;
-	status: PendingEditStatus;
 	createdAt: number;
 	reviewedChanges?: PendingEditReviewMap;
 }


### PR DESCRIPTION
## Description

Removed the unused `PendingEdit.status` field and associated `updatePendingEditStatus` method from the codebase. This field was defined but never actually used in any meaningful way throughout the application.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made

- Removed `PendingEditStatus` type from `types/pendingEdit.ts`
- Removed `status` field from `PendingEdit` interface
- Removed `updatePendingEditStatus` method from `pendingEditSlice.ts`
- Removed `status: "pending"` assignments in `useAICodeApplication.ts` and `useAIConversation.ts`
- Removed `updatePendingEditStatus()` calls in `EditorPanel.tsx`
- Updated `pendingEditSlice.test.ts` to remove status-related test assertions

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes (N/A - removed unused code)
- [x] Documentation updated (if needed) (N/A)

## Testing

Ran the following tests:
```bash
pnpm --filter client type-check  # ✅ Passed
pnpm --filter client test -- pendingEditSlice  # ✅ All 4 tests passed
```

All tests pass successfully with the status field removed.

## Related Issues

Closes #340