### PR TITLE
feat: add agent session approvals (#417)

### DIFF
--- a/client/src/core/state/__tests__/store.test.ts
+++ b/client/src/core/state/__tests__/store.test.ts
@@ -44,6 +44,9 @@ describe("Zustand Store", () => {
 				messages: [],
 				isLoading: false,
 				suggestions: [],
+				patchMatchFailures: 0,
+				patchMatchStatus: { lastFailureId: null, lastFailureReason: null },
+				agentSessionId: null,
 			},
 			settings: {
 				autoRun: false,

--- a/client/src/core/state/slices/aiSlice.ts
+++ b/client/src/core/state/slices/aiSlice.ts
@@ -118,6 +118,7 @@ export interface AIState {
 		suggestions: string[];
 		patchMatchFailures: number;
 		patchMatchStatus: PatchMatchStatus;
+		agentSessionId: string | null;
 	};
 	aiPanelRef: { focusInput: () => void } | null;
 	setAIPanelRef: (ref: { focusInput: () => void } | null) => void;
@@ -126,6 +127,7 @@ export interface AIState {
 	clearAIMessages: () => void;
 	setAIMessages: (messages: AIMessage[]) => void;
 	setAISuggestions: (suggestions: string[]) => void;
+	setAgentSessionId: (agentSessionId: string | null) => void;
 	recordPatchMatchFailure: (reason: string, id: string) => void;
 	recordPatchMatchSuccess: () => void;
 	startStreamingMessage: (streamingId: string, mode?: AIMode) => void;
@@ -149,6 +151,7 @@ export const createAISlice: StateCreator<AIState> = (set) => ({
 		suggestions: [],
 		patchMatchFailures: 0,
 		patchMatchStatus: { lastFailureId: null, lastFailureReason: null },
+		agentSessionId: null,
 	},
 	aiPanelRef: null,
 	setAIPanelRef: (ref) => set({ aiPanelRef: ref }),
@@ -166,7 +169,7 @@ export const createAISlice: StateCreator<AIState> = (set) => ({
 		})),
 	clearAIMessages: () =>
 		set((state) => ({
-			ai: { ...state.ai, messages: [] },
+			ai: { ...state.ai, messages: [], agentSessionId: null },
 		})),
 	setAISuggestions: (suggestions) =>
 		set((state) => ({
@@ -188,6 +191,13 @@ export const createAISlice: StateCreator<AIState> = (set) => ({
 			ai: {
 				...state.ai,
 				patchMatchStatus: { lastFailureId: null, lastFailureReason: null },
+			},
+		})),
+	setAgentSessionId: (agentSessionId) =>
+		set((state) => ({
+			ai: {
+				...state.ai,
+				agentSessionId,
 			},
 		})),
 	startStreamingMessage: (streamingId, mode) =>

--- a/client/src/hooks/__tests__/useAIConversation.test.ts
+++ b/client/src/hooks/__tests__/useAIConversation.test.ts
@@ -66,6 +66,7 @@ describe("useAIConversation", () => {
 	const mockCompleteStreamingMessage = vi.fn();
 	const mockUpdateBuffer = vi.fn();
 	const mockRegisterPendingEdit = vi.fn();
+	const mockSetAgentSessionId = vi.fn();
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -76,6 +77,7 @@ describe("useAIConversation", () => {
 				ai: {
 					messages: [],
 					isLoading: false,
+					agentSessionId: null,
 				},
 				activeMode: "agent",
 				activeAgent: null,
@@ -83,6 +85,7 @@ describe("useAIConversation", () => {
 				startStreamingMessage: mockStartStreamingMessage,
 				setAILoading: mockSetAILoading,
 				completeStreamingMessage: mockCompleteStreamingMessage,
+				setAgentSessionId: mockSetAgentSessionId,
 				getActiveBuffer: () => ({ id: "buf1", content: "x <- 1", filepath: "test.R" }),
 				updateBuffer: mockUpdateBuffer,
 				execution: { results: [] },

--- a/client/src/hooks/useAIConversation.ts
+++ b/client/src/hooks/useAIConversation.ts
@@ -55,11 +55,13 @@ export function useAIConversation() {
 	const isLoading = useStore((state) => state.ai.isLoading);
 	const activeMode = useStore((state) => state.activeMode);
 	const activeAgent = useStore((state) => state.activeAgent);
+	const agentSessionId = useStore((state) => state.ai.agentSessionId);
 
 	const addAIMessage = useStore((state) => state.addAIMessage);
 	const startStreamingMessage = useStore((state) => state.startStreamingMessage);
 	const setAILoading = useStore((state) => state.setAILoading);
 	const completeStreamingMessage = useStore((state) => state.completeStreamingMessage);
+	const setAgentSessionId = useStore((state) => state.setAgentSessionId);
 	const activeBuffer = useStore((state) => state.getActiveBuffer());
 	const updateBuffer = useStore((state) => state.updateBuffer);
 	const editorContent = activeBuffer?.content ?? "";
@@ -121,6 +123,15 @@ export function useAIConversation() {
 		}
 		activeRequestRef.current = null;
 	}, []);
+
+	const ensureAgentSessionId = useCallback((): string => {
+		if (agentSessionId) {
+			return agentSessionId;
+		}
+		const nextId = createRequestId();
+		setAgentSessionId(nextId);
+		return nextId;
+	}, [agentSessionId, setAgentSessionId]);
 
 	useEffect(() => {
 		return () => {
@@ -467,6 +478,7 @@ export function useAIConversation() {
 
 			const sent = socketService.send(
 				aiMessages.send(requestMessages, {
+					agentSessionId: ensureAgentSessionId(),
 					requestId,
 					stream: true,
 					enableTools,
@@ -499,6 +511,7 @@ export function useAIConversation() {
 			editorContent,
 			editorFilepath,
 			ensureAcpSession,
+			ensureAgentSessionId,
 			externalAgentClient,
 			input,
 			messages,

--- a/client/src/services/messageBuilders.ts
+++ b/client/src/services/messageBuilders.ts
@@ -61,7 +61,8 @@ export const plotHistoryMessages = {
 export const aiMessages = {
 	send: (
 		messages: ChatMessagePayload[],
-		options?: {
+		options: {
+			agentSessionId: string;
 			enableTools?: boolean;
 			requestId?: string;
 			stream?: boolean;
@@ -70,10 +71,11 @@ export const aiMessages = {
 	): Extract<ClientMessage, { type: "ai_message" }> => ({
 		type: "ai_message",
 		messages,
-		enable_tools: options?.enableTools,
-		request_id: options?.requestId,
-		stream: options?.stream,
-		mode: options?.mode,
+		agent_session_id: options.agentSessionId,
+		enable_tools: options.enableTools,
+		request_id: options.requestId,
+		stream: options.stream,
+		mode: options.mode,
 	}),
 	approvalDecision: (
 		decision: ApprovalResponse,

--- a/client/src/types/ws.ts
+++ b/client/src/types/ws.ts
@@ -100,6 +100,7 @@ export type ClientMessage =
 	| {
 			type: "ai_message";
 			messages: ChatMessagePayload[];
+			agent_session_id: string;
 			enable_tools?: boolean;
 			request_id?: string;
 			stream?: boolean;

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -20,8 +20,8 @@ use super::{
     common::{
         build_streaming_payload, error_response, now_millis, tool_log_from_call, with_system_prompts,
         AgentEventPayload, AgentEventStatus, AIMode, AppState, ApprovalDecisionPayload,
-        ApprovalOption, ApprovalRequestPayload, ArtifactDetailsPayload, ArtifactKind, ToolLogStatus,
-        ToolPreviewPayload, WSResponse,
+        ApprovalOption, ApprovalRequestPayload, ApprovalRule, ArtifactDetailsPayload, ArtifactKind,
+        ToolLogStatus, ToolPreviewPayload, WSResponse,
     },
     tool_handler::execute_ai_tool_call,
 };
@@ -83,6 +83,41 @@ fn extract_path_from_input(input: &serde_json::Value) -> Option<String> {
         .get("path")
         .and_then(|value| value.as_str())
         .map(|value| value.to_string())
+}
+
+fn normalize_relative_path(path: &str) -> Option<String> {
+    use std::path::Component;
+    let mut parts = Vec::new();
+    let path = std::path::Path::new(path);
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    Some(parts.join("/"))
+}
+
+fn approval_prefix_from_path(path: &str) -> Option<String> {
+    let normalized = normalize_relative_path(path)?;
+    if let Some((parent, _)) = normalized.rsplit_once('/') {
+        if !parent.is_empty() {
+            return Some(parent.to_string());
+        }
+    }
+    Some(normalized)
+}
+
+fn build_approval_rule(tool: &str, path: Option<&str>) -> Option<ApprovalRule> {
+    let path_prefix = path.and_then(approval_prefix_from_path);
+    Some(ApprovalRule {
+        tool: tool.to_string(),
+        path_prefix,
+    })
 }
 
 fn build_diff(path: &str, old_text: &str, new_text: &str) -> String {
@@ -280,6 +315,7 @@ pub(super) async fn handle_ai_message(
     state: &AppState,
     runtime: &Arc<ProjectRuntime>,
     messages: Vec<ChatMessage>,
+    agent_session_id: String,
     enable_tools: bool,
     request_id: Option<String>,
     stream: bool,
@@ -338,10 +374,19 @@ pub(super) async fn handle_ai_message(
 
                 for tool_call in tool_calls {
                     let mut tool_call = tool_call.clone();
+                    let normalized_path = extract_path_from_input(&tool_call.input)
+                        .and_then(|path| normalize_relative_path(&path));
+                    let approval_rule =
+                        build_approval_rule(&tool_call.name, normalized_path.as_deref());
                     let requires_approval = tool_requires_approval(&tool_call.name)
                         && !state
                             .approvals
-                            .is_allowed(&stream_id, &tool_call.name)
+                            .is_allowed(
+                                &agent_session_id,
+                                &tool_call.name,
+                                normalized_path.as_deref(),
+                                &runtime.descriptor.root_path,
+                            )
                             .await;
                     let request_event_id = event_stream.next_event_id();
                     let task_event_id = event_stream.next_event_id();
@@ -420,10 +465,19 @@ pub(super) async fn handle_ai_message(
                                 );
                             }
                             ApprovalOption::ApproveSession => {
-                                state
-                                    .approvals
-                                    .allow_for_session(&stream_id, &tool_call.name)
-                                    .await;
+                                if let Some(rule) = approval_rule.clone() {
+                                    state
+                                        .approvals
+                                        .allow_for_session(&agent_session_id, rule.clone())
+                                        .await;
+                                    if let Err(err) = state
+                                        .approvals
+                                        .allow_persistent(&runtime.descriptor.root_path, rule)
+                                        .await
+                                    {
+                                        tracing::warn!("Failed to persist approval: {}", err);
+                                    }
+                                }
                                 event_stream.emit(
                                     &mut responses,
                                     AgentEventPayload::ToolRequest {

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
     sync::{atomic::AtomicU64, Arc, OnceLock},
 };
 
@@ -96,6 +97,7 @@ pub(super) enum WSRequest {
     #[serde(rename = "ai_message")]
     AIMessage {
         messages: Vec<ChatMessage>,
+        agent_session_id: String,
         #[serde(default)]
         enable_tools: bool,
         #[serde(default)]
@@ -381,9 +383,38 @@ pub(super) struct ApprovalDecisionPayload {
     pub edited_input: Option<Value>,
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
+pub(super) struct ApprovalRule {
+    pub tool: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path_prefix: Option<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PersistentApprovalFile {
+    version: u32,
+    approvals: Vec<ApprovalRule>,
+}
+
+const APPROVALS_SCHEMA_VERSION: u32 = 1;
+
+fn rule_matches(rule: &ApprovalRule, tool: &str, path: Option<&str>) -> bool {
+    if rule.tool != tool {
+        return false;
+    }
+    match (&rule.path_prefix, path) {
+        (Some(prefix), Some(path)) => {
+            path == prefix || path.starts_with(&format!("{}/", prefix))
+        }
+        (None, None) => true,
+        _ => false,
+    }
+}
+
 pub struct ApprovalManager {
     pending: Mutex<HashMap<String, oneshot::Sender<ApprovalDecisionPayload>>>,
-    session_allowlist: Mutex<HashMap<String, HashSet<String>>>,
+    session_allowlist: Mutex<HashMap<String, HashSet<ApprovalRule>>>,
+    persistent_allowlist: Mutex<HashMap<String, HashSet<ApprovalRule>>>,
 }
 
 impl ApprovalManager {
@@ -391,6 +422,7 @@ impl ApprovalManager {
         Self {
             pending: Mutex::new(HashMap::new()),
             session_allowlist: Mutex::new(HashMap::new()),
+            persistent_allowlist: Mutex::new(HashMap::new()),
         }
     }
 
@@ -415,20 +447,149 @@ impl ApprovalManager {
         }
     }
 
-    pub(super) async fn is_allowed(&self, stream_id: &str, tool: &str) -> bool {
-        let allowlist = self.session_allowlist.lock().await;
-        allowlist
-            .get(stream_id)
-            .map(|tools| tools.contains(tool))
-            .unwrap_or(false)
+    pub(super) async fn is_allowed(
+        &self,
+        agent_session_id: &str,
+        tool: &str,
+        path: Option<&str>,
+        project_root: &Path,
+    ) -> bool {
+        let session_allowed = {
+            let allowlist = self.session_allowlist.lock().await;
+            allowlist
+                .get(agent_session_id)
+                .map(|rules| rules.iter().any(|rule| rule_matches(rule, tool, path)))
+                .unwrap_or(false)
+        };
+        if session_allowed {
+            return true;
+        }
+
+        let persistent = self.load_persistent_allowlist(project_root).await;
+        persistent
+            .iter()
+            .any(|rule| rule_matches(rule, tool, path))
     }
 
-    pub(super) async fn allow_for_session(&self, stream_id: &str, tool: &str) {
+    pub(super) async fn allow_for_session(&self, agent_session_id: &str, rule: ApprovalRule) {
         let mut allowlist = self.session_allowlist.lock().await;
         allowlist
-            .entry(stream_id.to_string())
+            .entry(agent_session_id.to_string())
             .or_default()
-            .insert(tool.to_string());
+            .insert(rule);
+    }
+
+    pub(super) async fn allow_persistent(
+        &self,
+        project_root: &Path,
+        rule: ApprovalRule,
+    ) -> Result<(), String> {
+        let key = project_root.to_string_lossy().to_string();
+        let _ = self.load_persistent_allowlist(project_root).await;
+        let mut allowlist = self.persistent_allowlist.lock().await;
+        let entry = allowlist.entry(key).or_insert_with(HashSet::new);
+        if entry.insert(rule) {
+            Self::save_persistent_allowlist(project_root, entry).map_err(|err| err.to_string())?;
+        }
+        Ok(())
+    }
+
+    async fn load_persistent_allowlist(
+        &self,
+        project_root: &Path,
+    ) -> HashSet<ApprovalRule> {
+        let key = project_root.to_string_lossy().to_string();
+        {
+            let allowlist = self.persistent_allowlist.lock().await;
+            if let Some(rules) = allowlist.get(&key) {
+                return rules.clone();
+            }
+        }
+
+        let loaded = Self::read_persistent_allowlist(project_root).unwrap_or_default();
+        let mut allowlist = self.persistent_allowlist.lock().await;
+        allowlist.insert(key, loaded.clone());
+        loaded
+    }
+
+    fn read_persistent_allowlist(project_root: &Path) -> Result<HashSet<ApprovalRule>, String> {
+        let path = Self::persistent_allowlist_path(project_root)?;
+        if !path.exists() {
+            return Ok(HashSet::new());
+        }
+        let content = std::fs::read_to_string(&path)
+            .map_err(|err| format!("Failed to read approvals: {}", err))?;
+        let parsed: PersistentApprovalFile = serde_json::from_str(&content)
+            .map_err(|err| format!("Failed to parse approvals: {}", err))?;
+        if parsed.version != APPROVALS_SCHEMA_VERSION {
+            return Err("Unsupported approvals schema version".to_string());
+        }
+        Ok(parsed.approvals.into_iter().collect())
+    }
+
+    fn save_persistent_allowlist(
+        project_root: &Path,
+        approvals: &HashSet<ApprovalRule>,
+    ) -> Result<(), String> {
+        let path = Self::persistent_allowlist_path(project_root)?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|err| format!("Failed to create approvals dir: {}", err))?;
+        }
+        let payload = PersistentApprovalFile {
+            version: APPROVALS_SCHEMA_VERSION,
+            approvals: approvals.iter().cloned().collect(),
+        };
+        let content = serde_json::to_string_pretty(&payload)
+            .map_err(|err| format!("Failed to serialize approvals: {}", err))?;
+        std::fs::write(&path, content)
+            .map_err(|err| format!("Failed to write approvals: {}", err))?;
+        Ok(())
+    }
+
+    fn persistent_allowlist_path(project_root: &Path) -> Result<PathBuf, String> {
+        Ok(project_root.join(".reprod").join("approvals.json"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn matches_prefix_rules() {
+        let rule = ApprovalRule {
+            tool: "write_text_file".to_string(),
+            path_prefix: Some("src".to_string()),
+        };
+        assert!(rule_matches(&rule, "write_text_file", Some("src/app.ts")));
+        assert!(rule_matches(&rule, "write_text_file", Some("src")));
+        assert!(!rule_matches(&rule, "write_text_file", Some("src2/app.ts")));
+        assert!(!rule_matches(&rule, "write_text_file", None));
+        assert!(!rule_matches(&rule, "edit_text_file", Some("src/app.ts")));
+    }
+
+    #[tokio::test]
+    async fn persists_and_loads_approvals() {
+        let temp = tempdir().unwrap();
+        let root = temp.path();
+        let manager = ApprovalManager::new();
+        let rule = ApprovalRule {
+            tool: "write_text_file".to_string(),
+            path_prefix: Some("src".to_string()),
+        };
+
+        manager
+            .allow_persistent(root, rule.clone())
+            .await
+            .expect("persist rule");
+
+        let manager = ApprovalManager::new();
+        let allowed = manager
+            .is_allowed("session-1", "write_text_file", Some("src/app.ts"), root)
+            .await;
+        assert!(allowed);
     }
 }
 

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -217,6 +217,7 @@ async fn handle_ws_text(
                 match request {
                     WSRequest::AIMessage {
                         messages,
+                        agent_session_id,
                         enable_tools,
                         request_id,
                         stream,
@@ -230,6 +231,7 @@ async fn handle_ws_text(
                                 &state,
                                 &runtime,
                                 messages,
+                                agent_session_id,
                                 enable_tools,
                                 request_id,
                                 stream,
@@ -271,6 +273,7 @@ async fn handle_ws_request(
     match request {
         WSRequest::AIMessage {
             messages,
+            agent_session_id,
             enable_tools,
             request_id,
             stream,
@@ -280,6 +283,7 @@ async fn handle_ws_request(
                 state,
                 runtime,
                 messages,
+                agent_session_id,
                 enable_tools,
                 request_id,
                 stream,


### PR DESCRIPTION
## Description

Add API-key agent session scoping with persistent approvals stored under the project `.reprod` directory. The client now sends a per-thread `agent_session_id`, and server approvals are matched by tool + path prefix and can persist across requests.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

Not run (unit tests not executed in this branch).

## Screenshots (if applicable)

N/A

## Related Issues

Closes #417
