### PR TITLE
feat: add ui-ready approval fields (#454)

### DIFF
--- a/client/src/components/ai-panel/AgentEventStream.tsx
+++ b/client/src/components/ai-panel/AgentEventStream.tsx
@@ -126,6 +126,9 @@ export function AgentEventStream({ events, approvals }: Props): JSX.Element | nu
 
 	const previewText = useMemo(() => {
 		if (!approval) return "";
+		if (approval.previewText) {
+			return approval.previewText;
+		}
 		if (approval.preview.kind === "diff") {
 			return approval.preview.diff ?? "";
 		}
@@ -173,8 +176,13 @@ export function AgentEventStream({ events, approvals }: Props): JSX.Element | nu
 			{approval && (
 				<div className="agent-event-stream__approval">
 					<div className="agent-event-stream__approval-header">
-						<div className="agent-event-stream__approval-title">Approval Required</div>
+						<div className="agent-event-stream__approval-title">
+							{approval.title ?? "Approval Required"}
+						</div>
 						<div className="agent-event-stream__approval-tool">{approval.tool}</div>
+						{approval.subtitle && (
+							<div className="agent-event-stream__approval-subtitle">{approval.subtitle}</div>
+						)}
 					</div>
 					{previewText && <pre className="agent-event-stream__preview">{previewText}</pre>}
 					{approval.input && (

--- a/client/src/types/generated/ApprovalRequestPayload.ts
+++ b/client/src/types/generated/ApprovalRequestPayload.ts
@@ -5,6 +5,9 @@ export type ApprovalRequestPayload = {
 	eventId: string;
 	tool: string;
 	preview: any;
+	previewText: string | null;
+	title: string | null;
+	subtitle: string | null;
 	options: Array<ApprovalOption>;
 	input: any;
 };

--- a/client/src/types/ui.ts
+++ b/client/src/types/ui.ts
@@ -274,6 +274,9 @@ export interface ApprovalRequest {
 	eventId: string;
 	tool: string;
 	preview: ToolPreview;
+	previewText?: string | null;
+	title?: string | null;
+	subtitle?: string | null;
 	options: ApprovalOption[];
 	input?: Record<string, unknown> | null;
 }

--- a/server/src/handlers/acp_handler.rs
+++ b/server/src/handlers/acp_handler.rs
@@ -422,6 +422,9 @@ pub async fn translate_acp_permission_request(
         event_id: request.request_id.clone(),
         tool: request.tool_title.clone().unwrap_or_else(|| request.tool_kind.clone().unwrap_or_else(|| "tool".to_string())),
         preview,
+        preview_text: request.raw_input.clone(),
+        title: None,
+        subtitle: None,
         options,
         input: None,
     };

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -19,7 +19,8 @@ use tokio::time::{timeout, Duration};
 
 use super::common::{
     build_streaming_payload, error_response, now_millis, tool_log_from_call, with_system_prompts,
-    AgentEventPayload, AgentEventStatus, AIMode, AppState, ApprovalDecisionPayload,
+    approval_preview_text, AgentEventPayload, AgentEventStatus, AIMode, AppState,
+    ApprovalDecisionPayload,
     ApprovalOption, ApprovalRequestPayload, ApprovalRule, ArtifactDetailsPayload, ArtifactKind,
     PendingEditPayload, PlanStepKind, PlanStepPayload, PlanStepStatus, ToolLogStatus,
     ToolPreviewPayload, WSResponse,
@@ -743,7 +744,10 @@ pub(super) async fn handle_ai_message(
                                 request: ApprovalRequestPayload {
                                     event_id: request_event_id.clone(),
                                     tool: tool_call.name.clone(),
-                                    preview: approval_preview,
+                                    preview: approval_preview.clone(),
+                                    preview_text: approval_preview_text(&approval_preview),
+                                    title: None,
+                                    subtitle: None,
                                     options: vec![
                                         ApprovalOption::ApproveOnce,
                                         ApprovalOption::ApproveSession,

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -408,6 +408,13 @@ pub(crate) struct ApprovalRequestPayload {
     pub tool: String,
     #[ts(type = "any")]
     pub preview: ToolPreviewPayload,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "previewText")]
+    #[ts(rename = "previewText")]
+    pub preview_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subtitle: Option<String>,
     pub options: Vec<ApprovalOption>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(type = "any")]
@@ -439,6 +446,15 @@ pub(crate) struct ApprovalDecisionPayload {
     #[ts(type = "any | null")]
     #[ts(rename = "editedInput")]
     pub edited_input: Option<Value>,
+}
+
+pub(crate) fn approval_preview_text(preview: &ToolPreviewPayload) -> Option<String> {
+    match preview.kind.as_str() {
+        "diff" => preview.diff.clone(),
+        "command" => preview.command.clone(),
+        "read" => preview.filepath.clone(),
+        _ => None,
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Hash, PartialEq, Eq, TS)]
@@ -743,6 +759,36 @@ mod tests {
         assert_eq!(prefixed[0].content, prompts.patch);
         assert_eq!(prefixed[1].content, prompts.range);
         assert_eq!(&prefixed[2..], messages.as_slice());
+    }
+
+    #[test]
+    fn approval_preview_text_prefers_payload_content() {
+        let diff_preview = ToolPreviewPayload {
+            kind: "diff".to_string(),
+            filepath: Some("note.txt".to_string()),
+            diff: Some("diff".to_string()),
+            command: None,
+            affected_lines: None,
+        };
+        assert_eq!(approval_preview_text(&diff_preview), Some("diff".to_string()));
+
+        let command_preview = ToolPreviewPayload {
+            kind: "command".to_string(),
+            filepath: None,
+            diff: None,
+            command: Some("ls".to_string()),
+            affected_lines: None,
+        };
+        assert_eq!(approval_preview_text(&command_preview), Some("ls".to_string()));
+
+        let read_preview = ToolPreviewPayload {
+            kind: "read".to_string(),
+            filepath: Some("note.txt".to_string()),
+            diff: None,
+            command: None,
+            affected_lines: None,
+        };
+        assert_eq!(approval_preview_text(&read_preview), Some("note.txt".to_string()));
     }
 
 }


### PR DESCRIPTION
## Description

Add UI-ready fields to approval_request payloads and prefer server-provided previewText in the approval UI. The backend now shapes previewText consistently for API-key and ACP flows, while the frontend falls back to existing preview logic when the field is absent.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `cargo test`
- `pnpm --filter client test`
- Not run: `pnpm test`, E2E build/tests

## Screenshots (if applicable)

N/A

## Related Issues

Closes #454
