### PR TITLE
Fix: Normalize file:// and ~ paths in project switch validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ base64 = "0.22"
 # Directory utilities
 dirs = "5"
 
+# URL parsing
+url = "2.5"
+
 # Config parsing
 toml = "0.8"
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,6 +32,10 @@ tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 
+# Path normalization
+url = { workspace = true }
+dirs = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
 tempfile = "3"

--- a/server/src/handlers/project_requests.rs
+++ b/server/src/handlers/project_requests.rs
@@ -15,6 +15,40 @@ use tokio::sync::mpsc as tokio_mpsc;
 
 use super::runtime_fs::FsWatcherHandle;
 
+/// Normalizes incoming path strings to handle various formats.
+///
+/// Supports:
+/// - file:// URLs (e.g., "file:///Users/me/workspace")
+/// - Tilde expansion (e.g., "~/workspace")
+/// - Regular file paths
+fn normalize_incoming_path(path: &str) -> PathBuf {
+    // Handle file:// URLs
+    if path.starts_with("file://") {
+        // Remove the file:// prefix and decode percent-encoded characters
+        if let Ok(url) = url::Url::parse(path) {
+            if let Ok(path) = url.to_file_path() {
+                return path;
+            }
+        }
+        // Fallback: simple string manipulation if URL parsing fails
+        return PathBuf::from(path.trim_start_matches("file://"));
+    }
+
+    // Handle tilde expansion
+    if path.starts_with("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(&path[2..]);
+        }
+    } else if path == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+
+    // Fallback to treating as regular path
+    PathBuf::from(path)
+}
+
 pub async fn handle_project_request(
     request: &WSRequest,
     state: &AppState,
@@ -29,7 +63,7 @@ pub async fn handle_project_request(
 ) -> Option<bool> {
     match request {
         WSRequest::ProjectSwitchFolder { path } => {
-            let folder_path = Path::new(path);
+            let folder_path = normalize_incoming_path(path);
             if !folder_path.exists() {
                 return Some(
                     send_responses(socket, error_response("Folder does not exist")).await,
@@ -52,7 +86,7 @@ pub async fn handle_project_request(
                     fs_event_tx,
                     fs_events_closed,
                     socket,
-                    folder_path,
+                    &folder_path,
                 )
                 .await,
             )


### PR DESCRIPTION
## Summary
Implements path normalization for `ProjectSwitchFolder` to handle non-canonical path formats.

## Changes
- Added `normalize_incoming_path()` function that:
  - Converts `file://` URLs to standard file paths using `url` crate
  - Expands `~` prefix to user's home directory using `dirs` crate
  - Falls back to treating input as a regular path
- Updated validation logic in `handle_project_request` to normalize paths before validation
- Added `url` and `dirs` dependencies to workspace and server package

## Testing
- Code compiles successfully with `cargo check -p reprod-server`
- Implementation handles all three path formats as specified in the issue

## Related Issues
Closes #407

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] Code follows Rust conventions
- [x] Changes compile without errors
- [x] Commit message references the issue
- [x] Dependencies properly added to Cargo.toml files