### PR TITLE
fix: prevent test mock from blocking native folder dialog

### DIFF
--- a/client/src/utils/folderOperations.ts
+++ b/client/src/utils/folderOperations.ts
@@ -24,14 +24,19 @@ const extractFolderPath = (selected: OpenFolderResult): string | null => {
 
 export const openFolder = async (): Promise<string | null> => {
 	// Test hook for E2E tests to bypass native dialog
-	const testMock = (
+	const testHelper = (
 		window as Window & {
 			reprodTest?: { mockDialogResult?: string | null };
 		}
-	).reprodTest?.mockDialogResult;
+	).reprodTest;
 
-	if (testMock !== undefined) {
-		return testMock;
+	// Only use test mock if explicitly set to a string value
+	if (
+		testHelper &&
+		"mockDialogResult" in testHelper &&
+		typeof testHelper.mockDialogResult === "string"
+	) {
+		return testHelper.mockDialogResult;
 	}
 
 	if (!isTauri()) {


### PR DESCRIPTION
## Summary

Fixes the issue where "File > Open Folder" menu item did nothing in the Tauri desktop app.

## Problem

The test mock in `openFolder()` was incorrectly triggered even when `mockDialogResult` was set to `null`, preventing the native Tauri folder picker dialog from opening in production.

**Root cause:**
```typescript
if (testMock !== undefined) {  // ← null is not undefined, so this condition passes!
    return testMock;  // Returns null, blocking the native dialog
}
```

## Solution

Changed the condition to only use test mock when `mockDialogResult` is explicitly set to a string value:

```typescript
if (testHelper && "mockDialogResult" in testHelper && typeof testHelper.mockDialogResult === "string") {
    return testHelper.mockDialogResult;
}
```

This allows the native Tauri dialog to open normally in non-test scenarios while preserving E2E test functionality.

## Test Plan

- [x] Click "File > Open Folder" in Tauri desktop app
- [x] Verify native folder picker dialog opens
- [x] Select a folder and verify project switches correctly
- [x] Verify E2E tests still work (test mock only activates when set to string)

## Files Changed

- `client/src/utils/folderOperations.ts` - Fixed test mock condition