### PR TITLE
chore: unify e2e summary output (#397)

### DIFF
--- a/desktop/e2e/package.json
+++ b/desktop/e2e/package.json
@@ -22,6 +22,7 @@
 		"@wdio/globals": "^8.0.0",
 		"@wdio/local-runner": "^8.0.0",
 		"@wdio/mocha-framework": "^8.0.0",
+		"@wdio/reporter": "^8.0.0",
 		"@wdio/spec-reporter": "^8.0.0",
 		"@wdio/types": "^8.0.0",
 		"ts-node": "^10.9.0",

--- a/desktop/e2e/playwright.config.ts
+++ b/desktop/e2e/playwright.config.ts
@@ -83,7 +83,9 @@ export default defineConfig({
 	workers: process.env.CI ? 1 : undefined,
 
 	// Reporter to use
-	reporter: process.env.CI ? "github" : "list",
+	reporter: process.env.CI
+		? [["github"], [path.resolve(__dirname, "reporters/playwright-summary-reporter.ts")]]
+		: [["list"], [path.resolve(__dirname, "reporters/playwright-summary-reporter.ts")]],
 
 	// Shared settings for all the projects below
 	use: {

--- a/desktop/e2e/reporters/playwright-summary-reporter.ts
+++ b/desktop/e2e/reporters/playwright-summary-reporter.ts
@@ -1,0 +1,34 @@
+import type { Reporter, TestCase, TestResult } from "@playwright/test/reporter";
+
+class E2eSummaryReporter implements Reporter {
+	private passed = 0;
+	private failed = 0;
+	private skipped = 0;
+
+	onTestEnd(_test: TestCase, result: TestResult): void {
+		switch (result.status) {
+			case "passed":
+				this.passed += 1;
+				break;
+			case "failed":
+			case "timedOut":
+			case "interrupted":
+				this.failed += 1;
+				break;
+			case "skipped":
+				this.skipped += 1;
+				break;
+			default:
+				break;
+		}
+	}
+
+	onEnd(): void {
+		const total = this.passed + this.failed + this.skipped;
+		console.log(
+			`[e2e] Summary: total=${total} passed=${this.passed} failed=${this.failed} skipped=${this.skipped}`,
+		);
+	}
+}
+
+export default E2eSummaryReporter;

--- a/desktop/e2e/reporters/wdio-summary-reporter.ts
+++ b/desktop/e2e/reporters/wdio-summary-reporter.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+import SpecReporter from "@wdio/spec-reporter";
+
+const summaryPath =
+	process.env.WDIO_SUMMARY_PATH ?? path.resolve(__dirname, "../.wdio-summary.jsonl");
+
+class E2eSummaryReporter extends SpecReporter {
+	onRunnerEnd(runner: { failures?: number }): void {
+		super.onRunnerEnd(runner);
+		const skipped = this.counts.skipping + this.counts.pending;
+		const payload = {
+			total: this.counts.tests,
+			passed: this.counts.passes,
+			failed: this.counts.failures,
+			skipped,
+		};
+		fs.appendFileSync(summaryPath, `${JSON.stringify(payload)}\n`);
+	}
+}
+
+export default E2eSummaryReporter;

--- a/desktop/e2e/wdio.conf.ts
+++ b/desktop/e2e/wdio.conf.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
 import type { Options } from "@wdio/types";
+import E2eSummaryReporter from "./reporters/wdio-summary-reporter";
 
 const driverHost = process.env.TAURI_DRIVER_HOST ?? "127.0.0.1";
 const driverPort = Number(process.env.TAURI_DRIVER_PORT ?? "9515");
@@ -29,6 +30,7 @@ const driverArgs = process.env.TAURI_DRIVER_ARGS
 	? process.env.TAURI_DRIVER_ARGS.split(" ").filter(Boolean)
 	: defaultDriverArgs;
 const isDocker = fs.existsSync("/.dockerenv") || process.env.REPROD_E2E_DOCKER === "1";
+const summaryPath = process.env.WDIO_SUMMARY_PATH ?? path.resolve(__dirname, ".wdio-summary.jsonl");
 
 if (!process.env.CI && !isDocker) {
 	throw new Error(
@@ -157,7 +159,7 @@ export const config: Options.Testrunner = {
 	connectionRetryCount: 2,
 	services: [],
 	framework: "mocha",
-	reporters: ["spec" as any],
+	reporters: [E2eSummaryReporter as any],
 	mochaOpts: {
 		ui: "bdd",
 		timeout: 300000,
@@ -167,10 +169,52 @@ export const config: Options.Testrunner = {
 	path: driverPath,
 	protocol: "http" as any,
 	onPrepare: async () => {
+		try {
+			fs.unlinkSync(summaryPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+				throw error;
+			}
+		}
 		startDriver();
 		await waitForDriverReady();
 	},
 	onComplete: () => {
+		if (fs.existsSync(summaryPath)) {
+			const lines = fs
+				.readFileSync(summaryPath, "utf8")
+				.split("\n")
+				.map((line) => line.trim())
+				.filter(Boolean);
+			const totals = lines.reduce(
+				(acc, line) => {
+					try {
+						const parsed = JSON.parse(line) as {
+							total: number;
+							passed: number;
+							failed: number;
+							skipped: number;
+						};
+						acc.total += parsed.total;
+						acc.passed += parsed.passed;
+						acc.failed += parsed.failed;
+						acc.skipped += parsed.skipped;
+					} catch {
+						// ignore malformed lines
+					}
+					return acc;
+				},
+				{ total: 0, passed: 0, failed: 0, skipped: 0 },
+			);
+			const summaryLine = `[e2e] Summary: total=${totals.total} passed=${totals.passed} failed=${totals.failed} skipped=${totals.skipped}`;
+			process.once("exit", () => {
+				try {
+					fs.writeSync(1, `${summaryLine}\n`);
+				} catch {
+					// ignore write failures during shutdown
+				}
+			});
+		}
 		stopDriver();
 	},
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@wdio/mocha-framework':
         specifier: ^8.0.0
         version: 8.46.0
+      '@wdio/reporter':
+        specifier: ^8.0.0
+        version: 8.43.0
       '@wdio/spec-reporter':
         specifier: ^8.0.0
         version: 8.43.0


### PR DESCRIPTION
## Description

Add a shared summary line for Playwright and WebDriver E2E runs so total pass/fail/skip counts match across frameworks. The WebDriver runner now aggregates per-worker counts and prints a single summary line at process exit, keeping the existing reporter output intact.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `pnpm --filter @reprod/e2e test:docker:webdriver`

## Screenshots (if applicable)

N/A

## Related Issues

Closes #397
