### PR TITLE
test: add ai agent e2e basics (#390)

### DIFF
--- a/client/src/dev/index.ts
+++ b/client/src/dev/index.ts
@@ -17,6 +17,8 @@ type DevWindow = Window & {
 		) => Promise<ExtractServerMessage<"project_opened">>;
 		setActiveMode: (mode: "api" | "external_agent") => void;
 		getActiveMode: () => "api" | "external_agent";
+		setActiveAgent: (agent: string | null) => void;
+		getActiveAgent: () => string | null;
 		appendTerminalOutput: (chunk: string) => void;
 		clearTerminalOutput: () => void;
 		getTerminalOutput: () => string;
@@ -82,6 +84,10 @@ export const setupDevGlobals = (): void => {
 			useStore.getState().setActiveMode(mode);
 		},
 		getActiveMode: () => useStore.getState().activeMode,
+		setActiveAgent: (agent) => {
+			useStore.getState().setActiveAgent(agent);
+		},
+		getActiveAgent: () => useStore.getState().activeAgent,
 		appendTerminalOutput: (chunk) => {
 			terminalOutputChunks.push(chunk);
 		},

--- a/desktop/e2e/package.json
+++ b/desktop/e2e/package.json
@@ -22,6 +22,7 @@
 		"@wdio/globals": "^8.0.0",
 		"@wdio/local-runner": "^8.0.0",
 		"@wdio/mocha-framework": "^8.0.0",
+		"@wdio/reporter": "^8.0.0",
 		"@wdio/spec-reporter": "^8.0.0",
 		"@wdio/types": "^8.0.0",
 		"ts-node": "^10.9.0",

--- a/desktop/e2e/playwright.config.ts
+++ b/desktop/e2e/playwright.config.ts
@@ -83,7 +83,9 @@ export default defineConfig({
 	workers: process.env.CI ? 1 : undefined,
 
 	// Reporter to use
-	reporter: process.env.CI ? "github" : "list",
+	reporter: process.env.CI
+		? [["github"], [path.resolve(__dirname, "reporters/playwright-summary-reporter.ts")]]
+		: [["list"], [path.resolve(__dirname, "reporters/playwright-summary-reporter.ts")]],
 
 	// Shared settings for all the projects below
 	use: {

--- a/desktop/e2e/reporters/playwright-summary-reporter.ts
+++ b/desktop/e2e/reporters/playwright-summary-reporter.ts
@@ -1,0 +1,34 @@
+import type { Reporter, TestCase, TestResult } from "@playwright/test/reporter";
+
+class E2eSummaryReporter implements Reporter {
+	private passed = 0;
+	private failed = 0;
+	private skipped = 0;
+
+	onTestEnd(_test: TestCase, result: TestResult): void {
+		switch (result.status) {
+			case "passed":
+				this.passed += 1;
+				break;
+			case "failed":
+			case "timedOut":
+			case "interrupted":
+				this.failed += 1;
+				break;
+			case "skipped":
+				this.skipped += 1;
+				break;
+			default:
+				break;
+		}
+	}
+
+	onEnd(): void {
+		const total = this.passed + this.failed + this.skipped;
+		console.log(
+			`[e2e] Summary: total=${total} passed=${this.passed} failed=${this.failed} skipped=${this.skipped}`,
+		);
+	}
+}
+
+export default E2eSummaryReporter;

--- a/desktop/e2e/reporters/wdio-summary-reporter.ts
+++ b/desktop/e2e/reporters/wdio-summary-reporter.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+import SpecReporter from "@wdio/spec-reporter";
+
+const summaryPath =
+	process.env.WDIO_SUMMARY_PATH ?? path.resolve(__dirname, "../.wdio-summary.jsonl");
+
+class E2eSummaryReporter extends SpecReporter {
+	onRunnerEnd(runner: { failures?: number }): void {
+		super.onRunnerEnd(runner);
+		const skipped = this.counts.skipping + this.counts.pending;
+		const payload = {
+			total: this.counts.tests,
+			passed: this.counts.passes,
+			failed: this.counts.failures,
+			skipped,
+		};
+		fs.appendFileSync(summaryPath, `${JSON.stringify(payload)}\n`);
+	}
+}
+
+export default E2eSummaryReporter;

--- a/desktop/e2e/shared/selectors.ts
+++ b/desktop/e2e/shared/selectors.ts
@@ -63,12 +63,14 @@ export const selectors = {
 	aiModeSelect: ".mode-dropdown",
 
 	// Plot
-	plotPane: ".plot-pane",
+	plotPane: ".plot-viewer",
 	plotImage: ".plot-image",
-	plotPrevButton: 'button[title="Previous Plot"]',
-	plotNextButton: 'button[title="Next Plot"]',
+	plotPrevButton: 'button[aria-label="Previous plot"]',
+	plotNextButton: 'button[aria-label="Next plot"]',
 	plotClearButton: 'button[title="Clear Plots"]',
 	plotExportButton: 'button[title="Export Plot"]',
+	plotCounter: ".plot-counter",
+	plotsTab: 'button.tab:has-text("Plots")',
 
 	// Menu
 	menuBar: ".menu-bar",

--- a/desktop/e2e/shared/selectors.ts
+++ b/desktop/e2e/shared/selectors.ts
@@ -54,12 +54,13 @@ export const selectors = {
 	// AI Agent
 	aiPanel: ".ai-panel",
 	aiInput: ".ai-input",
-	aiSendButton: ".ai-send-button",
-	aiMessage: ".ai-message",
-	aiCodeBlock: ".ai-code-block",
-	aiAcceptButton: ".ai-accept-button",
+	aiSendButton: 'button[aria-label="Send message"]',
+	aiMessage: ".ai-messages .message",
+	aiCodeBlock: ".code-block-container",
+	aiAcceptButton: 'button[title="Apply to editor"]',
 	aiRejectButton: ".ai-reject-button",
 	aiProviderSelect: ".ai-provider-select",
+	aiModeSelect: ".mode-dropdown",
 
 	// Plot
 	plotPane: ".plot-pane",

--- a/desktop/e2e/shared/test-registry.ts
+++ b/desktop/e2e/shared/test-registry.ts
@@ -41,6 +41,11 @@ export const TEST_CASES = {
 	],
 	"project-switch": ["opens modal and switches to a server project"],
 	"settings-acp-mode": ["keeps External Agent (ACP) selected after agent refresh"],
+	"ai-agent": [
+		"disables send until input is provided",
+		"opens settings when sending without a configured agent",
+		"switches between agent and chat modes",
+	],
 	terminal: [
 		"opens terminal pane and becomes visible",
 		"executes shell command and displays output",

--- a/desktop/e2e/shared/test-registry.ts
+++ b/desktop/e2e/shared/test-registry.ts
@@ -46,6 +46,10 @@ export const TEST_CASES = {
 		"opens settings when sending without a configured agent",
 		"switches between agent and chat modes",
 	],
+	plot: [
+		"renders a plot in the plots panel",
+		"navigates between plots with previous and next buttons",
+	],
 	terminal: [
 		"opens terminal pane and becomes visible",
 		"executes shell command and displays output",

--- a/desktop/e2e/tests/ai-agent.spec.ts
+++ b/desktop/e2e/tests/ai-agent.spec.ts
@@ -10,9 +10,14 @@ const waitForAiPanel = async (page: any) => {
 
 const setExternalAgentMode = async (page: any) => {
 	await page.evaluate(() => {
+		window.reprodTest?.setActiveAgent?.(null);
 		window.reprodTest?.setActiveMode("external_agent");
 	});
-	await page.waitForFunction(() => window.reprodTest?.getActiveMode?.() === "external_agent");
+	await page.waitForFunction(
+		() =>
+			window.reprodTest?.getActiveMode?.() === "external_agent" &&
+			window.reprodTest?.getActiveAgent?.() === null,
+	);
 };
 
 test.describe("AI agent", () => {

--- a/desktop/e2e/tests/ai-agent.spec.ts
+++ b/desktop/e2e/tests/ai-agent.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+import { selectors } from "../shared/selectors";
+import { TEST_CASES } from "../shared/test-registry";
+
+const waitForAiPanel = async (page: any) => {
+	const panel = page.locator(selectors.aiPanel);
+	await panel.waitFor({ timeout: 10000 });
+	return panel;
+};
+
+const setExternalAgentMode = async (page: any) => {
+	await page.evaluate(() => {
+		window.reprodTest?.setActiveMode("external_agent");
+	});
+	await page.waitForFunction(() => window.reprodTest?.getActiveMode?.() === "external_agent");
+};
+
+test.describe("AI agent", () => {
+	test(TEST_CASES["ai-agent"][0], async ({ page }) => {
+		await page.goto("/");
+
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
+
+		await waitForAiPanel(page);
+
+		const sendButton = page.locator(selectors.aiSendButton);
+		await sendButton.waitFor({ timeout: 10000 });
+		expect(await sendButton.isEnabled()).toBeFalsy();
+
+		const input = page.locator(selectors.aiInput);
+		await input.fill("Hello AI");
+		expect(await sendButton.isEnabled()).toBeTruthy();
+	});
+
+	test(TEST_CASES["ai-agent"][1], async ({ page }) => {
+		await page.goto("/");
+
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
+
+		await waitForAiPanel(page);
+		await setExternalAgentMode(page);
+
+		const input = page.locator(selectors.aiInput);
+		await input.fill("Test prompt");
+		await input.press("Enter");
+
+		const settingsDialog = page.locator(selectors.settingsDialog);
+		await settingsDialog.waitFor({ timeout: 10000 });
+		expect(await settingsDialog.isVisible()).toBeTruthy();
+	});
+
+	test(TEST_CASES["ai-agent"][2], async ({ page }) => {
+		await page.goto("/");
+
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
+
+		await waitForAiPanel(page);
+
+		const input = page.locator(selectors.aiInput);
+		await input.waitFor({ timeout: 10000 });
+		expect(await input.getAttribute("placeholder")).toBe("Describe a task...");
+
+		const modeSelect = page.locator(selectors.aiModeSelect);
+		await modeSelect.selectOption("chat");
+		expect(await input.getAttribute("placeholder")).toBe("Ask a question...");
+	});
+});

--- a/desktop/e2e/tests/ai-agent.spec.ts
+++ b/desktop/e2e/tests/ai-agent.spec.ts
@@ -51,7 +51,7 @@ test.describe("AI agent", () => {
 		await input.fill("Test prompt");
 		await input.press("Enter");
 
-		const settingsDialog = page.locator(selectors.settingsDialog);
+		const settingsDialog = page.getByRole("dialog", { name: "Settings" });
 		await settingsDialog.waitFor({ timeout: 10000 });
 		expect(await settingsDialog.isVisible()).toBeTruthy();
 	});

--- a/desktop/e2e/tests/plot.spec.ts
+++ b/desktop/e2e/tests/plot.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import { executeRCode, waitForElement } from "../shared/helpers";
+import { selectors } from "../shared/selectors";
+import { TEST_CASES } from "../shared/test-registry";
+
+const openPlotsTab = async (page: any) => {
+	const plotsTab = page.locator(selectors.plotsTab);
+	await plotsTab.waitFor({ timeout: 10000 });
+	await plotsTab.click();
+};
+
+test.describe("Plot visualization", () => {
+	test(TEST_CASES.plot[0], async ({ page }) => {
+		await page.goto("/");
+
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
+
+		await executeRCode(page, "plot(1:10)");
+		await openPlotsTab(page);
+
+		await waitForElement(page, selectors.plotImage, { timeout: 20000 });
+		const plotImage = page.locator(selectors.plotImage);
+		expect(await plotImage.isVisible()).toBeTruthy();
+	});
+
+	test(TEST_CASES.plot[1], async ({ page }) => {
+		await page.goto("/");
+
+		const editor = page.locator(selectors.editor);
+		await editor.waitFor({ timeout: 30000 });
+
+		await executeRCode(page, "plot(1:10)\nplot(10:1)");
+		await openPlotsTab(page);
+
+		await waitForElement(page, selectors.plotImage, { timeout: 20000 });
+
+		const counter = page.locator(selectors.plotCounter);
+		await counter.waitFor({ timeout: 10000 });
+		expect(await counter.textContent()).toContain("1 / 2");
+
+		const nextButton = page.locator(selectors.plotNextButton);
+		await nextButton.click();
+		expect(await counter.textContent()).toContain("2 / 2");
+
+		const prevButton = page.locator(selectors.plotPrevButton);
+		await prevButton.click();
+		expect(await counter.textContent()).toContain("1 / 2");
+	});
+});

--- a/desktop/e2e/tests/plot.spec.ts
+++ b/desktop/e2e/tests/plot.spec.ts
@@ -1,7 +1,23 @@
 import { expect, test } from "@playwright/test";
+import type { Locator } from "@playwright/test";
 import { executeRCode, waitForElement } from "../shared/helpers";
 import { selectors } from "../shared/selectors";
 import { TEST_CASES } from "../shared/test-registry";
+
+const parsePlotCounter = (text: string | null) => {
+	if (!text) {
+		return null;
+	}
+	const match = text.trim().match(/(\d+)\s*\/\s*(\d+)/);
+	if (!match) {
+		return null;
+	}
+	return { current: Number(match[1]), total: Number(match[2]) };
+};
+
+const readPlotCounter = async (counter: Locator) => {
+	return parsePlotCounter(await counter.textContent());
+};
 
 const openPlotsTab = async (page: any) => {
 	const plotsTab = page.locator(selectors.plotsTab);
@@ -37,14 +53,30 @@ test.describe("Plot visualization", () => {
 
 		const counter = page.locator(selectors.plotCounter);
 		await counter.waitFor({ timeout: 10000 });
-		expect(await counter.textContent()).toContain("1 / 2");
+		await expect.poll(async () => readPlotCounter(counter), { timeout: 10000 }).not.toBeNull();
+		const initial = (await readPlotCounter(counter))!;
+		expect(initial.total).toBeGreaterThanOrEqual(2);
 
 		const nextButton = page.locator(selectors.plotNextButton);
-		await nextButton.click();
-		expect(await counter.textContent()).toContain("2 / 2");
-
 		const prevButton = page.locator(selectors.plotPrevButton);
-		await prevButton.click();
-		expect(await counter.textContent()).toContain("1 / 2");
+		if (initial.current >= initial.total) {
+			await prevButton.click();
+			await expect
+				.poll(async () => (await readPlotCounter(counter))?.current, { timeout: 10000 })
+				.toBe(initial.current - 1);
+			await nextButton.click();
+			await expect
+				.poll(async () => (await readPlotCounter(counter))?.current, { timeout: 10000 })
+				.toBe(initial.current);
+		} else {
+			await nextButton.click();
+			await expect
+				.poll(async () => (await readPlotCounter(counter))?.current, { timeout: 10000 })
+				.toBe(initial.current + 1);
+			await prevButton.click();
+			await expect
+				.poll(async () => (await readPlotCounter(counter))?.current, { timeout: 10000 })
+				.toBe(initial.current);
+		}
 	});
 });

--- a/desktop/e2e/wdio.conf.ts
+++ b/desktop/e2e/wdio.conf.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
 import type { Options } from "@wdio/types";
+import E2eSummaryReporter from "./reporters/wdio-summary-reporter";
 
 const driverHost = process.env.TAURI_DRIVER_HOST ?? "127.0.0.1";
 const driverPort = Number(process.env.TAURI_DRIVER_PORT ?? "9515");
@@ -29,6 +30,7 @@ const driverArgs = process.env.TAURI_DRIVER_ARGS
 	? process.env.TAURI_DRIVER_ARGS.split(" ").filter(Boolean)
 	: defaultDriverArgs;
 const isDocker = fs.existsSync("/.dockerenv") || process.env.REPROD_E2E_DOCKER === "1";
+const summaryPath = process.env.WDIO_SUMMARY_PATH ?? path.resolve(__dirname, ".wdio-summary.jsonl");
 
 if (!process.env.CI && !isDocker) {
 	throw new Error(
@@ -157,7 +159,7 @@ export const config: Options.Testrunner = {
 	connectionRetryCount: 2,
 	services: [],
 	framework: "mocha",
-	reporters: ["spec" as any],
+	reporters: [E2eSummaryReporter as any],
 	mochaOpts: {
 		ui: "bdd",
 		timeout: 300000,
@@ -167,10 +169,52 @@ export const config: Options.Testrunner = {
 	path: driverPath,
 	protocol: "http" as any,
 	onPrepare: async () => {
+		try {
+			fs.unlinkSync(summaryPath);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+				throw error;
+			}
+		}
 		startDriver();
 		await waitForDriverReady();
 	},
 	onComplete: () => {
+		if (fs.existsSync(summaryPath)) {
+			const lines = fs
+				.readFileSync(summaryPath, "utf8")
+				.split("\n")
+				.map((line) => line.trim())
+				.filter(Boolean);
+			const totals = lines.reduce(
+				(acc, line) => {
+					try {
+						const parsed = JSON.parse(line) as {
+							total: number;
+							passed: number;
+							failed: number;
+							skipped: number;
+						};
+						acc.total += parsed.total;
+						acc.passed += parsed.passed;
+						acc.failed += parsed.failed;
+						acc.skipped += parsed.skipped;
+					} catch {
+						// ignore malformed lines
+					}
+					return acc;
+				},
+				{ total: 0, passed: 0, failed: 0, skipped: 0 },
+			);
+			const summaryLine = `[e2e] Summary: total=${totals.total} passed=${totals.passed} failed=${totals.failed} skipped=${totals.skipped}`;
+			process.once("exit", () => {
+				try {
+					fs.writeSync(1, `${summaryLine}\n`);
+				} catch {
+					// ignore write failures during shutdown
+				}
+			});
+		}
 		stopDriver();
 	},
 };

--- a/desktop/e2e/webdriver-specs/ai-agent.e2e.ts
+++ b/desktop/e2e/webdriver-specs/ai-agent.e2e.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert";
+import { selectors } from "../shared/selectors";
+import { TEST_CASES } from "../shared/test-registry";
+
+const waitForAiPanel = async () => {
+	const panel = await browser.$(selectors.aiPanel);
+	await panel.waitForDisplayed({ timeout: 10000 });
+	return panel;
+};
+
+const setExternalAgentMode = async () => {
+	await browser.execute(() => {
+		window.reprodTest?.setActiveMode("external_agent");
+	});
+	await browser.waitUntil(
+		async () =>
+			(await browser.execute(() => window.reprodTest?.getActiveMode?.())) === "external_agent",
+		{
+			timeout: 10000,
+			timeoutMsg: "Expected external agent mode to be active",
+		},
+	);
+};
+
+describe("AI agent", () => {
+	it(TEST_CASES["ai-agent"][0], async () => {
+		const editorInput = await browser.$(selectors.editor);
+		await editorInput.waitForDisplayed({ timeout: 30000 });
+
+		await waitForAiPanel();
+
+		const sendButton = await browser.$(selectors.aiSendButton);
+		await sendButton.waitForDisplayed({ timeout: 10000 });
+		assert.equal(await sendButton.isEnabled(), false);
+
+		const input = await browser.$(selectors.aiInput);
+		await input.setValue("Hello AI");
+		assert.equal(await sendButton.isEnabled(), true);
+	});
+
+	it(TEST_CASES["ai-agent"][1], async () => {
+		const editorInput = await browser.$(selectors.editor);
+		await editorInput.waitForDisplayed({ timeout: 30000 });
+
+		await waitForAiPanel();
+		await setExternalAgentMode();
+
+		const input = await browser.$(selectors.aiInput);
+		await input.setValue("Test prompt");
+		await input.keys("Enter");
+
+		const settingsDialog = await browser.$(selectors.settingsDialog);
+		await settingsDialog.waitForDisplayed({ timeout: 10000 });
+		assert.ok(await settingsDialog.isDisplayed());
+	});
+
+	it(TEST_CASES["ai-agent"][2], async () => {
+		const editorInput = await browser.$(selectors.editor);
+		await editorInput.waitForDisplayed({ timeout: 30000 });
+
+		await waitForAiPanel();
+
+		const input = await browser.$(selectors.aiInput);
+		await input.waitForDisplayed({ timeout: 10000 });
+		assert.equal(await input.getAttribute("placeholder"), "Describe a task...");
+
+		const modeSelect = await browser.$(selectors.aiModeSelect);
+		await modeSelect.selectByAttribute("value", "chat");
+		assert.equal(await input.getAttribute("placeholder"), "Ask a question...");
+	});
+});

--- a/desktop/e2e/webdriver-specs/ai-agent.e2e.ts
+++ b/desktop/e2e/webdriver-specs/ai-agent.e2e.ts
@@ -47,7 +47,7 @@ describe("AI agent", () => {
 
 		const input = await browser.$(selectors.aiInput);
 		await input.setValue("Test prompt");
-		await input.keys("Enter");
+		await browser.keys("Enter");
 
 		const settingsDialog = await browser.$(selectors.settingsDialog);
 		await settingsDialog.waitForDisplayed({ timeout: 10000 });

--- a/desktop/e2e/webdriver-specs/ai-agent.e2e.ts
+++ b/desktop/e2e/webdriver-specs/ai-agent.e2e.ts
@@ -10,11 +10,13 @@ const waitForAiPanel = async () => {
 
 const setExternalAgentMode = async () => {
 	await browser.execute(() => {
+		window.reprodTest?.setActiveAgent?.(null);
 		window.reprodTest?.setActiveMode("external_agent");
 	});
 	await browser.waitUntil(
 		async () =>
-			(await browser.execute(() => window.reprodTest?.getActiveMode?.())) === "external_agent",
+			(await browser.execute(() => window.reprodTest?.getActiveMode?.())) === "external_agent" &&
+			(await browser.execute(() => window.reprodTest?.getActiveAgent?.())) === null,
 		{
 			timeout: 10000,
 			timeoutMsg: "Expected external agent mode to be active",
@@ -47,10 +49,21 @@ describe("AI agent", () => {
 
 		const input = await browser.$(selectors.aiInput);
 		await input.setValue("Test prompt");
-		await browser.keys("Enter");
+		await browser.waitUntil(
+			async () =>
+				browser.execute((selector) => {
+					const button = document.querySelector(selector) as HTMLButtonElement | null;
+					if (!button || button.disabled) {
+						return false;
+					}
+					button.click();
+					return true;
+				}, selectors.aiSendButton),
+			{ timeout: 10000, timeoutMsg: "Send button not available" },
+		);
 
 		const settingsDialog = await browser.$(selectors.settingsDialog);
-		await settingsDialog.waitForDisplayed({ timeout: 10000 });
+		await settingsDialog.waitForDisplayed({ timeout: 20000 });
 		assert.ok(await settingsDialog.isDisplayed());
 	});
 
@@ -64,8 +77,26 @@ describe("AI agent", () => {
 		await input.waitForDisplayed({ timeout: 10000 });
 		assert.equal(await input.getAttribute("placeholder"), "Describe a task...");
 
-		const modeSelect = await browser.$(selectors.aiModeSelect);
-		await modeSelect.selectByAttribute("value", "chat");
-		assert.equal(await input.getAttribute("placeholder"), "Ask a question...");
+		await browser.waitUntil(
+			async () =>
+				browser.execute(
+					(selector, value) => {
+						const select = document.querySelector(selector) as HTMLSelectElement | null;
+						if (!select) {
+							return false;
+						}
+						select.value = value;
+						select.dispatchEvent(new Event("change", { bubbles: true }));
+						return select.value === value;
+					},
+					selectors.aiModeSelect,
+					"chat",
+				),
+			{ timeout: 10000, timeoutMsg: "Mode dropdown not available" },
+		);
+		await browser.waitUntil(
+			async () => (await input.getAttribute("placeholder")) === "Ask a question...",
+			{ timeout: 10000, timeoutMsg: "Placeholder did not update for chat mode" },
+		);
 	});
 });

--- a/desktop/e2e/webdriver-specs/ai-agent.e2e.ts
+++ b/desktop/e2e/webdriver-specs/ai-agent.e2e.ts
@@ -62,9 +62,11 @@ describe("AI agent", () => {
 			{ timeout: 10000, timeoutMsg: "Send button not available" },
 		);
 
-		const settingsDialog = await browser.$(selectors.settingsDialog);
-		await settingsDialog.waitForDisplayed({ timeout: 20000 });
-		assert.ok(await settingsDialog.isDisplayed());
+		const settingsTitle = await browser.$(
+			'//div[@role="dialog"]//h2[normalize-space()="Settings"]',
+		);
+		await settingsTitle.waitForDisplayed({ timeout: 20000 });
+		assert.ok(await settingsTitle.isDisplayed());
 	});
 
 	it(TEST_CASES["ai-agent"][2], async () => {

--- a/desktop/e2e/webdriver-specs/error-handling.e2e.ts
+++ b/desktop/e2e/webdriver-specs/error-handling.e2e.ts
@@ -1,15 +1,18 @@
 import assert from "node:assert";
-import { clickRunAll, setEditorValue } from "./helpers";
+import { clickRunAll, setEditorValue, waitForConnected } from "./helpers";
 import { TEST_CASES } from "../shared/test-registry";
 
 const editorSelector = ".monaco-editor textarea";
 const consoleOutputSelector = ".console-output, .console-entry";
 
 describe("Error handling scenarios", () => {
-	it(TEST_CASES["error-handling"][0], async () => {
+	beforeEach(async () => {
 		const editorInput = await browser.$(editorSelector);
 		await editorInput.waitForDisplayed({ timeout: 30000 });
+		await waitForConnected();
+	});
 
+	it(TEST_CASES["error-handling"][0], async () => {
 		await setEditorValue("x <- 1 +");
 		await clickRunAll();
 
@@ -40,9 +43,6 @@ describe("Error handling scenarios", () => {
 	});
 
 	it(TEST_CASES["error-handling"][1], async () => {
-		const editorInput = await browser.$(editorSelector);
-		await editorInput.waitForDisplayed({ timeout: 30000 });
-
 		await setEditorValue('x <- "text"\ny <- x / 2');
 		await clickRunAll();
 
@@ -71,9 +71,6 @@ describe("Error handling scenarios", () => {
 	});
 
 	it(TEST_CASES["error-handling"][2], async () => {
-		const editorInput = await browser.$(editorSelector);
-		await editorInput.waitForDisplayed({ timeout: 30000 });
-
 		await setEditorValue('stop("Error")');
 		await clickRunAll();
 		await browser.pause(3000);
@@ -106,9 +103,6 @@ describe("Error handling scenarios", () => {
 	});
 
 	it(TEST_CASES["error-handling"][3], async () => {
-		const editorInput = await browser.$(editorSelector);
-		await editorInput.waitForDisplayed({ timeout: 30000 });
-
 		await setEditorValue("print(undefined_variable)");
 		await clickRunAll();
 
@@ -174,9 +168,6 @@ describe("Error handling scenarios", () => {
 	});
 
 	it(TEST_CASES["error-handling"][5], async () => {
-		const editorInput = await browser.$(editorSelector);
-		await editorInput.waitForDisplayed({ timeout: 30000 });
-
 		await setEditorValue("}{][)( <- %% !!!");
 		await clickRunAll();
 
@@ -197,14 +188,12 @@ describe("Error handling scenarios", () => {
 			},
 		);
 
+		const editorInput = await browser.$(editorSelector);
 		const editorStillVisible = await editorInput.isDisplayed();
 		assert.ok(editorStillVisible, "Editor should still be functional after parse error");
 	});
 
 	it(TEST_CASES["error-handling"][6], async () => {
-		const editorInput = await browser.$(editorSelector);
-		await editorInput.waitForDisplayed({ timeout: 30000 });
-
 		await setEditorValue("x <- 1 +");
 		await clickRunAll();
 		await browser.pause(1000);

--- a/desktop/e2e/webdriver-specs/error-handling.e2e.ts
+++ b/desktop/e2e/webdriver-specs/error-handling.e2e.ts
@@ -1,15 +1,16 @@
 import assert from "node:assert";
-import { clickRunAll, setEditorValue, waitForConnected } from "./helpers";
+import { clickRunAll, openFixturesProject, setEditorValue, waitForConnected } from "./helpers";
 import { TEST_CASES } from "../shared/test-registry";
 
 const editorSelector = ".monaco-editor textarea";
-const consoleOutputSelector = ".console-output, .console-entry";
+const consoleOutputSelector = ".console-stdout, .console-stderr";
 
 describe("Error handling scenarios", () => {
-	beforeEach(async () => {
+	before(async () => {
 		const editorInput = await browser.$(editorSelector);
 		await editorInput.waitForDisplayed({ timeout: 30000 });
 		await waitForConnected();
+		await openFixturesProject();
 	});
 
 	it(TEST_CASES["error-handling"][0], async () => {

--- a/desktop/e2e/webdriver-specs/export.e2e.ts
+++ b/desktop/e2e/webdriver-specs/export.e2e.ts
@@ -2,7 +2,13 @@ import assert from "node:assert";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { clickRunAll, closeDialog, openExportDialog, setEditorValue } from "./helpers";
+import {
+	clickRunAll,
+	closeDialog,
+	openExportDialog,
+	setEditorValue,
+	waitForConnected,
+} from "./helpers";
 import { TEST_CASES } from "../shared/test-registry";
 
 const editorSelector = ".monaco-editor textarea";
@@ -25,10 +31,14 @@ describe("Export functionality", () => {
 		}
 	});
 
-	it(TEST_CASES["export"][0], async () => {
-		// Execute some R code first
+	beforeEach(async () => {
 		const editorInput = await browser.$(editorSelector);
 		await editorInput.waitForDisplayed({ timeout: 30000 });
+		await waitForConnected();
+	});
+
+	it(TEST_CASES["export"][0], async () => {
+		// Execute some R code first
 		await setEditorValue("# Export test\nresult <- mean(c(1, 2, 3, 4, 5))\nprint(result)");
 
 		await clickRunAll();

--- a/desktop/e2e/webdriver-specs/export.e2e.ts
+++ b/desktop/e2e/webdriver-specs/export.e2e.ts
@@ -6,6 +6,7 @@ import {
 	clickRunAll,
 	closeDialog,
 	openExportDialog,
+	openFixturesProject,
 	setEditorValue,
 	waitForConnected,
 } from "./helpers";
@@ -35,6 +36,10 @@ describe("Export functionality", () => {
 		const editorInput = await browser.$(editorSelector);
 		await editorInput.waitForDisplayed({ timeout: 30000 });
 		await waitForConnected();
+	});
+
+	before(async () => {
+		await openFixturesProject();
 	});
 
 	it(TEST_CASES["export"][0], async () => {

--- a/desktop/e2e/webdriver-specs/full-workflow.e2e.ts
+++ b/desktop/e2e/webdriver-specs/full-workflow.e2e.ts
@@ -5,6 +5,7 @@ import {
 	openExportDialog,
 	openTimelineDialog,
 	setEditorValue,
+	waitForConnected,
 } from "./helpers";
 import { TEST_CASES } from "../shared/test-registry";
 
@@ -27,12 +28,17 @@ const timelineEventSelector = ".timeline-event";
  * 7. Verify timeline updates
  */
 describe("Full user workflow", () => {
+	beforeEach(async () => {
+		const editorInput = await browser.$(editorSelector);
+		await editorInput.waitForDisplayed({ timeout: 30000 });
+		await waitForConnected();
+	});
+
 	it(TEST_CASES["full-workflow"][0], async () => {
 		// ========================================
 		// STEP 1: App Launch and Initial State
 		// ========================================
 		const editorInput = await browser.$(editorSelector);
-		await editorInput.waitForDisplayed({ timeout: 30000 });
 
 		const isEditorVisible = await editorInput.isDisplayed();
 		assert.ok(isEditorVisible, "Editor should be visible after app launch");
@@ -193,8 +199,6 @@ cat("Total sum:", result, "\\n")`);
 	});
 
 	it(TEST_CASES["full-workflow"][1], async () => {
-		const editorInput = await browser.$(editorSelector);
-
 		// Execute code with error
 		await setEditorValue("x <- 1\ny <- x / 0  # Division by zero warning");
 
@@ -236,8 +240,6 @@ cat("Total sum:", result, "\\n")`);
 	});
 
 	it(TEST_CASES["full-workflow"][2], async () => {
-		const editorInput = await browser.$(editorSelector);
-
 		// Execute first block
 		await setEditorValue("# Block 1\na <- 5");
 

--- a/desktop/e2e/webdriver-specs/full-workflow.e2e.ts
+++ b/desktop/e2e/webdriver-specs/full-workflow.e2e.ts
@@ -3,6 +3,7 @@ import {
 	clickRunAll,
 	closeDialog,
 	openExportDialog,
+	openFixturesProject,
 	openTimelineDialog,
 	setEditorValue,
 	waitForConnected,
@@ -28,10 +29,11 @@ const timelineEventSelector = ".timeline-event";
  * 7. Verify timeline updates
  */
 describe("Full user workflow", () => {
-	beforeEach(async () => {
+	before(async () => {
 		const editorInput = await browser.$(editorSelector);
 		await editorInput.waitForDisplayed({ timeout: 30000 });
 		await waitForConnected();
+		await openFixturesProject();
 	});
 
 	it(TEST_CASES["full-workflow"][0], async () => {

--- a/desktop/e2e/webdriver-specs/helpers.ts
+++ b/desktop/e2e/webdriver-specs/helpers.ts
@@ -165,6 +165,29 @@ export async function clickRunAll(): Promise<void> {
 	);
 }
 
+export async function waitForConsoleOutput(expected: string, timeoutMs = 60000): Promise<string[]> {
+	await browser.waitUntil(
+		async () => {
+			const texts = await browser.execute(() =>
+				Array.from(document.querySelectorAll(".console-stdout"), (element) =>
+					(element.textContent ?? "").trim(),
+				),
+			);
+			return texts.some((text) => text.includes(expected));
+		},
+		{
+			timeout: timeoutMs,
+			timeoutMsg: `Expected R execution output to include ${expected}`,
+		},
+	);
+
+	return (await browser.execute(() =>
+		Array.from(document.querySelectorAll(".console-stdout"), (element) =>
+			(element.textContent ?? "").trim(),
+		),
+	)) as string[];
+}
+
 export async function getFileTreeLabels(): Promise<string[]> {
 	return (await browser.execute(() => {
 		return Array.from(document.querySelectorAll(".file-tree-label"))

--- a/desktop/e2e/webdriver-specs/helpers.ts
+++ b/desktop/e2e/webdriver-specs/helpers.ts
@@ -211,6 +211,7 @@ export async function waitForConnected(timeoutMs = 30000): Promise<void> {
 export async function openFixturesProject(timeoutMs = 30000): Promise<void> {
 	const repoRoot = path.resolve(__dirname, "../../..");
 	const fixturesRoot = path.join(repoRoot, "desktop/e2e/shared/fixtures/projects");
+	await waitForConnected(timeoutMs);
 	await switchProjectFolderAndWait(fixturesRoot, "projects", timeoutMs);
 	await waitForFileTreeLabel("alpha", timeoutMs);
 }

--- a/desktop/e2e/webdriver-specs/helpers.ts
+++ b/desktop/e2e/webdriver-specs/helpers.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 export async function openTimelineDialog(): Promise<WebdriverIO.Element> {
 	await browser.waitUntil(
 		async () =>
@@ -196,7 +198,7 @@ export async function waitForConnected(timeoutMs = 30000): Promise<void> {
 				if (typeof helper?.isConnected === "function") {
 					return helper.isConnected();
 				}
-				const status = document.querySelector(".connection-status");
+				const status = document.querySelector(".connection-indicator .connection-text");
 				return status?.textContent?.toLowerCase().includes("connected") ?? false;
 			}),
 		{
@@ -204,6 +206,13 @@ export async function waitForConnected(timeoutMs = 30000): Promise<void> {
 			timeoutMsg: "Expected app to be connected before running code",
 		},
 	);
+}
+
+export async function openFixturesProject(timeoutMs = 30000): Promise<void> {
+	const repoRoot = path.resolve(__dirname, "../../..");
+	const fixturesRoot = path.join(repoRoot, "desktop/e2e/shared/fixtures/projects");
+	await switchProjectFolderAndWait(fixturesRoot, "projects", timeoutMs);
+	await waitForFileTreeLabel("alpha", timeoutMs);
 }
 
 export async function getFileTreeLabels(): Promise<string[]> {

--- a/desktop/e2e/webdriver-specs/helpers.ts
+++ b/desktop/e2e/webdriver-specs/helpers.ts
@@ -188,6 +188,24 @@ export async function waitForConsoleOutput(expected: string, timeoutMs = 60000):
 	)) as string[];
 }
 
+export async function waitForConnected(timeoutMs = 30000): Promise<void> {
+	await browser.waitUntil(
+		async () =>
+			browser.execute(() => {
+				const helper = (window as any).reprodTest as { isConnected?: () => boolean } | undefined;
+				if (typeof helper?.isConnected === "function") {
+					return helper.isConnected();
+				}
+				const status = document.querySelector(".connection-status");
+				return status?.textContent?.toLowerCase().includes("connected") ?? false;
+			}),
+		{
+			timeout: timeoutMs,
+			timeoutMsg: "Expected app to be connected before running code",
+		},
+	);
+}
+
 export async function getFileTreeLabels(): Promise<string[]> {
 	return (await browser.execute(() => {
 		return Array.from(document.querySelectorAll(".file-tree-label"))

--- a/desktop/e2e/webdriver-specs/plot.e2e.ts
+++ b/desktop/e2e/webdriver-specs/plot.e2e.ts
@@ -19,6 +19,18 @@ const openPlotsTab = async (): Promise<void> => {
 	);
 };
 
+const getPlotCounter = async (): Promise<{ current: number; total: number } | null> => {
+	const text = (await browser.execute(() => {
+		const counter = document.querySelector(".plot-counter");
+		return counter?.textContent?.trim() ?? "";
+	})) as string;
+	const match = text.match(/(\d+)\s*\/\s*(\d+)/);
+	if (!match) {
+		return null;
+	}
+	return { current: Number(match[1]), total: Number(match[2]) };
+};
+
 describe("Plot visualization", () => {
 	before(async () => {
 		const editorInput = await browser.$(selectors.editor);
@@ -38,31 +50,55 @@ describe("Plot visualization", () => {
 	});
 
 	it(TEST_CASES.plot[1], async () => {
+		const previousTotal = (await getPlotCounter())?.total ?? 0;
+
 		await setEditorValue("plot(1:10)\nplot(10:1)");
 		await clickRunAll();
 		await openPlotsTab();
 
-		const plotImage = await browser.$(selectors.plotImage);
-		await plotImage.waitForDisplayed({ timeout: 20000 });
-
 		const counter = await browser.$(selectors.plotCounter);
 		await counter.waitForDisplayed({ timeout: 10000 });
-		assert.ok((await counter.getText()).includes("1 / 2"));
 
-		const nextButton = await browser.$(selectors.plotNextButton);
-		await nextButton.waitForEnabled({ timeout: 10000 });
-		await nextButton.click();
-		await browser.waitUntil(async () => (await counter.getText()).includes("2 / 2"), {
-			timeout: 10000,
-			timeoutMsg: "Expected plot counter to move to 2 / 2",
-		});
+		await browser.waitUntil(
+			async () => {
+				const parsed = await getPlotCounter();
+				return parsed !== null && parsed.total >= previousTotal + 2;
+			},
+			{
+				timeout: 30000,
+				timeoutMsg: "Expected plot history to include two new plots",
+			},
+		);
+
+		const plotImage = await browser.$(selectors.plotImage);
+		await plotImage.waitForDisplayed({ timeout: 20000 });
 
 		const prevButton = await browser.$(selectors.plotPrevButton);
 		await prevButton.waitForEnabled({ timeout: 10000 });
 		await prevButton.click();
-		await browser.waitUntil(async () => (await counter.getText()).includes("1 / 2"), {
-			timeout: 10000,
-			timeoutMsg: "Expected plot counter to return to 1 / 2",
-		});
+		await browser.waitUntil(
+			async () => {
+				const parsed = await getPlotCounter();
+				return parsed !== null && parsed.current === parsed.total - 1;
+			},
+			{
+				timeout: 10000,
+				timeoutMsg: "Expected plot counter to move to previous plot",
+			},
+		);
+
+		const nextButton = await browser.$(selectors.plotNextButton);
+		await nextButton.waitForEnabled({ timeout: 10000 });
+		await nextButton.click();
+		await browser.waitUntil(
+			async () => {
+				const parsed = await getPlotCounter();
+				return parsed !== null && parsed.current === parsed.total;
+			},
+			{
+				timeout: 10000,
+				timeoutMsg: "Expected plot counter to return to latest plot",
+			},
+		);
 	});
 });

--- a/desktop/e2e/webdriver-specs/plot.e2e.ts
+++ b/desktop/e2e/webdriver-specs/plot.e2e.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert";
+import { selectors } from "../shared/selectors";
+import { TEST_CASES } from "../shared/test-registry";
+import { clickRunAll, setEditorValue } from "./helpers";
+
+const openPlotsTab = async (): Promise<void> => {
+	await browser.waitUntil(
+		async () =>
+			browser.execute(() => {
+				const tabs = Array.from(document.querySelectorAll(".tabs .tab"));
+				const plotTab = tabs.find((tab) => tab.textContent?.trim() === "Plots");
+				if (!plotTab) {
+					return false;
+				}
+				(plotTab as HTMLElement).click();
+				return true;
+			}),
+		{ timeout: 10000, timeoutMsg: "Plots tab not available" },
+	);
+};
+
+describe("Plot visualization", () => {
+	it(TEST_CASES.plot[0], async () => {
+		const editorInput = await browser.$(selectors.editor);
+		await editorInput.waitForDisplayed({ timeout: 30000 });
+
+		await setEditorValue("plot(1:10)");
+		await clickRunAll();
+		await openPlotsTab();
+
+		const plotImage = await browser.$(selectors.plotImage);
+		await plotImage.waitForDisplayed({ timeout: 20000 });
+		assert.ok(await plotImage.isDisplayed());
+	});
+
+	it(TEST_CASES.plot[1], async () => {
+		const editorInput = await browser.$(selectors.editor);
+		await editorInput.waitForDisplayed({ timeout: 30000 });
+
+		await setEditorValue("plot(1:10)\nplot(10:1)");
+		await clickRunAll();
+		await openPlotsTab();
+
+		const plotImage = await browser.$(selectors.plotImage);
+		await plotImage.waitForDisplayed({ timeout: 20000 });
+
+		const counter = await browser.$(selectors.plotCounter);
+		await counter.waitForDisplayed({ timeout: 10000 });
+		assert.ok((await counter.getText()).includes("1 / 2"));
+
+		const nextButton = await browser.$(selectors.plotNextButton);
+		await nextButton.click();
+		assert.ok((await counter.getText()).includes("2 / 2"));
+
+		const prevButton = await browser.$(selectors.plotPrevButton);
+		await prevButton.click();
+		assert.ok((await counter.getText()).includes("1 / 2"));
+	});
+});

--- a/desktop/e2e/webdriver-specs/plot.e2e.ts
+++ b/desktop/e2e/webdriver-specs/plot.e2e.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { selectors } from "../shared/selectors";
 import { TEST_CASES } from "../shared/test-registry";
-import { clickRunAll, setEditorValue } from "./helpers";
+import { clickRunAll, setEditorValue, waitForConnected } from "./helpers";
 
 const openPlotsTab = async (): Promise<void> => {
 	await browser.waitUntil(
@@ -20,10 +20,13 @@ const openPlotsTab = async (): Promise<void> => {
 };
 
 describe("Plot visualization", () => {
-	it(TEST_CASES.plot[0], async () => {
+	beforeEach(async () => {
 		const editorInput = await browser.$(selectors.editor);
 		await editorInput.waitForDisplayed({ timeout: 30000 });
+		await waitForConnected();
+	});
 
+	it(TEST_CASES.plot[0], async () => {
 		await setEditorValue("plot(1:10)");
 		await clickRunAll();
 		await openPlotsTab();
@@ -34,9 +37,6 @@ describe("Plot visualization", () => {
 	});
 
 	it(TEST_CASES.plot[1], async () => {
-		const editorInput = await browser.$(selectors.editor);
-		await editorInput.waitForDisplayed({ timeout: 30000 });
-
 		await setEditorValue("plot(1:10)\nplot(10:1)");
 		await clickRunAll();
 		await openPlotsTab();

--- a/desktop/e2e/webdriver-specs/plot.e2e.ts
+++ b/desktop/e2e/webdriver-specs/plot.e2e.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { selectors } from "../shared/selectors";
 import { TEST_CASES } from "../shared/test-registry";
-import { clickRunAll, setEditorValue, waitForConnected } from "./helpers";
+import { clickRunAll, openFixturesProject, setEditorValue, waitForConnected } from "./helpers";
 
 const openPlotsTab = async (): Promise<void> => {
 	await browser.waitUntil(
@@ -20,10 +20,11 @@ const openPlotsTab = async (): Promise<void> => {
 };
 
 describe("Plot visualization", () => {
-	beforeEach(async () => {
+	before(async () => {
 		const editorInput = await browser.$(selectors.editor);
 		await editorInput.waitForDisplayed({ timeout: 30000 });
 		await waitForConnected();
+		await openFixturesProject();
 	});
 
 	it(TEST_CASES.plot[0], async () => {

--- a/desktop/e2e/webdriver-specs/plot.e2e.ts
+++ b/desktop/e2e/webdriver-specs/plot.e2e.ts
@@ -49,11 +49,19 @@ describe("Plot visualization", () => {
 		assert.ok((await counter.getText()).includes("1 / 2"));
 
 		const nextButton = await browser.$(selectors.plotNextButton);
+		await nextButton.waitForEnabled({ timeout: 10000 });
 		await nextButton.click();
-		assert.ok((await counter.getText()).includes("2 / 2"));
+		await browser.waitUntil(async () => (await counter.getText()).includes("2 / 2"), {
+			timeout: 10000,
+			timeoutMsg: "Expected plot counter to move to 2 / 2",
+		});
 
 		const prevButton = await browser.$(selectors.plotPrevButton);
+		await prevButton.waitForEnabled({ timeout: 10000 });
 		await prevButton.click();
-		assert.ok((await counter.getText()).includes("1 / 2"));
+		await browser.waitUntil(async () => (await counter.getText()).includes("1 / 2"), {
+			timeout: 10000,
+			timeoutMsg: "Expected plot counter to return to 1 / 2",
+		});
 	});
 });

--- a/desktop/e2e/webdriver-specs/r-execution.e2e.ts
+++ b/desktop/e2e/webdriver-specs/r-execution.e2e.ts
@@ -1,12 +1,19 @@
 import assert from "node:assert";
-import { clickRunAll, setEditorValue, waitForConnected, waitForConsoleOutput } from "./helpers";
+import {
+	clickRunAll,
+	openFixturesProject,
+	setEditorValue,
+	waitForConnected,
+	waitForConsoleOutput,
+} from "./helpers";
 import { TEST_CASES } from "../shared/test-registry";
 
 describe("R execution flow", () => {
-	beforeEach(async () => {
+	before(async () => {
 		const editorInput = await browser.$(".monaco-editor textarea");
 		await editorInput.waitForDisplayed({ timeout: 30000 });
 		await waitForConnected();
+		await openFixturesProject();
 	});
 
 	it(TEST_CASES["r-execution"][0], async () => {

--- a/desktop/e2e/webdriver-specs/r-execution.e2e.ts
+++ b/desktop/e2e/webdriver-specs/r-execution.e2e.ts
@@ -1,11 +1,15 @@
 import assert from "node:assert";
-import { clickRunAll, setEditorValue, waitForConsoleOutput } from "./helpers";
+import { clickRunAll, setEditorValue, waitForConnected, waitForConsoleOutput } from "./helpers";
 import { TEST_CASES } from "../shared/test-registry";
 
 describe("R execution flow", () => {
-	it(TEST_CASES["r-execution"][0], async () => {
+	beforeEach(async () => {
 		const editorInput = await browser.$(".monaco-editor textarea");
 		await editorInput.waitForDisplayed({ timeout: 30000 });
+		await waitForConnected();
+	});
+
+	it(TEST_CASES["r-execution"][0], async () => {
 		await setEditorValue("x <- 1 + 1\nprint(x)");
 		await clickRunAll();
 
@@ -17,9 +21,6 @@ describe("R execution flow", () => {
 	});
 
 	it(TEST_CASES["r-execution"][1], async () => {
-		const editorInput = await browser.$(".monaco-editor textarea");
-		await editorInput.waitForDisplayed({ timeout: 30000 });
-
 		const code = `x <- 5
 y <- 10
 print(x + y)`;
@@ -34,9 +35,6 @@ print(x + y)`;
 	});
 
 	it(TEST_CASES["r-execution"][2], async () => {
-		const editorInput = await browser.$(".monaco-editor textarea");
-		await editorInput.waitForDisplayed({ timeout: 30000 });
-
 		await setEditorValue('print("Hello, Re-prod!")');
 		await clickRunAll();
 

--- a/desktop/e2e/webdriver-specs/r-execution.e2e.ts
+++ b/desktop/e2e/webdriver-specs/r-execution.e2e.ts
@@ -1,8 +1,6 @@
 import assert from "node:assert";
-import { clickRunAll, setEditorValue } from "./helpers";
+import { clickRunAll, setEditorValue, waitForConsoleOutput } from "./helpers";
 import { TEST_CASES } from "../shared/test-registry";
-
-const consoleOutputSelector = ".console-stdout";
 
 describe("R execution flow", () => {
 	it(TEST_CASES["r-execution"][0], async () => {
@@ -11,26 +9,7 @@ describe("R execution flow", () => {
 		await setEditorValue("x <- 1 + 1\nprint(x)");
 		await clickRunAll();
 
-		await browser.waitUntil(
-			async () => {
-				const texts = await browser.execute(() =>
-					Array.from(document.querySelectorAll(".console-stdout"), (element) =>
-						(element.textContent ?? "").trim(),
-					),
-				);
-				return texts.some((text) => text.includes("[1] 2"));
-			},
-			{
-				timeout: 30000,
-				timeoutMsg: "Expected R execution output to include [1] 2",
-			},
-		);
-
-		const outputs = await browser.execute(() =>
-			Array.from(document.querySelectorAll(".console-stdout"), (element) =>
-				(element.textContent ?? "").trim(),
-			),
-		);
+		const outputs = await waitForConsoleOutput("[1] 2");
 		assert.ok(
 			outputs.some((text) => text.includes("[1] 2")),
 			"Console should show the result [1] 2",
@@ -47,26 +26,7 @@ print(x + y)`;
 		await setEditorValue(code);
 		await clickRunAll();
 
-		await browser.waitUntil(
-			async () => {
-				const texts = await browser.execute(() =>
-					Array.from(document.querySelectorAll(".console-stdout"), (element) =>
-						(element.textContent ?? "").trim(),
-					),
-				);
-				return texts.some((text) => text.includes("[1] 15"));
-			},
-			{
-				timeout: 30000,
-				timeoutMsg: "Expected R execution output to include [1] 15",
-			},
-		);
-
-		const outputs = await browser.execute(() =>
-			Array.from(document.querySelectorAll(".console-stdout"), (element) =>
-				(element.textContent ?? "").trim(),
-			),
-		);
+		const outputs = await waitForConsoleOutput("[1] 15");
 		assert.ok(
 			outputs.some((text) => text.includes("[1] 15")),
 			"Console should show the result [1] 15",
@@ -80,26 +40,7 @@ print(x + y)`;
 		await setEditorValue('print("Hello, Re-prod!")');
 		await clickRunAll();
 
-		await browser.waitUntil(
-			async () => {
-				const texts = await browser.execute(() =>
-					Array.from(document.querySelectorAll(".console-stdout"), (element) =>
-						(element.textContent ?? "").trim(),
-					),
-				);
-				return texts.some((text) => text.includes("Hello, Re-prod!"));
-			},
-			{
-				timeout: 30000,
-				timeoutMsg: "Expected R execution output to include Hello, Re-prod!",
-			},
-		);
-
-		const outputs = await browser.execute(() =>
-			Array.from(document.querySelectorAll(".console-stdout"), (element) =>
-				(element.textContent ?? "").trim(),
-			),
-		);
+		const outputs = await waitForConsoleOutput("Hello, Re-prod!");
 		assert.ok(
 			outputs.some((text) => text.includes("Hello, Re-prod!")),
 			"Console should show formatted output",

--- a/desktop/e2e/webdriver-specs/timeline.e2e.ts
+++ b/desktop/e2e/webdriver-specs/timeline.e2e.ts
@@ -4,6 +4,7 @@ import {
 	closeDialog,
 	openTimelineDialog,
 	setEditorValue,
+	waitForConnected,
 	waitForConsoleOutput,
 } from "./helpers";
 import { TEST_CASES } from "../shared/test-registry";
@@ -13,10 +14,14 @@ const timelineDialogSelector = ".timeline-dialog";
 const timelineEventSelector = ".timeline-event";
 const timelineStatsSelector = ".timeline-stat";
 describe("Timeline feature", () => {
-	it(TEST_CASES["timeline"][0], async () => {
-		// Execute some R code to create timeline events
+	beforeEach(async () => {
 		const editorInput = await browser.$(editorSelector);
 		await editorInput.waitForDisplayed({ timeout: 30000 });
+		await waitForConnected();
+	});
+
+	it(TEST_CASES["timeline"][0], async () => {
+		// Execute some R code to create timeline events
 		await setEditorValue("x <- 1 + 1\nprint(x)");
 
 		// Run the code

--- a/desktop/e2e/webdriver-specs/timeline.e2e.ts
+++ b/desktop/e2e/webdriver-specs/timeline.e2e.ts
@@ -3,6 +3,7 @@ import {
 	clickRunAll,
 	closeDialog,
 	openTimelineDialog,
+	openFixturesProject,
 	setEditorValue,
 	waitForConnected,
 	waitForConsoleOutput,
@@ -14,10 +15,11 @@ const timelineDialogSelector = ".timeline-dialog";
 const timelineEventSelector = ".timeline-event";
 const timelineStatsSelector = ".timeline-stat";
 describe("Timeline feature", () => {
-	beforeEach(async () => {
+	before(async () => {
 		const editorInput = await browser.$(editorSelector);
 		await editorInput.waitForDisplayed({ timeout: 30000 });
 		await waitForConnected();
+		await openFixturesProject();
 	});
 
 	it(TEST_CASES["timeline"][0], async () => {

--- a/desktop/e2e/webdriver-specs/timeline.e2e.ts
+++ b/desktop/e2e/webdriver-specs/timeline.e2e.ts
@@ -1,13 +1,17 @@
 import assert from "node:assert";
-import { clickRunAll, closeDialog, openTimelineDialog, setEditorValue } from "./helpers";
+import {
+	clickRunAll,
+	closeDialog,
+	openTimelineDialog,
+	setEditorValue,
+	waitForConsoleOutput,
+} from "./helpers";
 import { TEST_CASES } from "../shared/test-registry";
 
 const editorSelector = ".monaco-editor textarea";
 const timelineDialogSelector = ".timeline-dialog";
 const timelineEventSelector = ".timeline-event";
 const timelineStatsSelector = ".timeline-stat";
-const consoleOutputSelector = ".console-stdout";
-
 describe("Timeline feature", () => {
 	it(TEST_CASES["timeline"][0], async () => {
 		// Execute some R code to create timeline events
@@ -19,22 +23,7 @@ describe("Timeline feature", () => {
 		await clickRunAll();
 
 		// Wait for execution to complete
-		await browser.waitUntil(
-			async () => {
-				const outputs = await browser.$$(consoleOutputSelector);
-				for (const output of outputs) {
-					const text = await output.getText();
-					if (text.includes("[1] 2")) {
-						return true;
-					}
-				}
-				return false;
-			},
-			{
-				timeout: 30000,
-				timeoutMsg: "Expected code execution to complete",
-			},
-		);
+		await waitForConsoleOutput("[1] 2");
 
 		const timelineDialog = await openTimelineDialog();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@wdio/mocha-framework':
         specifier: ^8.0.0
         version: 8.46.0
+      '@wdio/reporter':
+        specifier: ^8.0.0
+        version: 8.43.0
       '@wdio/spec-reporter':
         specifier: ^8.0.0
         version: 8.43.0


### PR DESCRIPTION
## Description

Adds a minimal AI Agent E2E suite for both Playwright and WebDriver, covering basic UI behavior without requiring a configured provider. Updates shared selectors to match current AI panel elements.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

Not run (not requested).

## Screenshots (if applicable)

N/A

## Related Issues

Closes #390
