### PR TITLE
refactor: Remove any type from monacoEditor in editorSlice

### DIFF
--- a/client/src/core/state/slices/editorSlice.ts
+++ b/client/src/core/state/slices/editorSlice.ts
@@ -1,4 +1,5 @@
 import type { RefObject } from "react";
+import type * as Monaco from "monaco-editor";
 import type { StateCreator } from "zustand";
 import type { EditorRef } from "@/components/editor/editorRef";
 import { createBufferId } from "@/core/state/utils/createBufferId";
@@ -37,7 +38,7 @@ export interface EditorState {
 		buffers: Buffer[];
 		activeBufferId: string | null;
 	};
-	monacoEditor: any | null;
+	monacoEditor: Monaco.editor.IStandaloneCodeEditor | null;
 	applyCodeChange: ((codeBlock: CodeBlock) => Promise<AppliedCodeChange | null>) | null;
 	runCurrentCell: (() => void) | null;
 	runAll: (() => void) | null;
@@ -49,7 +50,7 @@ export interface EditorState {
 	getActiveBuffer: () => Buffer | null;
 	getBufferById: (id: string) => Buffer | null;
 	getBufferByFilepath: (filepath: string) => Buffer | null;
-	setMonacoEditor: (editor: any) => void;
+	setMonacoEditor: (editor: Monaco.editor.IStandaloneCodeEditor) => void;
 	setApplyCodeChange: (
 		handler: (codeBlock: CodeBlock) => Promise<AppliedCodeChange | null>,
 	) => void;


### PR DESCRIPTION
Closes #369

### Description
This PR improves type safety in `editorSlice.ts` by replacing the `any` type for `monacoEditor` with the proper `Monaco.editor.IStandaloneCodeEditor` type from the `monaco-editor` package.

### Changes
- Imported `monaco-editor` types.
- Updated `monacoEditor` state property type.
- Updated `setMonacoEditor` action payload type.

### Verification
- Ran `pnpm type-check` in `client` directory -> Passed.
- Verified application builds successfully.