### PR TITLE
Fix: Improve error handling for Open Folder and file tree operations

### DIFF
--- a/client/src/core/commands/modules/file.ts
+++ b/client/src/core/commands/modules/file.ts
@@ -6,6 +6,7 @@ import { useStore } from "@/core/state/store";
 import { useFileSystemStore } from "@/core/fileSystemStore";
 import { socketService } from "@/services/socket";
 import { showError } from "@/services/toastService";
+import { getErrorMessage } from "@/utils/error";
 import { downloadFile, openFile } from "@/utils/fileOperations";
 import { openFolder } from "@/utils/folderOperations";
 import type { ExtractServerMessage } from "@/types";
@@ -103,16 +104,14 @@ export function setupFileCommands() {
 					useFileSystemStore
 						.getState()
 						.resetAndLoadRoot()
-						.catch(() => {
-							// Ignore errors when resetting and loading root; file system may be unavailable or user cancelled.
-							// User experience: File tree may not refresh, but app remains usable.
+						.catch((error) => {
+							showError(getErrorMessage(error, "Failed to refresh file tree"));
 						});
 					return;
 				}
 				useStore.getState().setModalOpen("projectSwitch", true);
 			} catch (error) {
-				// Ignore errors during folder open; user may cancel dialog or folder may be inaccessible.
-				// User experience: No folder is opened, app continues normally.
+				showError(getErrorMessage(error, "Failed to open folder"));
 			}
 		})
 

--- a/client/src/hooks/useFileSystemData.ts
+++ b/client/src/hooks/useFileSystemData.ts
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import { useFileSystemStore } from "@/core/fileSystemStore";
 import { socketService } from "@/services/socket";
+import { showError } from "@/services/toastService";
+import { getErrorMessage } from "@/utils/error";
 import type { ExtractServerMessage } from "@/types";
 
 export function useFileSystemData(): void {
@@ -9,7 +11,9 @@ export function useFileSystemData(): void {
 
 	useEffect(() => {
 		const triggerLoad = (): void => {
-			loadRoot().catch(() => {});
+			loadRoot().catch((error) => {
+				showError(getErrorMessage(error, "Failed to load file tree"));
+			});
 		};
 
 		if (socketService.isConnected()) {


### PR DESCRIPTION
## Description

Replaces silent error handling with user-visible toast notifications for Open Folder and file tree refresh operations, providing better feedback when operations fail.

## Related Issues

Closes #403
Closes #404

## Changes

- **file.ts**: Added error feedback for Open Folder failures
- **file.ts**: Added error feedback for file tree refresh failures after project switch
- **useFileSystemData.ts**: Added error feedback for file tree load failures

## Testing

- [x] Frontend lint passes
- [x] Frontend formatting passes
- [x] Code follows conventions
- [x] Error messages are user-friendly

## Screenshots

N/A