### PR TITLE
Fix: Handle object return type with path property in folder dialog

### DIFF
--- a/client/src/utils/folderOperations.ts
+++ b/client/src/utils/folderOperations.ts
@@ -11,6 +11,9 @@ const extractFolderPath = (selected: OpenFolderResult): string | null => {
 	if (Array.isArray(selected)) {
 		return selected[0] ?? null;
 	}
+	if (selected && typeof selected === "object" && "path" in selected && typeof selected.path === "string") {
+		return selected.path;
+	}
 	return null;
 };
 


### PR DESCRIPTION
## Description

Adds support for object return types with a `.path` property from Tauri's open folder dialog, completing the type normalization that was partially implemented in #409.

The folder dialog can return three different formats depending on platform and Tauri version:
1. String (direct path)
2. Array (multiple selections, we take first)
3. Object with `.path` property (some Tauri versions on macOS)

This PR handles case #3 which was missing.

## Related Issues

Closes #405

## Changes

- **folderOperations.ts**: Added object type handling with `.path` property extraction to `extractFolderPath` function

## Testing

- [x] Code follows conventions
- [x] Handles all three return type formats (string, array, object)
- [x] Type-safe with proper checks

## Screenshots

N/A