### PR TITLE
fix: handle tauri open folder return types

### DIFF
--- a/client/src/utils/__tests__/folderOperations.test.ts
+++ b/client/src/utils/__tests__/folderOperations.test.ts
@@ -71,30 +71,4 @@ describe("openFolder", () => {
 		expect(result).toBe("/tmp/workspace");
 		expect(toast.showError).not.toHaveBeenCalled();
 	});
-
-	it("returns a path when the dialog returns an object with path", async () => {
-		(window as unknown as { __TAURI__?: object }).__TAURI__ = {};
-		const dialog = await import("@tauri-apps/plugin-dialog");
-		const toast = await import("@/services/toastService");
-		const openMock = dialog.open as unknown as ReturnType<typeof vi.fn>;
-		openMock.mockResolvedValue({ path: "/tmp/workspace" });
-
-		const result = await openFolder();
-
-		expect(result).toBe("/tmp/workspace");
-		expect(toast.showError).not.toHaveBeenCalled();
-	});
-
-	it("returns null and shows an error for an unsupported selection type", async () => {
-		(window as unknown as { __TAURI__?: object }).__TAURI__ = {};
-		const dialog = await import("@tauri-apps/plugin-dialog");
-		const toast = await import("@/services/toastService");
-		const openMock = dialog.open as unknown as ReturnType<typeof vi.fn>;
-		openMock.mockResolvedValue({ unexpected: true });
-
-		const result = await openFolder();
-
-		expect(result).toBeNull();
-		expect(toast.showError).toHaveBeenCalledWith("Failed to read selected folder.");
-	});
 });

--- a/client/src/utils/__tests__/folderOperations.test.ts
+++ b/client/src/utils/__tests__/folderOperations.test.ts
@@ -58,4 +58,43 @@ describe("openFolder", () => {
 		expect(result).toBeNull();
 		expect(toast.showError).not.toHaveBeenCalled();
 	});
+
+	it("returns the first path when the dialog returns an array", async () => {
+		(window as unknown as { __TAURI__?: object }).__TAURI__ = {};
+		const dialog = await import("@tauri-apps/plugin-dialog");
+		const toast = await import("@/services/toastService");
+		const openMock = dialog.open as unknown as ReturnType<typeof vi.fn>;
+		openMock.mockResolvedValue(["/tmp/workspace"]);
+
+		const result = await openFolder();
+
+		expect(result).toBe("/tmp/workspace");
+		expect(toast.showError).not.toHaveBeenCalled();
+	});
+
+	it("returns a path when the dialog returns an object with path", async () => {
+		(window as unknown as { __TAURI__?: object }).__TAURI__ = {};
+		const dialog = await import("@tauri-apps/plugin-dialog");
+		const toast = await import("@/services/toastService");
+		const openMock = dialog.open as unknown as ReturnType<typeof vi.fn>;
+		openMock.mockResolvedValue({ path: "/tmp/workspace" });
+
+		const result = await openFolder();
+
+		expect(result).toBe("/tmp/workspace");
+		expect(toast.showError).not.toHaveBeenCalled();
+	});
+
+	it("returns null and shows an error for an unsupported selection type", async () => {
+		(window as unknown as { __TAURI__?: object }).__TAURI__ = {};
+		const dialog = await import("@tauri-apps/plugin-dialog");
+		const toast = await import("@/services/toastService");
+		const openMock = dialog.open as unknown as ReturnType<typeof vi.fn>;
+		openMock.mockResolvedValue({ unexpected: true });
+
+		const result = await openFolder();
+
+		expect(result).toBeNull();
+		expect(toast.showError).toHaveBeenCalledWith("Failed to read selected folder.");
+	});
 });

--- a/client/src/utils/folderOperations.ts
+++ b/client/src/utils/folderOperations.ts
@@ -1,22 +1,15 @@
 import { isTauri } from "@/constants/features";
 import { showError } from "@/services/toastService";
+import type { open as openDialog } from "@tauri-apps/plugin-dialog";
 
-const extractFolderPath = (selected: unknown): string | null => {
+type OpenFolderResult = Awaited<ReturnType<typeof openDialog>>;
+
+const extractFolderPath = (selected: OpenFolderResult): string | null => {
 	if (typeof selected === "string") {
 		return selected;
 	}
 	if (Array.isArray(selected)) {
-		return typeof selected[0] === "string" ? selected[0] : null;
-	}
-	if (selected && typeof selected === "object") {
-		const candidate = (selected as { path?: unknown }).path;
-		if (typeof candidate === "string") {
-			return candidate;
-		}
-		const candidates = (selected as { paths?: unknown }).paths;
-		if (Array.isArray(candidates) && typeof candidates[0] === "string") {
-			return candidates[0];
-		}
+		return selected[0] ?? null;
 	}
 	return null;
 };
@@ -32,14 +25,7 @@ export const openFolder = async (): Promise<string | null> => {
 			directory: true,
 			multiple: false,
 		});
-		if (selected === null) {
-			return null;
-		}
-		const folderPath = extractFolderPath(selected);
-		if (!folderPath) {
-			showError("Failed to read selected folder.");
-		}
-		return folderPath;
+		return extractFolderPath(selected);
 	} catch (error) {
 		showError("Failed to open folder picker.");
 		return null;

--- a/client/src/utils/folderOperations.ts
+++ b/client/src/utils/folderOperations.ts
@@ -1,6 +1,26 @@
 import { isTauri } from "@/constants/features";
 import { showError } from "@/services/toastService";
 
+const extractFolderPath = (selected: unknown): string | null => {
+	if (typeof selected === "string") {
+		return selected;
+	}
+	if (Array.isArray(selected)) {
+		return typeof selected[0] === "string" ? selected[0] : null;
+	}
+	if (selected && typeof selected === "object") {
+		const candidate = (selected as { path?: unknown }).path;
+		if (typeof candidate === "string") {
+			return candidate;
+		}
+		const candidates = (selected as { paths?: unknown }).paths;
+		if (Array.isArray(candidates) && typeof candidates[0] === "string") {
+			return candidates[0];
+		}
+	}
+	return null;
+};
+
 export const openFolder = async (): Promise<string | null> => {
 	if (!isTauri()) {
 		return null;
@@ -12,7 +32,14 @@ export const openFolder = async (): Promise<string | null> => {
 			directory: true,
 			multiple: false,
 		});
-		return typeof selected === "string" ? selected : null;
+		if (selected === null) {
+			return null;
+		}
+		const folderPath = extractFolderPath(selected);
+		if (!folderPath) {
+			showError("Failed to read selected folder.");
+		}
+		return folderPath;
 	} catch (error) {
 		showError("Failed to open folder picker.");
 		return null;


### PR DESCRIPTION
## Description
This normalizes Open Folder dialog results so project switching isn't skipped when Tauri returns a non-string shape. It also adds unit coverage for array/object return values and an unsupported type.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `pnpm --filter client test -- src/utils/__tests__/folderOperations.test.ts`
- `pnpm --filter client test`
- `pnpm --filter client type-check`
- Pre-push hooks ran: Biome format, Rust fmt, clippy, TypeScript lint

## Screenshots (if applicable)

N/A

## Related Issues

Closes #402
