### PR TITLE
feat: add API-key staged edit parity (#420)

### DIFF
--- a/client/src/hooks/__tests__/useAssistantEventAdapter.test.ts
+++ b/client/src/hooks/__tests__/useAssistantEventAdapter.test.ts
@@ -2,10 +2,15 @@ import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { useAssistantEventAdapter } from "../useAssistantEventAdapter";
 import { useStore } from "@/core";
+import { useFileSystemStore } from "@/core/fileSystemStore";
 
 // Mock dependencies
 vi.mock("@/core", () => ({
 	useStore: vi.fn(),
+}));
+
+vi.mock("@/core/fileSystemStore", () => ({
+	useFileSystemStore: vi.fn(),
 }));
 
 describe("useAssistantEventAdapter", () => {
@@ -16,6 +21,8 @@ describe("useAssistantEventAdapter", () => {
 	const mockRecordToolEvent = vi.fn();
 	const mockCompleteStreamingMessage = vi.fn();
 	const mockSetAILoading = vi.fn();
+	const mockRegisterPendingEdit = vi.fn();
+	const mockUpdateBuffer = vi.fn();
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -29,7 +36,15 @@ describe("useAssistantEventAdapter", () => {
 				recordToolEvent: mockRecordToolEvent,
 				completeStreamingMessage: mockCompleteStreamingMessage,
 				setAILoading: mockSetAILoading,
+				registerPendingEdit: mockRegisterPendingEdit,
+				getActiveBuffer: () => null,
+				updateBuffer: mockUpdateBuffer,
 			};
+			return selector(state);
+		});
+
+		(useFileSystemStore as any).mockImplementation((selector: any) => {
+			const state = { workspaceRoot: "" };
 			return selector(state);
 		});
 	});

--- a/client/src/hooks/useAssistantEventAdapter.ts
+++ b/client/src/hooks/useAssistantEventAdapter.ts
@@ -2,8 +2,11 @@ import { useCallback } from "react";
 import { useStore } from "@/core";
 import { extractCodeBlocks } from "@/core/ai/codeBlockUtils";
 import type { AgentEvent, ApprovalRequest, PlanStep, ToolCallLog } from "@/types";
+import type { PendingEdit } from "@/types";
 import type { AcpPlanStep } from "@/types/generated/AcpPlanStep";
 import type { AcpSessionUpdate } from "@/types/generated/AcpSessionUpdate";
+import { normalizeWorkspaceRelativePath } from "@/core/pathUtils";
+import { useFileSystemStore } from "@/core/fileSystemStore";
 
 type AcpToolCall = Extract<AcpSessionUpdate, { ToolCall: unknown }>["ToolCall"];
 type AcpToolCallUpdate = Extract<AcpSessionUpdate, { ToolCallUpdate: unknown }>["ToolCallUpdate"];
@@ -33,6 +36,12 @@ export const useAssistantEventAdapter = () => {
 	const recordToolEvent = useStore((state) => state.recordToolEvent);
 	const completeStreamingMessage = useStore((state) => state.completeStreamingMessage);
 	const setAILoading = useStore((state) => state.setAILoading);
+	const registerPendingEdit = useStore((state) => state.registerPendingEdit);
+	const activeBuffer = useStore((state) => state.getActiveBuffer());
+	const updateBuffer = useStore((state) => state.updateBuffer);
+	const workspaceRoot = useFileSystemStore((state) => state.workspaceRoot);
+	const activeBufferId = activeBuffer?.id ?? null;
+	const editorFilepath = activeBuffer?.filepath ?? "";
 
 	const appendChunk = useCallback(
 		(streamingId: string, chunk: string) => {
@@ -58,8 +67,65 @@ export const useAssistantEventAdapter = () => {
 	const recordAgentEvent = useCallback(
 		(streamingId: string, event: AgentEvent) => {
 			appendAgentEvent(streamingId, event);
+
+			if (event.type !== "tool_result") {
+				return;
+			}
+
+			const output = (event as { output?: unknown }).output;
+			if (!output || typeof output !== "object") {
+				return;
+			}
+
+			const pendingType = (output as { type?: unknown }).type;
+			if (pendingType !== "pending_edit") {
+				return;
+			}
+
+			const editPayload = (output as { edit?: any }).edit;
+			if (!editPayload || typeof editPayload !== "object") {
+				return;
+			}
+
+			const normalizedFilePath = normalizeWorkspaceRelativePath(
+				String(editPayload.file_path ?? ""),
+				workspaceRoot,
+				{ keepRootEmpty: true },
+			);
+			const normalizedEditorPath = normalizeWorkspaceRelativePath(editorFilepath, workspaceRoot, {
+				keepRootEmpty: true,
+			});
+
+			const pendingEdit: PendingEdit = {
+				id: String(editPayload.id ?? ""),
+				source: { type: "api-key", codeBlockId: (event as any).requestId ?? event.id },
+				filePath: normalizedFilePath,
+				oldContent: String(editPayload.old_text ?? ""),
+				newContent: String(editPayload.new_text ?? ""),
+				unifiedDiff: String(editPayload.unified_diff ?? ""),
+				baseHash: String(editPayload.base_sha256 ?? ""),
+				expectedSha: editPayload.expected_sha256 ?? null,
+				createdAt: Date.now(),
+			};
+
+			const registered = registerPendingEdit(pendingEdit);
+			if (registered && pendingEdit.filePath === normalizedEditorPath) {
+				if (activeBufferId) {
+					updateBuffer(activeBufferId, {
+						content: pendingEdit.newContent,
+						isDirty: true,
+					});
+				}
+			}
 		},
-		[appendAgentEvent],
+		[
+			activeBufferId,
+			appendAgentEvent,
+			editorFilepath,
+			registerPendingEdit,
+			updateBuffer,
+			workspaceRoot,
+		],
 	);
 
 	const enqueueApproval = useCallback(

--- a/client/src/services/pendingEditService.ts
+++ b/client/src/services/pendingEditService.ts
@@ -3,11 +3,7 @@ import { socketService } from "@/services/socket";
 import type { PendingEdit } from "@/types/pendingEdit";
 
 export async function acceptPendingEdit(edit: PendingEdit): Promise<void> {
-	if (edit.source.type !== "acp") {
-		return;
-	}
-
-	if (IS_TAURI) {
+	if (IS_TAURI && edit.source.type === "acp") {
 		const { invoke } = await import("@tauri-apps/api/core");
 		await invoke("acp_accept_pending_edit", { editId: edit.id });
 		return;
@@ -25,11 +21,7 @@ export async function acceptPendingEdit(edit: PendingEdit): Promise<void> {
 }
 
 export async function rejectPendingEdit(edit: PendingEdit): Promise<void> {
-	if (edit.source.type !== "acp") {
-		return;
-	}
-
-	if (IS_TAURI) {
+	if (IS_TAURI && edit.source.type === "acp") {
 		const { invoke } = await import("@tauri-apps/api/core");
 		await invoke("acp_reject_pending_edit", { editId: edit.id });
 		return;
@@ -47,11 +39,7 @@ export async function rejectPendingEdit(edit: PendingEdit): Promise<void> {
 }
 
 export async function updatePendingEdit(edit: PendingEdit, newContent: string): Promise<void> {
-	if (edit.source.type !== "acp") {
-		return;
-	}
-
-	if (IS_TAURI) {
+	if (IS_TAURI && edit.source.type === "acp") {
 		const { invoke } = await import("@tauri-apps/api/core");
 		await invoke("acp_update_pending_edit", { editId: edit.id, newText: newContent });
 		return;

--- a/core/src/ai/tools/mod.rs
+++ b/core/src/ai/tools/mod.rs
@@ -1,5 +1,6 @@
 mod console;
 mod filesystem;
+mod pending_edit;
 mod r_context;
 mod repo;
 mod web_search;
@@ -11,6 +12,7 @@ pub use filesystem::{
     get_filesystem_tools, FileInfo, FileSystemTool, ListFilesRequest, ReadTextFileRequest,
     WriteTextFileRequest,
 };
+pub use pending_edit::get_pending_edit_tools;
 pub use r_context::{
     get_r_context_tools, GetInstalledPackagesRequest, GetVariablesRequest, GetWorkingDirRequest,
     RContextTool, VariableInfo,

--- a/core/src/ai/tools/pending_edit.rs
+++ b/core/src/ai/tools/pending_edit.rs
@@ -1,0 +1,71 @@
+use serde_json::Value;
+
+pub fn get_pending_edit_tools() -> Vec<Value> {
+    serde_json::json!([
+        {
+            "name": "propose_text_edit",
+            "description": "Propose a text edit without writing to disk. Returns a pending edit payload.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative path to the file within workspace (e.g., 'analysis.R')"
+                    },
+                    "operation": {
+                        "type": "string",
+                        "enum": ["create", "replace", "apply_edits", "delete"],
+                        "description": "Edit operation to propose"
+                    },
+                    "expected_sha256": {
+                        "type": "string",
+                        "description": "Optional SHA-256 of the file content from read_text_file for conflict detection"
+                    },
+                    "new_text": {
+                        "type": "string",
+                        "description": "Full new file contents (required for create/replace)"
+                    },
+                    "edits": {
+                        "type": "array",
+                        "description": "Range-based edits (required for apply_edits)",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "range": {
+                                    "type": "object",
+                                    "properties": {
+                                        "start_line": { "type": "integer" },
+                                        "start_col": { "type": "integer" },
+                                        "end_line": { "type": "integer" },
+                                        "end_col": { "type": "integer" }
+                                    },
+                                    "required": ["start_line", "start_col", "end_line", "end_col"]
+                                },
+                                "text": { "type": "string" }
+                            },
+                            "required": ["range", "text"]
+                        }
+                    }
+                },
+                "required": ["path", "operation"]
+            }
+        },
+        {
+            "name": "apply_pending_edit",
+            "description": "Apply a previously proposed pending edit by id.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "edit_id": {
+                        "type": "string",
+                        "description": "Pending edit id"
+                    }
+                },
+                "required": ["edit_id"]
+            }
+        }
+    ])
+    .as_array()
+    .expect("get_pending_edit_tools: json! array literal should always be an array")
+    .clone()
+}

--- a/server/src/handlers/acp_handler.rs
+++ b/server/src/handlers/acp_handler.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use super::common::{error_response, single_response, with_system_prompts, AIMode, WSResponse};
+use crate::pending_edits;
 use crate::projects::ProjectRuntime;
 use reprod_core::acp::types::{AcpPermissionDecision, AcpPromptMessage};
 use reprod_core::ChatMessage;
@@ -73,7 +74,18 @@ pub async fn handle_acp_pending_edit_accept(
     runtime: &Arc<ProjectRuntime>,
     edit_id: &str,
 ) -> Vec<WSResponse> {
-    match runtime.acp.accept_pending_edit(edit_id).await {
+    let handled = pending_edits::has_pending_edit(&runtime.pending_edits, edit_id).await;
+    let result = if handled {
+        pending_edits::accept_pending_edit(
+            &runtime.edit_service,
+            &runtime.pending_edits,
+            edit_id,
+        )
+        .await
+    } else {
+        runtime.acp.accept_pending_edit(edit_id).await.map_err(|e| e.to_string())
+    };
+    match result {
         Ok(()) => single_response(WSResponse::AcpPendingEditResolved {
             edit_id: edit_id.to_string(),
             success: true,
@@ -82,7 +94,7 @@ pub async fn handle_acp_pending_edit_accept(
         Err(error) => single_response(WSResponse::AcpPendingEditResolved {
             edit_id: edit_id.to_string(),
             success: false,
-            error: Some(error.to_string()),
+            error: Some(error),
         }),
     }
 }
@@ -91,7 +103,13 @@ pub async fn handle_acp_pending_edit_reject(
     runtime: &Arc<ProjectRuntime>,
     edit_id: &str,
 ) -> Vec<WSResponse> {
-    match runtime.acp.reject_pending_edit(edit_id).await {
+    let handled = pending_edits::has_pending_edit(&runtime.pending_edits, edit_id).await;
+    let result = if handled {
+        pending_edits::reject_pending_edit(&runtime.pending_edits, edit_id).await
+    } else {
+        runtime.acp.reject_pending_edit(edit_id).await.map_err(|e| e.to_string())
+    };
+    match result {
         Ok(()) => single_response(WSResponse::AcpPendingEditResolved {
             edit_id: edit_id.to_string(),
             success: true,
@@ -100,7 +118,7 @@ pub async fn handle_acp_pending_edit_reject(
         Err(error) => single_response(WSResponse::AcpPendingEditResolved {
             edit_id: edit_id.to_string(),
             success: false,
-            error: Some(error.to_string()),
+            error: Some(error),
         }),
     }
 }
@@ -110,7 +128,13 @@ pub async fn handle_acp_pending_edit_update(
     edit_id: &str,
     new_text: &str,
 ) -> Vec<WSResponse> {
-    match runtime.acp.update_pending_edit(edit_id, new_text).await {
+    let handled = pending_edits::has_pending_edit(&runtime.pending_edits, edit_id).await;
+    let result = if handled {
+        pending_edits::update_pending_edit(&runtime.pending_edits, edit_id, new_text).await
+    } else {
+        runtime.acp.update_pending_edit(edit_id, new_text).await.map_err(|e| e.to_string())
+    };
+    match result {
         Ok(()) => single_response(WSResponse::AcpPendingEditUpdated {
             edit_id: edit_id.to_string(),
             success: true,
@@ -119,8 +143,7 @@ pub async fn handle_acp_pending_edit_update(
         Err(error) => single_response(WSResponse::AcpPendingEditUpdated {
             edit_id: edit_id.to_string(),
             success: false,
-            error: Some(error.to_string()),
+            error: Some(error),
         }),
     }
 }
-

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -5,7 +5,8 @@ use reprod_core::{
     ai::{
         self,
         tools::{
-            get_console_tools, get_filesystem_tools, get_r_context_tools, get_repo_tools,
+            get_console_tools, get_filesystem_tools, get_pending_edit_tools, get_r_context_tools,
+            get_repo_tools,
             get_web_search_tools, WriteTextFileRequest,
         },
     },
@@ -75,7 +76,7 @@ impl EventStream {
 }
 
 fn tool_requires_approval(name: &str) -> bool {
-    matches!(name, "write_text_file" | "edit_text_file")
+    matches!(name, "apply_pending_edit")
 }
 
 fn push_cancel_response(
@@ -113,6 +114,24 @@ fn extract_path_from_input(input: &serde_json::Value) -> Option<String> {
         .get("path")
         .and_then(|value| value.as_str())
         .map(|value| value.to_string())
+}
+
+fn extract_pending_edit_fields(
+    output: &serde_json::Value,
+) -> Option<(String, String, String, String)> {
+    let edit = output.get("edit")?;
+    if output.get("type")?.as_str()? != "pending_edit" {
+        return None;
+    }
+    let file_path = edit.get("file_path")?.as_str()?.to_string();
+    let old_text = edit.get("old_text")?.as_str()?.to_string();
+    let new_text = edit.get("new_text")?.as_str()?.to_string();
+    let unified_diff = edit.get("unified_diff")?.as_str()?.to_string();
+    Some((file_path, old_text, new_text, unified_diff))
+}
+
+fn extract_pending_edit_path(output: &serde_json::Value) -> Option<String> {
+    extract_pending_edit_fields(output).map(|(path, _, _, _)| path)
 }
 
 fn normalize_relative_path(path: &str) -> Option<String> {
@@ -236,7 +255,7 @@ async fn build_tool_preview(
                 affected_lines: None,
             })
         }
-        "edit_text_file" => {
+        "edit_text_file" | "propose_text_edit" => {
             let request: EditTextFileRequest =
                 serde_json::from_value(tool_call.input.clone()).ok()?;
             let read_result = runtime.edit_service.read_text_file(&request.path).await;
@@ -260,6 +279,24 @@ async fn build_tool_preview(
                 affected_lines: None,
             })
         }
+        "apply_pending_edit" => {
+            let edit_id = tool_call
+                .input
+                .get("edit_id")
+                .and_then(|value| value.as_str())?;
+            let edit = crate::pending_edits::get_pending_edit(
+                &runtime.pending_edits,
+                edit_id,
+            )
+            .await?;
+            Some(ToolPreviewPayload {
+                kind: "diff".to_string(),
+                filepath: Some(edit.file_path),
+                diff: Some(edit.unified_diff),
+                command: None,
+                affected_lines: None,
+            })
+        }
         _ => None,
     }
 }
@@ -269,9 +306,12 @@ fn summarize_tool_result(tool_call: &reprod_core::ToolCall, outcome: &serde_json
         "read_text_file" => extract_path_from_input(&tool_call.input)
             .map(|path| format!("Read file {}", path))
             .unwrap_or_else(|| "Read file".to_string()),
-        "write_text_file" | "edit_text_file" => extract_path_from_input(&tool_call.input)
-            .map(|path| format!("Updated file {}", path))
-            .unwrap_or_else(|| "Updated file".to_string()),
+        "write_text_file" | "edit_text_file" | "propose_text_edit" => {
+            extract_pending_edit_path(outcome)
+                .map(|path| format!("Proposed edit for {}", path))
+                .unwrap_or_else(|| "Proposed edit".to_string())
+        }
+        "apply_pending_edit" => "Applied pending edit".to_string(),
         _ => outcome.to_string(),
     }
 }
@@ -282,14 +322,19 @@ fn artifact_for_tool_result(
     diff_summary: &str,
     display_summary: &str,
 ) -> Option<(ArtifactKind, Option<String>, String, Option<ArtifactDetailsPayload>)> {
-    let old_text = output
-        .get("old_text")
-        .and_then(|value| value.as_str())
-        .map(|value| value.to_string());
-    let new_text = output
-        .get("new_text")
-        .and_then(|value| value.as_str())
-        .map(|value| value.to_string());
+    let (old_text, new_text, diff, pending_path) = extract_pending_edit_fields(output)
+        .map(|(path, old_text, new_text, diff)| (Some(old_text), Some(new_text), Some(diff), Some(path)))
+        .unwrap_or_else(|| {
+            let old_text = output
+                .get("old_text")
+                .and_then(|value| value.as_str())
+                .map(|value| value.to_string());
+            let new_text = output
+                .get("new_text")
+                .and_then(|value| value.as_str())
+                .map(|value| value.to_string());
+            (old_text, new_text, None, None)
+        });
 
     match tool_call.name.as_str() {
         "read_text_file" => Some((
@@ -298,12 +343,12 @@ fn artifact_for_tool_result(
             display_summary.to_string(),
             None,
         )),
-        "write_text_file" | "edit_text_file" => Some((
+        "write_text_file" | "edit_text_file" | "propose_text_edit" => Some((
             ArtifactKind::FileWrite,
-            extract_path_from_input(&tool_call.input),
+            pending_path.or_else(|| extract_path_from_input(&tool_call.input)),
             display_summary.to_string(),
             Some(ArtifactDetailsPayload {
-                diff: Some(diff_summary.to_string()),
+                diff: diff.or_else(|| Some(diff_summary.to_string())),
                 exit_code: None,
                 stdout: None,
                 stderr: None,
@@ -382,6 +427,7 @@ pub(super) async fn handle_ai_message(
         tools.extend(get_console_tools());
         tools.extend(get_web_search_tools());
         tools.extend(get_repo_tools());
+        tools.extend(get_pending_edit_tools());
         let mut responses = Vec::new();
         let mut conversation = messages.clone();
         let mut loop_count = 0;
@@ -643,7 +689,8 @@ pub(super) async fn handle_ai_message(
                         },
                     );
 
-                    let tool_result = execute_ai_tool_call(&tool_call, runtime).await;
+                    let tool_result =
+                        execute_ai_tool_call(&tool_call, runtime, &agent_session_id).await;
                     match tool_result {
                         Ok(result) => {
                             log.status = ToolLogStatus::Done;

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -676,6 +676,23 @@ mod tests {
         manager.unregister("req-1").await;
         assert!(!manager.cancel("req-1").await);
     }
+
+    #[test]
+    fn with_system_prompts_preserves_existing_conversation() {
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "request".to_string(),
+        }];
+
+        let prefixed = with_system_prompts(&messages, AIMode::Agent);
+        let prompts = load_system_prompts();
+
+        assert_eq!(prefixed.len(), messages.len() + 2);
+        assert_eq!(prefixed[0].role, "system");
+        assert_eq!(prefixed[0].content, prompts.patch);
+        assert_eq!(prefixed[1].content, prompts.range);
+        assert_eq!(&prefixed[2..], messages.as_slice());
+    }
 }
 
 #[derive(serde::Serialize, Clone, Copy)]
@@ -864,6 +881,7 @@ fn tool_kind_from_name(name: &str) -> Option<String> {
         "web_search" => Some("Fetch".to_string()),
         "search_repo" => Some("Search".to_string()),
         "git_status" | "git_diff" | "git_log" => Some("Git".to_string()),
+        "propose_text_edit" | "apply_pending_edit" => Some("Edit".to_string()),
         _ => None,
     }
 }
@@ -905,26 +923,4 @@ pub(super) fn error_response(message: impl Into<String>) -> Vec<WSResponse> {
 
 pub(super) fn single_response(response: WSResponse) -> Vec<WSResponse> {
     vec![response]
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn with_system_prompts_preserves_existing_conversation() {
-        let messages = vec![ChatMessage {
-            role: "user".to_string(),
-            content: "request".to_string(),
-        }];
-
-        let prefixed = with_system_prompts(&messages, AIMode::Agent);
-        let prompts = load_system_prompts();
-
-        assert_eq!(prefixed.len(), messages.len() + 2);
-        assert_eq!(prefixed[0].role, "system");
-        assert_eq!(prefixed[0].content, prompts.patch);
-        assert_eq!(prefixed[1].content, prompts.range);
-        assert_eq!(&prefixed[2..], messages.as_slice());
-    }
 }

--- a/server/src/handlers/tool_handler.rs
+++ b/server/src/handlers/tool_handler.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use crate::{projects::ProjectRuntime, repo_tools};
+use crate::{pending_edits, projects::ProjectRuntime, repo_tools};
 use reprod_core::{
     ai::tools::*,
     edit::{EditOperation, EditTextFileRequest},
@@ -49,6 +49,7 @@ pub(super) struct ToolCallOutcome {
 pub(super) async fn execute_ai_tool_call(
     tool_call: &ToolCall,
     runtime: &Arc<ProjectRuntime>,
+    agent_session_id: &str,
 ) -> Result<ToolCallOutcome, String> {
     match tool_call.name.as_str() {
         "read_text_file" => {
@@ -79,37 +80,75 @@ pub(super) async fn execute_ai_tool_call(
                 new_text: Some(request.content),
                 edits: None,
             };
-            let result = runtime
-                .edit_service
-                .edit_text_file(edit_request)
-                .await
-                .map_err(|e| e.to_string())?;
-            let summary = if result.unified_diff.is_empty() {
-                serde_json::to_string(&result).unwrap_or_default()
-            } else {
-                result.unified_diff.clone()
-            };
-            let output = serde_json::to_value(result)
-                .map_err(|e| format!("Failed to serialize edit result: {}", e))?;
+            let edit = pending_edits::propose_pending_edit(
+                &runtime.edit_service,
+                &runtime.pending_edits,
+                agent_session_id,
+                &tool_call.id,
+                edit_request,
+            )
+            .await?;
+            let output = serde_json::json!({
+                "type": "pending_edit",
+                "edit": edit,
+            });
+            let summary = output.to_string();
             Ok(ToolCallOutcome { output, summary })
         }
         "edit_text_file" => {
             let request: EditTextFileRequest = serde_json::from_value(tool_call.input.clone())
                 .map_err(|e| format!("Invalid request: {}", e))?;
-
-            let result = runtime
-                .edit_service
-                .edit_text_file(request)
-                .await
-                .map_err(|e| e.to_string())?;
-            let summary = if result.unified_diff.is_empty() {
-                serde_json::to_string(&result).unwrap_or_default()
-            } else {
-                result.unified_diff.clone()
-            };
-            let output = serde_json::to_value(result)
-                .map_err(|e| format!("Failed to serialize edit result: {}", e))?;
+            let edit = pending_edits::propose_pending_edit(
+                &runtime.edit_service,
+                &runtime.pending_edits,
+                agent_session_id,
+                &tool_call.id,
+                request,
+            )
+            .await?;
+            let output = serde_json::json!({
+                "type": "pending_edit",
+                "edit": edit,
+            });
+            let summary = output.to_string();
             Ok(ToolCallOutcome { output, summary })
+        }
+        "propose_text_edit" => {
+            let request: EditTextFileRequest = serde_json::from_value(tool_call.input.clone())
+                .map_err(|e| format!("Invalid request: {}", e))?;
+            let edit = pending_edits::propose_pending_edit(
+                &runtime.edit_service,
+                &runtime.pending_edits,
+                agent_session_id,
+                &tool_call.id,
+                request,
+            )
+            .await?;
+            let output = serde_json::json!({
+                "type": "pending_edit",
+                "edit": edit,
+            });
+            let summary = output.to_string();
+            Ok(ToolCallOutcome { output, summary })
+        }
+        "apply_pending_edit" => {
+            let request: pending_edits::ApplyPendingEditRequest =
+                serde_json::from_value(tool_call.input.clone())
+                    .map_err(|e| format!("Invalid request: {}", e))?;
+            pending_edits::accept_pending_edit(
+                &runtime.edit_service,
+                &runtime.pending_edits,
+                &request.edit_id,
+            )
+            .await?;
+            let output = serde_json::to_value(pending_edits::ApplyPendingEditResult {
+                success: true,
+            })
+            .map_err(|e| format!("Failed to serialize apply result: {}", e))?;
+            Ok(ToolCallOutcome {
+                summary: output.to_string(),
+                output,
+            })
         }
         "list_files" => {
             let request: ListFilesRequest = serde_json::from_value(tool_call.input.clone())

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,6 +5,7 @@ mod acp;
 mod conversions;
 mod handlers;
 mod http;
+mod pending_edits;
 mod projects;
 mod repo_tools;
 mod routes;

--- a/server/src/pending_edits.rs
+++ b/server/src/pending_edits.rs
@@ -1,0 +1,173 @@
+use std::sync::Arc;
+
+use reprod_core::{
+    acp::pending_edit::{PendingEdit, PendingEditStore},
+    edit::{sha256_hex, EditOperation, EditStatus, EditTextFileRequest, EditService},
+};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+#[derive(serde::Deserialize)]
+pub struct ApplyPendingEditRequest {
+    pub edit_id: String,
+}
+
+#[derive(serde::Serialize)]
+pub struct ApplyPendingEditResult {
+    pub success: bool,
+}
+
+pub async fn propose_pending_edit(
+    edit_service: &Arc<EditService>,
+    store: &Arc<Mutex<PendingEditStore>>,
+    session_id: &str,
+    tool_call_id: &str,
+    request: EditTextFileRequest,
+) -> Result<PendingEdit, String> {
+    let preview = edit_service
+        .preview_text_file(request.clone(), None)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if matches!(preview.status, EditStatus::Conflict) {
+        return Err("Pending edit base mismatch: file changed since edit was created".to_string());
+    }
+
+    let edit = PendingEdit {
+        id: format!("api-edit-{}", Uuid::new_v4()),
+        session_id: session_id.to_string(),
+        tool_call_id: tool_call_id.to_string(),
+        file_path: request.path.clone(),
+        old_text: preview.old_text.clone(),
+        new_text: preview.new_text.clone(),
+        unified_diff: preview.unified_diff.clone(),
+        base_sha256: preview.old_sha256.clone(),
+        expected_sha256: request.expected_sha256.clone(),
+    };
+
+    let mut pending = store.lock().await;
+    pending
+        .register_pending_edit(edit.clone(), &preview)
+        .map_err(|e| e.to_string())?;
+
+    Ok(edit)
+}
+
+pub async fn accept_pending_edit(
+    edit_service: &Arc<EditService>,
+    store: &Arc<Mutex<PendingEditStore>>,
+    edit_id: &str,
+) -> Result<(), String> {
+    let edit = {
+        let pending = store.lock().await;
+        pending
+            .get_edit(edit_id)
+            .ok_or_else(|| "Pending edit not found".to_string())?
+    };
+
+    let current_sha = match edit_service.read_text_file(&edit.file_path).await {
+        Ok(result) => result.sha256,
+        Err(error) => {
+            let message = error.to_string();
+            if message.contains("Cannot read file metadata")
+                || message.contains("No such file or directory")
+            {
+                sha256_hex("")
+            } else {
+                return Err(message);
+            }
+        }
+    };
+    if current_sha != edit.base_sha256 {
+        return Err("Pending edit base mismatch: file changed since edit was created".to_string());
+    }
+
+    let request = EditTextFileRequest {
+        path: edit.file_path.clone(),
+        operation: EditOperation::Replace,
+        expected_sha256: edit
+            .expected_sha256
+            .clone()
+            .or_else(|| Some(edit.base_sha256.clone())),
+        new_text: Some(edit.new_text.clone()),
+        edits: None,
+    };
+    let result = edit_service
+        .edit_text_file(request)
+        .await
+        .map_err(|e| e.to_string())?;
+    if matches!(result.status, EditStatus::Conflict) {
+        return Err("Conflict detected while applying pending edit".to_string());
+    }
+
+    let mut pending = store.lock().await;
+    pending.remove_edit(edit_id);
+    Ok(())
+}
+
+pub async fn reject_pending_edit(
+    store: &Arc<Mutex<PendingEditStore>>,
+    edit_id: &str,
+) -> Result<(), String> {
+    let mut pending = store.lock().await;
+    if pending.remove_edit(edit_id).is_none() {
+        return Err("Pending edit not found".to_string());
+    }
+    Ok(())
+}
+
+pub async fn update_pending_edit(
+    store: &Arc<Mutex<PendingEditStore>>,
+    edit_id: &str,
+    new_text: &str,
+) -> Result<(), String> {
+    let mut pending = store.lock().await;
+    pending
+        .update_edit_text(edit_id, new_text.to_string())
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+pub async fn has_pending_edit(store: &Arc<Mutex<PendingEditStore>>, edit_id: &str) -> bool {
+    let pending = store.lock().await;
+    pending.get_edit(edit_id).is_some()
+}
+
+pub async fn get_pending_edit(
+    store: &Arc<Mutex<PendingEditStore>>,
+    edit_id: &str,
+) -> Option<PendingEdit> {
+    let pending = store.lock().await;
+    pending.get_edit(edit_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn propose_and_accept_pending_edit() {
+        let temp = TempDir::new().unwrap();
+        let edit_service = Arc::new(EditService::new(temp.path().to_path_buf()));
+        let store = Arc::new(Mutex::new(PendingEditStore::default()));
+
+        let request = EditTextFileRequest {
+            path: "note.txt".to_string(),
+            operation: EditOperation::Replace,
+            expected_sha256: None,
+            new_text: Some("hello".to_string()),
+            edits: None,
+        };
+
+        let edit = propose_pending_edit(&edit_service, &store, "session-1", "tool-1", request)
+            .await
+            .expect("pending edit");
+
+        assert!(has_pending_edit(&store, &edit.id).await);
+        accept_pending_edit(&edit_service, &store, &edit.id)
+            .await
+            .expect("accept");
+        assert!(!has_pending_edit(&store, &edit.id).await);
+    }
+}

--- a/server/src/projects.rs
+++ b/server/src/projects.rs
@@ -2,6 +2,7 @@ use crate::acp::AcpService;
 use crate::handlers::stream_buffer::StreamBuffer;
 use anyhow::{anyhow, Context, Result};
 use reprod_core::{
+    acp::pending_edit::PendingEditStore,
     ai::tools::{FileSystemTool, RContextTool},
     edit::EditService,
     execution_repository::{ExecutionRepository, TimelineExecutionRepository},
@@ -57,6 +58,7 @@ pub struct ProjectRuntime {
     pub plot_history: Arc<Mutex<PlotHistoryManager>>,
     pub acp: Arc<AcpService>,
     pub web_search_registry: Arc<Mutex<WebSearchRegistry>>,
+    pub pending_edits: Arc<Mutex<PendingEditStore>>,
 }
 
 impl ProjectRuntime {
@@ -135,6 +137,7 @@ impl ProjectRuntime {
             plot_history,
             acp,
             web_search_registry,
+            pending_edits: Arc::new(Mutex::new(PendingEditStore::default())),
         })
     }
 }


### PR DESCRIPTION
## Description

Adds staged edit parity for API-key mode by introducing pending edit tools, server-side pending edit storage/apply logic, and client-side handling of pending edits emitted from tool results. This reuses existing pending edit UI and WS messages for accept/reject/update.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- cargo test -p reprod-server

## Screenshots (if applicable)

N/A

## Related Issues

Closes #420
