### PR TITLE
Fix ts-rs warnings for serde skip_serializing_if attributes

### DIFF
--- a/core/src/acp/types.rs
+++ b/core/src/acp/types.rs
@@ -53,14 +53,19 @@ pub struct AcpPlanStep {
     pub id: String,
     pub title: String,
     pub status: AcpPlanStepStatus,
+    #[ts(optional = nullable)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<String>,
+    #[ts(optional = nullable)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[ts(optional = nullable)]
     #[serde(skip_serializing_if = "Option::is_none", rename = "startedAt")]
     pub started_at: Option<i64>,
+    #[ts(optional = nullable)]
     #[serde(skip_serializing_if = "Option::is_none", rename = "finishedAt")]
     pub finished_at: Option<i64>,
+    #[ts(optional = nullable)]
     #[serde(skip_serializing_if = "Option::is_none", rename = "waitingReason")]
     pub waiting_reason: Option<String>,
 }
@@ -86,12 +91,13 @@ pub enum AcpSessionUpdate {
         kind: String,
         status: String,
         locations: Vec<String>,
-        #[ts(type = "unknown")]
+        #[ts(optional = nullable, type = "unknown")]
         #[serde(skip_serializing_if = "Option::is_none")]
         input: Option<serde_json::Value>,
-        #[ts(type = "unknown")]
+        #[ts(optional = nullable, type = "unknown")]
         #[serde(skip_serializing_if = "Option::is_none")]
         output: Option<serde_json::Value>,
+        #[ts(optional = nullable)]
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },
@@ -99,12 +105,13 @@ pub enum AcpSessionUpdate {
         id: String,
         status: Option<String>,
         content: Option<String>,
-        #[ts(type = "unknown")]
+        #[ts(optional = nullable, type = "unknown")]
         #[serde(skip_serializing_if = "Option::is_none")]
         input: Option<serde_json::Value>,
-        #[ts(type = "unknown")]
+        #[ts(optional = nullable, type = "unknown")]
         #[serde(skip_serializing_if = "Option::is_none")]
         output: Option<serde_json::Value>,
+        #[ts(optional = nullable)]
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },
@@ -158,6 +165,7 @@ pub struct AcpPermissionDecision {
     pub request_id: String,
     pub outcome: AcpPermissionDecisionOutcome,
     pub option_id: Option<String>,
+    #[ts(optional = nullable)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remember_scope: Option<AcpPermissionDecisionScope>,
 }


### PR DESCRIPTION
## Summary

Resolves ts-rs build warnings by adding `#[ts(optional = nullable)]` attributes to fields using `#[serde(skip_serializing_if = "Option::is_none")]`.

## Problem

During `cargo check` and `cargo build`, ts-rs emitted 12 warnings:

```
warning: failed to parse serde attribute
  |
  | #[serde(skip_serializing_if = "Option::is_none")]
  |
  = note: ts-rs failed to parse this attribute. It will be ignored.
```

These warnings appeared because ts-rs requires explicit `#[ts(optional = nullable)]` attributes to properly handle optional fields with conditional serialization.

## Solution

Added `#[ts(optional = nullable)]` to 12 fields across:
- `AcpPlanStep` struct (5 fields)
- `AcpSessionUpdate::ToolCall` variant (3 fields)
- `AcpSessionUpdate::ToolCallUpdate` variant (3 fields)
- `AcpPermissionDecision` struct (1 field)

## Verification

- ✅ `cargo check` completes with 0 ts-rs warnings (previously 12)
- ✅ TypeScript types maintain correct nullable signatures (`| null`)
- ✅ No breaking changes to serialization/deserialization behavior

## Files Changed

- `core/src/acp/types.rs`

Closes #401