### PR TITLE
feat: Add copy button to chat messages (#425)

### DIFF
--- a/client/src/components/ai-panel/AIPanel.tsx
+++ b/client/src/components/ai-panel/AIPanel.tsx
@@ -6,6 +6,7 @@ import { useSettingsStore } from "@/core/state/slices/settingsStore";
 import { resolveProviderMetadata } from "@/domain/provider/ProviderMetadata";
 import { useAIConversation } from "@/hooks/useAIConversation";
 import type { AIMode } from "@/types";
+import { CopyButton } from "./CopyButton";
 import { ProviderIcon } from "./ProviderIcon";
 import { ProviderSwitcher } from "./ProviderSwitcher";
 import { StreamingMessage } from "./StreamingMessage";
@@ -172,6 +173,7 @@ export const AIPanel = forwardRef<AIPanelRef, AIPanelProps>(({ hasConfiguredProv
 								) : (
 									<div key={message.id} className="message message-user">
 										<div className="message-content">{message.content}</div>
+										<CopyButton text={message.content} className="message-copy-btn" />
 									</div>
 								),
 							)}

--- a/client/src/components/ai-panel/CopyButton.tsx
+++ b/client/src/components/ai-panel/CopyButton.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { IconCheck, IconClipboard } from "@/components/shared";
+
+interface CopyButtonProps {
+	text: string;
+	className?: string;
+}
+
+const COPY_FEEDBACK_DURATION = 2000; // 2 seconds as specified in issue #425
+
+export function CopyButton({ text, className = "" }: CopyButtonProps): JSX.Element {
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = (): void => {
+		navigator.clipboard
+			.writeText(text)
+			.then(() => {
+				setCopied(true);
+				setTimeout(() => setCopied(false), COPY_FEEDBACK_DURATION);
+			})
+			.catch(() => {
+				// Intentionally ignored: Clipboard write failures are silent.
+				// The copy button simply won't show success feedback if it fails.
+			});
+	};
+
+	return (
+		<button
+			type="button"
+			className={`icon-btn copy-btn ${className}`}
+			onClick={handleCopy}
+			title={copied ? "Copied!" : "Copy to clipboard"}
+			aria-label={copied ? "Copied to clipboard" : "Copy to clipboard"}
+		>
+			{copied ? (
+				<IconCheck width={16} height={16} aria-hidden />
+			) : (
+				<IconClipboard width={16} height={16} aria-hidden />
+			)}
+		</button>
+	);
+}

--- a/client/src/components/ai-panel/StreamingMessage.tsx
+++ b/client/src/components/ai-panel/StreamingMessage.tsx
@@ -12,6 +12,7 @@ import { classNames } from "@/utils/classNames";
 import { AIPlanCard } from "./AIPlanCard";
 import { AgentEventStream } from "./AgentEventStream";
 import { CodeBlockWithApply } from "./CodeBlockWithApply";
+import { CopyButton } from "./CopyButton";
 import { FileAccessIndicator } from "./FileAccessIndicator";
 import { ToolCallLog } from "./ToolCallLog";
 import "github-markdown-css/github-markdown.css";
@@ -194,6 +195,7 @@ export function StreamingMessage({ message, onApplyCode }: Props): JSX.Element {
 					</div>
 				)}
 			</div>
+			{displayContent && <CopyButton text={displayContent} className="message-copy-btn" />}
 
 			{isAssistant && (
 				<>

--- a/client/src/css/components/ai-panel/message.css
+++ b/client/src/css/components/ai-panel/message.css
@@ -95,6 +95,7 @@
 	flex-direction: column;
 	gap: 8px;
 	max-width: 100%;
+	position: relative;
 }
 
 .message-user {
@@ -106,6 +107,27 @@
 	margin-bottom: 16px;
 	color: var(--text-primary);
 	box-shadow: none;
+}
+
+/* Copy button - hidden by default, shown on hover */
+.message-copy-btn {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	opacity: 0;
+	transition: opacity 0.15s ease;
+	background-color: var(--bg-primary);
+	border: 1px solid var(--border-medium);
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.message:hover .message-copy-btn {
+	opacity: 1;
+}
+
+.message-copy-btn:hover {
+	background-color: var(--border-faint);
+	border-color: var(--border-strong);
 }
 
 .message-assistant {


### PR DESCRIPTION
## Description

Implements copy-to-clipboard functionality for chat messages in the AI Panel. Users can now easily copy both their prompts and AI responses by clicking a copy button that appears on hover.

## Related Issue

Closes #425

## Changes

- Create reusable `CopyButton` component with icon swap feedback (IconClipboard → IconCheck)
- Add copy button to user messages in `AIPanel.tsx`
- Add copy button to AI assistant messages in `StreamingMessage.tsx`
- Implement CSS hover effects to show copy button only on message hover
- Use 2-second feedback duration for visual confirmation

## Technical Details

**Component Architecture:**
- `CopyButton` component handles clipboard API interaction
- Uses React `useState` for managing copied state
- Gracefully handles clipboard API failures with silent error handling
- Icon swap provides immediate visual feedback (2 seconds)

**UI/UX:**
- Copy button positioned absolutely in top-right corner of messages
- Hidden by default, shown on message hover (ghost button style)
- Consistent with existing button styling (`icon-btn` class)
- Accessible with proper ARIA labels

**Files Modified:**
- `client/src/components/ai-panel/CopyButton.tsx` (new)
- `client/src/components/ai-panel/AIPanel.tsx`
- `client/src/components/ai-panel/StreamingMessage.tsx`
- `client/src/css/components/ai-panel/message.css`

## Testing

Manual testing completed:
- ✅ Copy button appears on hover for user messages
- ✅ Copy button appears on hover for AI messages
- ✅ Clicking copies message content to clipboard
- ✅ Icon swaps to checkmark for 2 seconds
- ✅ Button styling matches existing UI patterns
- ✅ Hover effects work correctly

## Screenshots

N/A - Feature requires manual interaction testing