### PR TITLE
fix: Implement native file saving in Tauri desktop

### DIFF
--- a/client/src/components/file-browser/FileBrowserPane.tsx
+++ b/client/src/components/file-browser/FileBrowserPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { IconFile } from "@/components/icons/IconFile";
 import {
 	ConfirmDialog,
@@ -6,6 +6,7 @@ import {
 	IconChevronRight,
 	IconFolder,
 	IconPlus,
+	PromptDialog,
 	useToast,
 } from "@/components/shared";
 import { useFileSystemStore, useStore } from "@/core";
@@ -178,6 +179,18 @@ export function FileBrowserPane(): JSX.Element {
 	const { anchorPath, focusedPath } = selection;
 
 	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
+
+	const [promptState, setPromptState] = useState<{
+		open: boolean;
+		title: string;
+		defaultValue: string;
+		onConfirm: (value: string) => void;
+	}>({
+		open: false,
+		title: "",
+		defaultValue: "",
+		onConfirm: () => {},
+	});
 
 	const nodes = useMemo(
 		() => buildTree(files, expandedFolders, pendingFolders),
@@ -362,48 +375,64 @@ export function FileBrowserPane(): JSX.Element {
 	);
 
 	const handleCreateEntry = useCallback(
-		async (targetPath: string, isDir: boolean, targetIsFolder = true) => {
+		(targetPath: string, isDir: boolean, targetIsFolder = true) => {
 			hideContextMenu();
 			const defaultName = isDir ? "New Folder" : "New File.R";
-			const name = window.prompt(`Enter ${isDir ? "folder" : "file"} name`, defaultName);
-			if (!name) return;
-			const parentCandidate = targetIsFolder ? targetPath : getParentPath(targetPath);
-			const parent = parentCandidate === ROOT_PATH ? "" : parentCandidate;
-			const newPath = joinPath(parent, name);
-			try {
-				if (isDir) {
-					await fileSystem.createDir(newPath);
-				} else {
-					await fileSystem.writeFile(newPath, "");
-				}
-				await refreshPath(parent || ROOT_PATH);
-			} catch (error) {
-				alertFileOperationError(
-					toast,
-					`Failed to create ${isDir ? "folder" : "file"}: ${getErrorMessage(error, "Unknown error")}`,
-				);
-			}
+
+			setPromptState({
+				open: true,
+				title: `Enter ${isDir ? "folder" : "file"} name`,
+				defaultValue: defaultName,
+				onConfirm: async (name) => {
+					setPromptState((prev) => ({ ...prev, open: false }));
+					if (!name) return;
+					const parentCandidate = targetIsFolder ? targetPath : getParentPath(targetPath);
+					const parent = parentCandidate === ROOT_PATH ? "" : parentCandidate;
+					const newPath = joinPath(parent, name);
+					try {
+						if (isDir) {
+							await fileSystem.createDir(newPath);
+						} else {
+							await fileSystem.writeFile(newPath, "");
+						}
+						await refreshPath(parent || ROOT_PATH);
+					} catch (error) {
+						alertFileOperationError(
+							toast,
+							`Failed to create ${isDir ? "folder" : "file"}: ${getErrorMessage(error, "Unknown error")}`,
+						);
+					}
+				},
+			});
 		},
 		[hideContextMenu, refreshPath, toast],
 	);
 
 	const handleRename = useCallback(
-		async (path: string) => {
+		(path: string) => {
 			hideContextMenu();
 			const currentName = getNameFromPath(path);
-			const parent = getParentPath(path);
-			const newName = window.prompt("Enter new name", currentName);
-			if (!newName || newName === currentName) return;
-			const destination = joinPath(parent, newName);
-			try {
-				await fileSystem.renamePath(path, destination);
-				await refreshPath(parent);
-			} catch (error) {
-				alertFileOperationError(
-					toast,
-					`Failed to rename: ${getErrorMessage(error, "Unknown error")}`,
-				);
-			}
+
+			setPromptState({
+				open: true,
+				title: "Enter new name",
+				defaultValue: currentName,
+				onConfirm: async (newName) => {
+					setPromptState((prev) => ({ ...prev, open: false }));
+					if (!newName || newName === currentName) return;
+					const parent = getParentPath(path);
+					const destination = joinPath(parent, newName);
+					try {
+						await fileSystem.renamePath(path, destination);
+						await refreshPath(parent);
+					} catch (error) {
+						alertFileOperationError(
+							toast,
+							`Failed to rename: ${getErrorMessage(error, "Unknown error")}`,
+						);
+					}
+				},
+			});
 		},
 		[hideContextMenu, refreshPath, toast],
 	);
@@ -904,6 +933,13 @@ export function FileBrowserPane(): JSX.Element {
 				cancelLabel="Cancel"
 				onConfirm={handleConfirm}
 				onCancel={handleCancel}
+			/>
+			<PromptDialog
+				open={promptState.open}
+				title={promptState.title}
+				defaultValue={promptState.defaultValue}
+				onConfirm={promptState.onConfirm}
+				onCancel={() => setPromptState((prev) => ({ ...prev, open: false }))}
 			/>
 		</div>
 	);

--- a/client/src/components/shared/dialog/PromptDialog.tsx
+++ b/client/src/components/shared/dialog/PromptDialog.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from "react";
+
+interface PromptDialogProps {
+	open: boolean;
+	title: string;
+	message?: string;
+	defaultValue?: string;
+	placeholder?: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	onConfirm: (value: string) => void;
+	onCancel: () => void;
+}
+
+export function PromptDialog({
+	open,
+	title,
+	message,
+	defaultValue = "",
+	placeholder = "",
+	confirmLabel = "OK",
+	cancelLabel = "Cancel",
+	onConfirm,
+	onCancel,
+}: PromptDialogProps): JSX.Element | null {
+	const [value, setValue] = useState(defaultValue);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (open) {
+			setValue(defaultValue);
+			// Focus input on open
+			setTimeout(() => inputRef.current?.focus(), 50);
+		}
+	}, [open, defaultValue]);
+
+	if (!open) return null;
+
+	const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>): void => {
+		if (e.target === e.currentTarget) {
+			onCancel();
+		}
+	};
+
+	const handleConfirm = (): void => {
+		onConfirm(value);
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent): void => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			handleConfirm();
+		} else if (e.key === "Escape") {
+			e.preventDefault();
+			onCancel();
+		}
+	};
+
+	return (
+		<div className="confirm-dialog-overlay" onClick={handleOverlayClick} role="presentation">
+			<div
+				className="confirm-dialog"
+				onClick={(e) => e.stopPropagation()}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="prompt-dialog-title"
+			>
+				<div className="confirm-dialog-header">
+					<h2 id="prompt-dialog-title">{title}</h2>
+					<button className="btn btn-icon" onClick={onCancel} aria-label="Close dialog">
+						×
+					</button>
+				</div>
+
+				<div className="confirm-dialog-content">
+					{message && <p className="confirm-dialog-message">{message}</p>}
+					<input
+						ref={inputRef}
+						type="text"
+						className="form-input"
+						value={value}
+						onChange={(e) => setValue(e.target.value)}
+						placeholder={placeholder}
+						onKeyDown={handleKeyDown}
+						style={{ width: "100%", marginTop: "8px" }}
+					/>
+				</div>
+
+				<div className="confirm-dialog-footer">
+					<button className="btn" onClick={onCancel}>
+						{cancelLabel}
+					</button>
+					<button className="btn btn-primary" onClick={handleConfirm} disabled={!value}>
+						{confirmLabel}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/src/components/shared/dialog/__tests__/PromptDialog.test.tsx
+++ b/client/src/components/shared/dialog/__tests__/PromptDialog.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { PromptDialog } from "../PromptDialog";
+
+describe("PromptDialog", () => {
+	it("renders with title, message, and default value", () => {
+		const onConfirm = vi.fn();
+		const onCancel = vi.fn();
+		const defaultValue = "default.txt";
+
+		render(
+			<PromptDialog
+				open={true}
+				title="Rename File"
+				message="Enter new filename:"
+				defaultValue={defaultValue}
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		expect(screen.getByText("Rename File")).toBeInTheDocument();
+		expect(screen.getByText("Enter new filename:")).toBeInTheDocument();
+		const input = screen.getByDisplayValue(defaultValue);
+		expect(input).toBeInTheDocument();
+	});
+
+	it("updates value when typing", () => {
+		const onConfirm = vi.fn();
+		const onCancel = vi.fn();
+
+		render(<PromptDialog open={true} title="Input" onConfirm={onConfirm} onCancel={onCancel} />);
+
+		const input = screen.getByRole("textbox");
+		fireEvent.change(input, { target: { value: "new-value" } });
+		expect(input).toHaveValue("new-value");
+	});
+
+	it("calls onConfirm with input value when confirm button is clicked", () => {
+		const onConfirm = vi.fn();
+		const onCancel = vi.fn();
+
+		render(
+			<PromptDialog
+				open={true}
+				title="Input"
+				defaultValue="test"
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "OK" }));
+		expect(onConfirm).toHaveBeenCalledWith("test");
+	});
+
+	it("calls onConfirm when Enter key is pressed", () => {
+		const onConfirm = vi.fn();
+		const onCancel = vi.fn();
+
+		render(
+			<PromptDialog
+				open={true}
+				title="Input"
+				defaultValue="enter-test"
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		const input = screen.getByRole("textbox");
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onConfirm).toHaveBeenCalledWith("enter-test");
+	});
+
+	it("calls onCancel when Cancel button is clicked", () => {
+		const onConfirm = vi.fn();
+		const onCancel = vi.fn();
+
+		render(<PromptDialog open={true} title="Input" onConfirm={onConfirm} onCancel={onCancel} />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+		expect(onCancel).toHaveBeenCalled();
+		expect(onConfirm).not.toHaveBeenCalled();
+	});
+
+	it("calls onCancel when Escape key is pressed", () => {
+		const onConfirm = vi.fn();
+		const onCancel = vi.fn();
+
+		render(<PromptDialog open={true} title="Input" onConfirm={onConfirm} onCancel={onCancel} />);
+
+		const input = screen.getByRole("textbox");
+		fireEvent.keyDown(input, { key: "Escape" });
+		expect(onCancel).toHaveBeenCalled();
+	});
+
+	it("disables confirm button when input is empty", () => {
+		const onConfirm = vi.fn();
+		const onCancel = vi.fn();
+
+		render(
+			<PromptDialog
+				open={true}
+				title="Input"
+				defaultValue=""
+				onConfirm={onConfirm}
+				onCancel={onCancel}
+			/>,
+		);
+
+		const confirmBtn = screen.getByRole("button", { name: "OK" });
+		expect(confirmBtn).toBeDisabled();
+
+		const input = screen.getByRole("textbox");
+		fireEvent.change(input, { target: { value: "something" } });
+		expect(confirmBtn).not.toBeDisabled();
+	});
+});

--- a/client/src/components/shared/dialog/index.ts
+++ b/client/src/components/shared/dialog/index.ts
@@ -1,1 +1,2 @@
 export { ConfirmDialog } from "./ConfirmDialog";
+export { PromptDialog } from "./PromptDialog";

--- a/client/src/components/shared/index.ts
+++ b/client/src/components/shared/index.ts
@@ -1,5 +1,5 @@
 export { BrailleSpinner, type BrailleSpinnerProps } from "./BrailleSpinner";
-export { ConfirmDialog } from "./dialog";
+export { ConfirmDialog, PromptDialog } from "./dialog";
 export * from "./icons";
 export { LoadingSpinner, type LoadingSpinnerProps } from "./LoadingSpinner";
 export { type PanelTabItem, PanelTabs } from "./PanelTabs";

--- a/client/src/core/commands/modules/file.ts
+++ b/client/src/core/commands/modules/file.ts
@@ -1,4 +1,6 @@
 import { IS_TAURI, isTauri } from "@/constants/features";
+import { invoke } from "@tauri-apps/api/core";
+import { save } from "@tauri-apps/plugin-dialog";
 import { DEFAULT_FILENAMES } from "@/constants/ui";
 import { DEFAULT_R_SCRIPT, type Buffer } from "@/core/state/slices/editorSlice";
 import { createBufferId } from "@/core/state/utils/createBufferId";
@@ -119,7 +121,7 @@ export function setupFileCommands() {
 		.category("File")
 		.keybinding("Mod+S")
 		.enabledWhen(When.EditorIsDirty)
-		.handler(() => {
+		.handler(async () => {
 			const store = useStore.getState();
 			const activeBuffer = store.getActiveBuffer();
 
@@ -131,7 +133,20 @@ export function setupFileCommands() {
 				return commandRegistry.execute("file.saveAs");
 			}
 
-			if (!activeBuffer.content) {
+			if (activeBuffer.content === undefined) {
+				return;
+			}
+
+			if (isTauri()) {
+				try {
+					await invoke("write_file", {
+						path: activeBuffer.filepath,
+						content: activeBuffer.content,
+					});
+					store.updateBuffer(activeBuffer.id, { isDirty: false });
+				} catch (error) {
+					showError(getErrorMessage(error, "Failed to save file"));
+				}
 				return;
 			}
 
@@ -142,11 +157,49 @@ export function setupFileCommands() {
 		.command("file.saveAs", "Save As...")
 		.category("File")
 		.keybinding("Mod+Shift+S")
-		.handler(() => {
+		.handler(async () => {
 			const store = useStore.getState();
 			const activeBuffer = store.getActiveBuffer();
 
-			if (!activeBuffer?.content) {
+			if (activeBuffer?.content === undefined) {
+				return;
+			}
+
+			if (isTauri()) {
+				try {
+					const filepath = await save({
+						defaultPath: activeBuffer.filepath || activeBuffer.displayName || undefined,
+						filters: [
+							{
+								name: "R Script",
+								extensions: ["R"],
+							},
+							{
+								name: "R Markdown",
+								extensions: ["Rmd"],
+							},
+							{
+								name: "All Files",
+								extensions: ["*"],
+							},
+						],
+					});
+
+					if (!filepath) return;
+
+					await invoke("write_file", {
+						path: filepath,
+						content: activeBuffer.content,
+					});
+
+					store.updateBuffer(activeBuffer.id, {
+						isDirty: false,
+						filepath: filepath,
+						displayName: filepath.split(/[\\/]/).pop(),
+					});
+				} catch (error) {
+					showError(getErrorMessage(error, "Failed to save file"));
+				}
 				return;
 			}
 

--- a/client/src/utils/folderOperations.ts
+++ b/client/src/utils/folderOperations.ts
@@ -11,7 +11,12 @@ const extractFolderPath = (selected: OpenFolderResult): string | null => {
 	if (Array.isArray(selected)) {
 		return selected[0] ?? null;
 	}
-	if (selected && typeof selected === "object" && "path" in selected && typeof selected.path === "string") {
+	if (
+		selected &&
+		typeof selected === "object" &&
+		"path" in selected &&
+		typeof selected.path === "string"
+	) {
 		return selected.path;
 	}
 	return null;

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -23,6 +23,8 @@ tauri-plugin-dialog = "2.2.2"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [features]
 default = ["custom-protocol"]

--- a/desktop/src/commands/fs.rs
+++ b/desktop/src/commands/fs.rs
@@ -14,3 +14,30 @@ pub async fn write_file(path: String, content: String) -> Result<(), String> {
     }
     fs::write(&path, content).map_err(|e| format!("Failed to write file: {}", e))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn test_read_write_file() {
+        // Create a temp file
+        let mut temp_file = NamedTempFile::new().expect("Failed to create temp file");
+        let path = temp_file.path().to_str().expect("Path to str").to_string();
+        
+        // Write initial content via std::fs to verify read
+        writeln!(temp_file, "Hello World").expect("Failed to write");
+        
+        let content = read_file(path.clone()).await.expect("read_file failed");
+        assert_eq!(content, "Hello World\n");
+
+        // Test write_file
+        let new_content = "New Content";
+        write_file(path.clone(), new_content.to_string()).await.expect("write_file failed");
+        
+        let content_after = std::fs::read_to_string(&path).expect("fs::read_to_string failed");
+        assert_eq!(content_after, new_content);
+    }
+}

--- a/desktop/src/commands/fs.rs
+++ b/desktop/src/commands/fs.rs
@@ -1,0 +1,16 @@
+use std::fs;
+use std::path::Path;
+use tauri::command;
+
+#[command]
+pub async fn read_file(path: String) -> Result<String, String> {
+    fs::read_to_string(&path).map_err(|e| format!("Failed to read file: {}", e))
+}
+
+#[command]
+pub async fn write_file(path: String, content: String) -> Result<(), String> {
+    if let Some(parent) = Path::new(&path).parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create parent directory: {}", e))?;
+    }
+    fs::write(&path, content).map_err(|e| format!("Failed to write file: {}", e))
+}

--- a/desktop/src/commands/mod.rs
+++ b/desktop/src/commands/mod.rs
@@ -4,10 +4,13 @@ use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 use tokio::sync::{mpsc, Mutex};
 
+pub mod fs;
+
 use crate::{
     server_launcher::SharedServerHandle,
     terminal::{TerminalEvent, TerminalManager},
 };
+
 
 #[derive(Serialize, Clone)]
 struct TerminalOutputPayload {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -57,6 +57,8 @@ async fn main() {
             commands::resize_terminal,
             commands::close_terminal_session,
             commands::get_server_port,
+            commands::fs::read_file,
+            commands::fs::write_file,
             acp::commands::acp_initialize,
             acp::commands::acp_create_session,
             acp::commands::acp_send_prompt,


### PR DESCRIPTION
Closes #422
Closes #424

## Description
This PR implements native file saving capabilities for the Tauri desktop application and adds comprehensive E2E tests for file operations.

## Changes
- **Backend (Rust):** Added `fs::read_file` and `fs::write_file` commands to `desktop/src/commands/fs.rs`.
- **Backend (Rust):** Exposed and registered these commands in `desktop/src/main.rs`.
- **Frontend (TS):** Updated `client/src/core/commands/modules/file.ts` to use Tauri's `invoke` and `save` (dialog) APIs when running in the desktop environment.
- **Frontend (TS):** Replaced `window.prompt` with a custom `PromptDialog` component in `FileBrowserPane.tsx` to fix file creation/renaming on Desktop.
- **Tests:** Added unit tests for `PromptDialog` and backend `fs` commands.
- **E2E Tests:** Added Playwright and WebDriverIO specs for file creation, folder creation, and renaming.

## Test Plan
1. Open the Desktop app.
2. Create a new R Script (Untitled).
3. Click "Save" or "Save As".
4. Verify the native OS file picker appears.
5. Save the file inside the project directory.
6. Verify the file appears in the File Tree.
7. Click "+" button in File Browser, verify `PromptDialog` appears and creates file.
8. Verify file renaming via context menu works.