### PR TITLE
fix: suppress dead_code warnings with annotations

### DIFF
--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -450,6 +450,8 @@ pub(super) enum ArtifactKind {
     FileRead,
     FileWrite,
     Command,
+    /// Reserved for future test result artifact tracking.
+    #[allow(dead_code)]
     TestResult,
 }
 

--- a/server/src/handlers/stream_buffer.rs
+++ b/server/src/handlers/stream_buffer.rs
@@ -25,6 +25,8 @@ impl StreamBuffer {
     }
 
     /// Finalize a run and return aggregated stdout/stderr.
+    /// Reserved for future use when implementing complete run lifecycle management.
+    #[allow(dead_code)]
     pub fn finalize(&mut self, run_id: &str) -> (String, Option<String>) {
         let chunks = self.chunks.remove(run_id).unwrap_or_default();
         let mut stdout = String::new();


### PR DESCRIPTION
## Summary
Resolves #386 by adding `#[allow(dead_code)]` annotations with explanatory comments to intentionally unused code.

## Changes
- **StreamBuffer::finalize** - Annotated with explanation that it's reserved for future run lifecycle management
- **ArtifactKind::TestResult** - Annotated with explanation that it's reserved for future test result tracking

## Reasoning
Both items are part of complete, well-designed APIs and are intentionally kept for future functionality:
- `finalize` provides a clean way to aggregate stream chunks into final output
- `TestResult` completes the set of artifact types alongside FileRead, FileWrite, and Command

Removing these would make the APIs incomplete. Annotating them with `#[allow(dead_code)]` and comments preserves the design intent while eliminating compiler warnings.

## Verification
- [x] `cargo check` passes with no `dead_code` warnings
- [x] Code properly annotated with explanatory comments
- [x] No functional changes to existing behavior

## Related Issue
Closes #386