### PR TITLE
refactor: consume pending edit event (#453)

### DIFF
--- a/client/src/services/agent/transport/ApiTransport.ts
+++ b/client/src/services/agent/transport/ApiTransport.ts
@@ -2,12 +2,14 @@ import { socketService } from "@/services/socket";
 import { aiMessages } from "@/services/messageBuilders";
 import { normalizeWorkspaceRelativePath } from "@/core/pathUtils";
 import type { AITransport, AITransportRequest, TransportListener } from "./AITransport";
-import type { AgentEvent, PendingEdit, TransportEvent } from "@/types";
+import type { PendingEdit, TransportEvent } from "@/types";
+import type { PendingEditPayload } from "@/types/generated/PendingEditPayload";
 
 export class ApiTransport implements AITransport {
 	private listeners: Set<TransportListener> = new Set();
 	private activeRequestIds = new Set<string>();
 	private requestContext = new Map<string, AITransportRequest["context"]>();
+	private seenPendingEdits = new Set<string>();
 
 	onEvent(listener: TransportListener): () => void {
 		this.listeners.add(listener);
@@ -115,17 +117,24 @@ export class ApiTransport implements AITransport {
 						});
 					}
 				}
+			}),
+		);
 
-				if (event.type === "tool_result") {
-					const pendingEdit = this.extractPendingEdit(event, requestId);
-					if (pendingEdit) {
-						this.emit({
-							type: "PENDING_EDIT",
-							edit: pendingEdit,
-							streamingId: requestId,
-						});
-					}
+		disposers.push(
+			socketService.on("pending_edit_created", (message) => {
+				if (message.type !== "pending_edit_created") return;
+				const editId = String(message.edit?.id ?? "");
+				if (editId && this.seenPendingEdits.has(editId)) return;
+				const pendingEdit = this.pendingEditFromPayload(message.edit, requestId);
+				if (!pendingEdit) return;
+				if (editId) {
+					this.seenPendingEdits.add(editId);
 				}
+				this.emit({
+					type: "PENDING_EDIT",
+					edit: pendingEdit,
+					streamingId: requestId,
+				});
 			}),
 		);
 
@@ -187,25 +196,24 @@ export class ApiTransport implements AITransport {
 		return cleanup;
 	}
 
-	private extractPendingEdit(event: AgentEvent, requestId: string): PendingEdit | null {
-		const output = (event as any).output;
-		if (!output || typeof output !== "object") return null;
-
-		const pendingType = (output as any).type;
-		if (pendingType !== "pending_edit") return null;
-
-		const editPayload = (output as any).edit;
+	private pendingEditFromPayload(
+		editPayload: PendingEditPayload,
+		requestId: string,
+	): PendingEdit | null {
 		const context = this.requestContext.get(requestId);
-		if (editPayload && typeof editPayload === "object" && context) {
-			const normalizedFilePath = normalizeWorkspaceRelativePath(
-				String(editPayload.file_path ?? ""),
-				context.workspaceRoot,
-				{ keepRootEmpty: true },
-			);
+		if (editPayload && typeof editPayload === "object") {
+			const rawPath = String(editPayload.file_path ?? "");
+			const normalizedFilePath = context
+				? normalizeWorkspaceRelativePath(rawPath, context.workspaceRoot, { keepRootEmpty: true })
+				: rawPath;
+
+			const isApiKey = String(editPayload.id ?? "").startsWith("api-edit-");
 
 			return {
 				id: String(editPayload.id ?? ""),
-				source: { type: "api-key", codeBlockId: (event as any).requestId ?? event.id ?? requestId },
+				source: isApiKey
+					? { type: "api-key", codeBlockId: String(editPayload.tool_call_id ?? requestId) }
+					: { type: "acp", sessionId: String(editPayload.session_id ?? "") },
 				filePath: normalizedFilePath,
 				oldContent: String(editPayload.old_text ?? ""),
 				newContent: String(editPayload.new_text ?? ""),

--- a/client/src/services/agent/transport/__tests__/ApiTransport.test.ts
+++ b/client/src/services/agent/transport/__tests__/ApiTransport.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { ApiTransport } from "../ApiTransport";
+import type { PendingEditPayload } from "@/types/generated/PendingEditPayload";
+import { socketService } from "@/services/socket";
+
+vi.mock("@/services/socket", () => ({
+	socketService: {
+		send: vi.fn(),
+		on: vi.fn(),
+	},
+}));
+
+describe("ApiTransport", () => {
+	let mockHandlers: Map<string, (message: any) => void>;
+
+	beforeEach(() => {
+		mockHandlers = new Map();
+		vi.mocked(socketService.send).mockReturnValue(true);
+		vi.mocked(socketService.on).mockImplementation((event, handler) => {
+			mockHandlers.set(event, handler);
+			return () => mockHandlers.delete(event);
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		mockHandlers.clear();
+	});
+
+	it("emits PENDING_EDIT when pending_edit_created arrives", () => {
+		const transport = new ApiTransport();
+		const events: any[] = [];
+		transport.onEvent((event) => events.push(event));
+
+		transport.send({
+			id: "req-1",
+			agentSessionId: "session-1",
+			mode: "agent",
+			messages: [{ role: "user", content: "edit" }],
+			context: {
+				editorFilepath: "notes.txt",
+				editorContent: "old",
+				workspaceRoot: "/workspace",
+			},
+		});
+
+		const handler = mockHandlers.get("pending_edit_created");
+		expect(handler).toBeDefined();
+
+		const payload: PendingEditPayload = {
+			id: "api-edit-123",
+			session_id: "session-1",
+			tool_call_id: "tool-1",
+			file_path: "notes.txt",
+			old_text: "old",
+			new_text: "new",
+			unified_diff: "@@ -1 +1 @@",
+			base_sha256: "base",
+			expected_sha256: null,
+		};
+
+		handler!({ type: "pending_edit_created", edit: payload });
+
+		expect(events).toHaveLength(1);
+		expect(events[0].type).toBe("PENDING_EDIT");
+		expect(events[0].edit.filePath).toBe("notes.txt");
+		expect(events[0].edit.source).toEqual({ type: "api-key", codeBlockId: "tool-1" });
+	});
+});


### PR DESCRIPTION
## Description

Wire the frontend transport to consume the backend `pending_edit_created` event and stop parsing pending edits from tool results. Adds a focused ApiTransport unit test to cover the new event path.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `pnpm --filter client test`
- Not run: `pnpm test`, cargo tests, E2E build/tests

## Screenshots (if applicable)

N/A

## Related Issues

Closes #453
