### PR TITLE
feat: Add unit tests for Code Action classes (#394)

### DIFF
--- a/client/src/core/ai/actions/__tests__/BaseCodeAction.test.ts
+++ b/client/src/core/ai/actions/__tests__/BaseCodeAction.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import { BaseCodeAction } from "../BaseCodeAction";
+import type { CodeBlock } from "@/types";
+import type { CodeActionContext, CodeActionValidation } from "../ICodeAction";
+
+class TestCodeAction extends BaseCodeAction {
+	getLabel(codeBlock: CodeBlock): string {
+		return "Test Action";
+	}
+
+	protected validateSpecific(codeBlock: CodeBlock): CodeActionValidation {
+		if (codeBlock.code === "invalid") {
+			return { valid: false, error: "Specific validation failed" };
+		}
+		return { valid: true };
+	}
+
+	async apply(codeBlock: CodeBlock, context: CodeActionContext): Promise<void> {
+		await this.applyWithValidation(codeBlock, context, "Success");
+	}
+
+	// Expose protected methods for testing
+	public testRequiresCode(): boolean {
+		return this.requiresCode();
+	}
+
+	public testIsCurrentEditor(
+		targetFile: string | undefined,
+		editorFilepath: string | null | undefined,
+	): boolean {
+		return this.isCurrentEditor(targetFile, editorFilepath);
+	}
+
+	public testValidateTargetRange(codeBlock: CodeBlock): CodeActionValidation {
+		return this.validateTargetRange(codeBlock);
+	}
+}
+
+class NoCodeAction extends TestCodeAction {
+	protected requiresCode(): boolean {
+		return false;
+	}
+}
+
+describe("BaseCodeAction", () => {
+	const context: CodeActionContext = {
+		editorFilepath: "test.ts",
+		applyToEditor: vi.fn(),
+		applyToFile: vi.fn(),
+		postMessage: vi.fn(),
+	};
+
+	describe("validate", () => {
+		it("should validate empty code when required", () => {
+			const action = new TestCodeAction();
+			const result = action.validate({ code: "" } as CodeBlock);
+			expect(result.valid).toBe(false);
+			expect(result.error).toBe("Cannot apply action with empty content");
+		});
+
+		it("should allow empty code when not required", () => {
+			const action = new NoCodeAction();
+			const result = action.validate({ code: "" } as CodeBlock);
+			expect(result.valid).toBe(true);
+		});
+
+		it("should run specific validation", () => {
+			const action = new TestCodeAction();
+			const result = action.validate({ code: "invalid" } as CodeBlock);
+			expect(result.valid).toBe(false);
+			expect(result.error).toBe("Specific validation failed");
+		});
+	});
+
+	describe("isCurrentEditor", () => {
+		const action = new TestCodeAction();
+
+		it("should match undefined target file", () => {
+			expect(action.testIsCurrentEditor(undefined, "any")).toBe(true);
+		});
+
+		it("should match exact filepath", () => {
+			expect(action.testIsCurrentEditor("test.ts", "test.ts")).toBe(true);
+		});
+
+		it("should match buffer placeholders", () => {
+			expect(action.testIsCurrentEditor("current editor buffer", "other.ts")).toBe(true);
+			expect(action.testIsCurrentEditor("<buffer>", "other.ts")).toBe(true);
+		});
+
+		it("should not match different files", () => {
+			expect(action.testIsCurrentEditor("file1.ts", "file2.ts")).toBe(false);
+		});
+	});
+
+	describe("validateTargetRange", () => {
+		const action = new TestCodeAction();
+
+		it("should fail if range is missing", () => {
+			const result = action.testValidateTargetRange({} as CodeBlock);
+			expect(result.valid).toBe(false);
+		});
+
+		it("should fail if coordinates are negative", () => {
+			const result = action.testValidateTargetRange({
+				targetRange: { startLine: -1, startColumn: 0, endLine: 1, endColumn: 1 },
+			} as CodeBlock);
+			expect(result.valid).toBe(false);
+		});
+
+		it("should fail if start > end", () => {
+			const result = action.testValidateTargetRange({
+				targetRange: { startLine: 2, startColumn: 0, endLine: 1, endColumn: 1 },
+			} as CodeBlock);
+			expect(result.valid).toBe(false);
+		});
+
+		it("should pass for valid range", () => {
+			const result = action.testValidateTargetRange({
+				targetRange: { startLine: 1, startColumn: 0, endLine: 2, endColumn: 1 },
+			} as CodeBlock);
+			expect(result.valid).toBe(true);
+		});
+	});
+
+	describe("applyWithValidation", () => {
+		it("should apply to editor when current", async () => {
+			const action = new TestCodeAction();
+			const codeBlock = { code: "valid", filepath: "test.ts" } as CodeBlock;
+
+			await action.apply(codeBlock, context);
+
+			expect(context.applyToEditor).toHaveBeenCalledWith(codeBlock);
+			expect(context.postMessage).toHaveBeenCalledWith("Success");
+		});
+
+		it("should apply to file when not current", async () => {
+			const action = new TestCodeAction();
+			const codeBlock = { code: "valid", filepath: "other.ts" } as CodeBlock;
+
+			await action.apply(codeBlock, context);
+
+			expect(context.applyToFile).toHaveBeenCalledWith(codeBlock);
+			expect(context.postMessage).toHaveBeenCalledWith("Success");
+		});
+
+		it("should throw if validation fails", async () => {
+			const action = new TestCodeAction();
+			const codeBlock = { code: "invalid" } as CodeBlock;
+
+			await expect(action.apply(codeBlock, context)).rejects.toThrow("Specific validation failed");
+		});
+	});
+});

--- a/client/src/core/ai/actions/actions/__tests__/CreateFileAction.test.ts
+++ b/client/src/core/ai/actions/actions/__tests__/CreateFileAction.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { CreateFileAction } from "../CreateFileAction";
+import type { CodeBlock } from "@/types";
+import type { CodeActionContext } from "../../ICodeAction";
+
+describe("CreateFileAction", () => {
+	const action = new CreateFileAction();
+	const context: CodeActionContext = {
+		editorFilepath: "active.ts",
+		applyToEditor: vi.fn(),
+		applyToFile: vi.fn(),
+		postMessage: vi.fn(),
+	};
+
+	describe("getLabel", () => {
+		it("should return generic label without filepath", () => {
+			expect(action.getLabel({} as CodeBlock)).toBe("Create new file");
+		});
+
+		it("should return specific label with filepath", () => {
+			expect(action.getLabel({ filepath: "test.ts" } as CodeBlock)).toBe("Create file test.ts");
+		});
+	});
+
+	describe("validate", () => {
+		it("should fail if filepath is empty", () => {
+			expect(action.validate({ code: "content" } as CodeBlock).valid).toBe(false);
+			expect(action.validate({ filepath: "", code: "content" } as CodeBlock).valid).toBe(false);
+		});
+
+		it("should fail if content is empty", () => {
+			expect(action.validate({ filepath: "test.ts", code: "" } as CodeBlock).valid).toBe(false);
+		});
+
+		it("should fail for placeholder paths", () => {
+			expect(
+				action.validate({ filepath: "current editor buffer", code: "content" } as CodeBlock).valid,
+			).toBe(false);
+			expect(action.validate({ filepath: "<new file>", code: "content" } as CodeBlock).valid).toBe(
+				false,
+			);
+		});
+
+		it("should pass for valid input", () => {
+			expect(action.validate({ filepath: "test.ts", code: "content" } as CodeBlock).valid).toBe(
+				true,
+			);
+		});
+	});
+
+	describe("apply", () => {
+		it("should call applyToFile", async () => {
+			const block = { filepath: "test.ts", code: "content" } as CodeBlock;
+			await action.apply(block, context);
+
+			expect(context.applyToFile).toHaveBeenCalledWith(block);
+			expect(context.postMessage).toHaveBeenCalledWith("Created file test.ts");
+		});
+
+		it("should throw if validation fails", async () => {
+			const block = { filepath: "", code: "content" } as CodeBlock;
+			await expect(action.apply(block, context)).rejects.toThrow("Create file requires a filepath");
+		});
+
+		it("should throw if applyToFile is missing", async () => {
+			const block = { filepath: "test.ts", code: "content" } as CodeBlock;
+			const invalidContext = { ...context, applyToFile: undefined };
+
+			await expect(action.apply(block, invalidContext)).rejects.toThrow(
+				"File apply method not available",
+			);
+		});
+	});
+});

--- a/client/src/core/ai/actions/actions/__tests__/DeleteRangeAction.test.ts
+++ b/client/src/core/ai/actions/actions/__tests__/DeleteRangeAction.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { DeleteRangeAction } from "../DeleteRangeAction";
+import type { CodeBlock } from "@/types";
+import type { CodeActionContext } from "../../ICodeAction";
+
+describe("DeleteRangeAction", () => {
+	const action = new DeleteRangeAction();
+	const context: CodeActionContext = {
+		editorFilepath: "active.ts",
+		applyToEditor: vi.fn(),
+		applyToFile: vi.fn(),
+		postMessage: vi.fn(),
+	};
+
+	describe("getLabel", () => {
+		it("should return label with range", () => {
+			const block = { filepath: "test.ts", targetRange: { startLine: 1, endLine: 5 } } as CodeBlock;
+			expect(action.getLabel(block)).toBe("Delete test.ts lines 1-5");
+		});
+
+		it("should return label with active editor fallback", () => {
+			const block = { targetRange: { startLine: 1, endLine: 5 } } as CodeBlock;
+			expect(action.getLabel(block)).toBe("Delete active editor lines 1-5");
+		});
+
+		it("should return generic label without range", () => {
+			const block = { filepath: "test.ts" } as CodeBlock;
+			expect(action.getLabel(block)).toBe("Delete code in test.ts");
+		});
+	});
+
+	describe("validate", () => {
+		it("should validate without code content", () => {
+			const block = {
+				targetRange: { startLine: 1, startColumn: 0, endLine: 2, endColumn: 0 },
+			} as CodeBlock;
+			expect(action.validate(block).valid).toBe(true);
+		});
+
+		it("should fail without range or context", () => {
+			const block = {} as CodeBlock;
+			expect(action.validate(block).valid).toBe(false);
+			expect(action.validate(block).error).toContain("requires targetRange");
+		});
+
+		it("should pass if has originalCode context", () => {
+			const block = { originalCode: "some context" } as CodeBlock;
+			expect(action.validate(block).valid).toBe(true);
+		});
+
+		it("should validate invalid range", () => {
+			const block = {
+				targetRange: { startLine: 5, startColumn: 0, endLine: 1, endColumn: 0 },
+			} as CodeBlock;
+			expect(action.validate(block).valid).toBe(false);
+		});
+	});
+
+	describe("apply", () => {
+		it("should call applyToEditor", async () => {
+			const block = { targetRange: { startLine: 1, endLine: 2 } } as any;
+			await action.apply(block, context);
+
+			expect(context.applyToEditor).toHaveBeenCalledWith(block);
+			expect(context.postMessage).toHaveBeenCalledWith("Delete active editor lines 1-2");
+		});
+
+		it("should throw if validation fails", async () => {
+			const block = {} as CodeBlock;
+			await expect(action.apply(block, context)).rejects.toThrow();
+		});
+
+		it("should throw if applyToEditor is missing", async () => {
+			const block = { targetRange: { startLine: 1, endLine: 2 } } as any;
+			const invalidContext = { ...context, applyToEditor: undefined };
+
+			await expect(action.apply(block, invalidContext)).rejects.toThrow(
+				"Editor apply method not available",
+			);
+		});
+	});
+});

--- a/client/src/core/ai/actions/actions/__tests__/InsertAction.test.ts
+++ b/client/src/core/ai/actions/actions/__tests__/InsertAction.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { InsertAction } from "../InsertAction";
+import type { CodeBlock } from "@/types";
+import type { CodeActionContext } from "../../ICodeAction";
+
+describe("InsertAction", () => {
+	const action = new InsertAction();
+	const context: CodeActionContext = {
+		editorFilepath: "active.ts",
+		applyToEditor: vi.fn(),
+		applyToFile: vi.fn(),
+		postMessage: vi.fn(),
+	};
+
+	describe("getLabel", () => {
+		it("should return label with filepath", () => {
+			const block = { filepath: "test.ts" } as CodeBlock;
+			expect(action.getLabel(block)).toBe("Insert code in test.ts");
+		});
+
+		it("should return label with active editor fallback", () => {
+			const block = {} as CodeBlock;
+			expect(action.getLabel(block)).toBe("Insert code in active editor");
+		});
+	});
+
+	describe("validate", () => {
+		it("should fail if code is empty", () => {
+			expect(action.validate({ code: "" } as CodeBlock).valid).toBe(false);
+		});
+
+		it("should pass if code is provided", () => {
+			expect(action.validate({ code: "content" } as CodeBlock).valid).toBe(true);
+		});
+	});
+
+	describe("apply", () => {
+		it("should call applyToEditor", async () => {
+			const block = { code: "content" } as CodeBlock;
+			await action.apply(block, context);
+
+			expect(context.applyToEditor).toHaveBeenCalledWith(block);
+			expect(context.postMessage).toHaveBeenCalledWith("Insert code in active editor");
+		});
+
+		it("should throw if validation fails", async () => {
+			const block = { code: "" } as CodeBlock;
+			await expect(action.apply(block, context)).rejects.toThrow(
+				"Cannot apply action with empty content",
+			);
+		});
+
+		it("should throw if applyToEditor is missing", async () => {
+			const block = { code: "content" } as CodeBlock;
+			const invalidContext = { ...context, applyToEditor: undefined };
+
+			await expect(action.apply(block, invalidContext)).rejects.toThrow(
+				"Editor apply method not available",
+			);
+		});
+	});
+});

--- a/client/src/core/ai/actions/actions/__tests__/ReplaceAllAction.test.ts
+++ b/client/src/core/ai/actions/actions/__tests__/ReplaceAllAction.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { ReplaceAllAction } from "../ReplaceAllAction";
+import type { CodeBlock } from "@/types";
+import type { CodeActionContext } from "../../ICodeAction";
+
+describe("ReplaceAllAction", () => {
+	const action = new ReplaceAllAction();
+	const context: CodeActionContext = {
+		editorFilepath: "active.ts",
+		applyToEditor: vi.fn(),
+		applyToFile: vi.fn(),
+		postMessage: vi.fn(),
+	};
+
+	describe("getLabel", () => {
+		it("should return label with filepath", () => {
+			const block = { filepath: "test.ts" } as CodeBlock;
+			expect(action.getLabel(block)).toBe("Replace entire test.ts");
+		});
+
+		it("should return label with active editor fallback", () => {
+			const block = {} as CodeBlock;
+			expect(action.getLabel(block)).toBe("Replace entire active editor");
+		});
+	});
+
+	describe("validate", () => {
+		it("should fail if code is empty", () => {
+			expect(action.validate({ code: "" } as CodeBlock).valid).toBe(false);
+		});
+
+		it("should pass if code is provided", () => {
+			expect(action.validate({ code: "content" } as CodeBlock).valid).toBe(true);
+		});
+	});
+
+	describe("apply", () => {
+		it("should apply to editor if current file", async () => {
+			const block = { code: "content", filepath: "active.ts" } as CodeBlock;
+			await action.apply(block, context);
+
+			expect(context.applyToEditor).toHaveBeenCalledWith(block);
+			expect(context.postMessage).toHaveBeenCalledWith("Replaced entire active.ts");
+		});
+
+		it("should apply to editor if no file specified", async () => {
+			const block = { code: "content" } as CodeBlock;
+			await action.apply(block, context);
+
+			expect(context.applyToEditor).toHaveBeenCalledWith(block);
+			expect(context.postMessage).toHaveBeenCalledWith("Replaced entire active editor");
+		});
+
+		it("should apply to file if not current", async () => {
+			const block = { code: "content", filepath: "other.ts" } as CodeBlock;
+			await action.apply(block, context);
+
+			expect(context.applyToFile).toHaveBeenCalledWith(block);
+			expect(context.postMessage).toHaveBeenCalledWith("Replaced entire other.ts");
+		});
+
+		it("should throw if validation fails", async () => {
+			const block = { code: "" } as CodeBlock;
+			await expect(action.apply(block, context)).rejects.toThrow(
+				"Cannot replace with empty content",
+			);
+		});
+
+		it("should throw if apply method is missing", async () => {
+			const block = { code: "content", filepath: "active.ts" } as CodeBlock;
+			const invalidContext = { ...context, applyToEditor: undefined, applyToFile: undefined };
+
+			await expect(action.apply(block, invalidContext)).rejects.toThrow(
+				"No suitable apply method available",
+			);
+		});
+	});
+});

--- a/client/src/core/ai/actions/actions/__tests__/ReplaceRangeAction.test.ts
+++ b/client/src/core/ai/actions/actions/__tests__/ReplaceRangeAction.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { ReplaceRangeAction } from "../ReplaceRangeAction";
+import type { CodeBlock } from "@/types";
+import type { CodeActionContext } from "../../ICodeAction";
+
+describe("ReplaceRangeAction", () => {
+	const action = new ReplaceRangeAction();
+	const context: CodeActionContext = {
+		editorFilepath: "active.ts",
+		applyToEditor: vi.fn(),
+		applyToFile: vi.fn(),
+		postMessage: vi.fn(),
+	};
+
+	describe("getLabel", () => {
+		it("should return label with range", () => {
+			const block = {
+				filepath: "test.ts",
+				targetRange: { startLine: 1, startColumn: 1, endLine: 2, endColumn: 2 },
+			} as CodeBlock;
+			expect(action.getLabel(block)).toBe("Replace test.ts 1:1-2:2");
+		});
+
+		it("should return label with active editor fallback", () => {
+			const block = {
+				targetRange: { startLine: 1, startColumn: 1, endLine: 2, endColumn: 2 },
+			} as CodeBlock;
+			expect(action.getLabel(block)).toBe("Replace active editor 1:1-2:2");
+		});
+
+		it("should return generic label without range", () => {
+			const block = { filepath: "test.ts" } as CodeBlock;
+			expect(action.getLabel(block)).toBe("Replace code in test.ts");
+		});
+	});
+
+	describe("validate", () => {
+		it("should fail if code is empty", () => {
+			const block = { code: "", targetRange: { startLine: 1, endLine: 2 } } as any;
+			expect(action.validate(block).valid).toBe(false);
+			expect(action.validate(block).error).toContain("Cannot apply action with empty content");
+		});
+
+		it("should fail without range or context", () => {
+			const block = { code: "content" } as CodeBlock;
+			expect(action.validate(block).valid).toBe(false);
+			expect(action.validate(block).error).toContain("requires targetRange");
+		});
+
+		it("should pass if has originalCode context", () => {
+			const block = { code: "content", originalCode: "context" } as CodeBlock;
+			expect(action.validate(block).valid).toBe(true);
+		});
+
+		it("should validate invalid range", () => {
+			const block = {
+				code: "content",
+				targetRange: { startLine: 5, startColumn: 0, endLine: 1, endColumn: 0 },
+			} as CodeBlock;
+			expect(action.validate(block).valid).toBe(false);
+		});
+	});
+
+	describe("apply", () => {
+		it("should call applyToEditor", async () => {
+			const block = { code: "content", targetRange: { startLine: 1, endLine: 2 } } as any;
+			await action.apply(block, context);
+
+			expect(context.applyToEditor).toHaveBeenCalledWith(block);
+			expect(context.postMessage).toHaveBeenCalledWith(expect.stringContaining("Replace"));
+		});
+
+		it("should throw if validation fails", async () => {
+			const block = { code: "" } as CodeBlock;
+			await expect(action.apply(block, context)).rejects.toThrow();
+		});
+
+		it("should throw if applyToEditor is missing", async () => {
+			const block = { code: "content", targetRange: { startLine: 1, endLine: 2 } } as any;
+			const invalidContext = { ...context, applyToEditor: undefined };
+
+			await expect(action.apply(block, invalidContext)).rejects.toThrow(
+				"Editor apply method not available",
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
This PR adds unit tests for Code Action classes as part of the medium-priority coverage improvements (Issue #394).

## Changes
- Added tests for `BaseCodeAction`.
- Added tests for `CreateFileAction`, `DeleteRangeAction`, `InsertAction`, `ReplaceAllAction`, `ReplaceRangeAction`.

## Verification
- All new tests passing locally.



Close #394 