### PR TITLE
test: parity checks for pending edits and approvals (#455)

### DIFF
--- a/server/src/handlers/acp_handler.rs
+++ b/server/src/handlers/acp_handler.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use super::ai_handler::build_context_prompt;
 use super::common::{
-    error_response, now_millis, single_response, with_system_prompts, AgentEventPayload,
-    AgentEventStatus, AIMode, ApprovalOption, ApprovalRequestPayload, PlanStepKind, PlanStepPayload,
-    PlanStepStatus, ToolLogPayload, ToolLogStatus, WSResponse,
+    build_approval_request_payload, error_response, now_millis, single_response,
+    with_system_prompts, AgentEventPayload, AgentEventStatus, AIMode, ApprovalOption, PlanStepKind,
+    PlanStepPayload, PlanStepStatus, ToolLogPayload, ToolLogStatus, WSResponse,
 };
 use super::pending_edit_ui::pending_edit_payload_from_output;
 use crate::pending_edits;
@@ -418,16 +418,18 @@ pub async fn translate_acp_permission_request(
     };
 
     let options = map_permission_options(&request.options);
-    let approval = ApprovalRequestPayload {
-        event_id: request.request_id.clone(),
-        tool: request.tool_title.clone().unwrap_or_else(|| request.tool_kind.clone().unwrap_or_else(|| "tool".to_string())),
+    let approval = build_approval_request_payload(
+        request.request_id.clone(),
+        request
+            .tool_title
+            .clone()
+            .unwrap_or_else(|| request.tool_kind.clone().unwrap_or_else(|| "tool".to_string())),
         preview,
-        preview_text: request.raw_input.clone(),
-        title: None,
-        subtitle: None,
         options,
-        input: None,
-    };
+        None,
+        None,
+        None,
+    );
 
     Some(WSResponse::ApprovalRequest {
         id: stream_id,

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -19,9 +19,8 @@ use tokio::time::{timeout, Duration};
 
 use super::common::{
     build_streaming_payload, error_response, now_millis, tool_log_from_call, with_system_prompts,
-    approval_preview_text, AgentEventPayload, AgentEventStatus, AIMode, AppState,
-    ApprovalDecisionPayload,
-    ApprovalOption, ApprovalRequestPayload, ApprovalRule, ArtifactDetailsPayload, ArtifactKind,
+    build_approval_request_payload, AgentEventPayload, AgentEventStatus, AIMode, AppState,
+    ApprovalDecisionPayload, ApprovalOption, ApprovalRule, ArtifactDetailsPayload, ArtifactKind,
     PendingEditPayload, PlanStepKind, PlanStepPayload, PlanStepStatus, ToolLogStatus,
     ToolPreviewPayload, WSResponse,
 };
@@ -741,21 +740,20 @@ pub(super) async fn handle_ai_message(
                             &sender,
                             WSResponse::ApprovalRequest {
                                 id: stream_id.clone(),
-                                request: ApprovalRequestPayload {
-                                    event_id: request_event_id.clone(),
-                                    tool: tool_call.name.clone(),
-                                    preview: approval_preview.clone(),
-                                    preview_text: approval_preview_text(&approval_preview),
-                                    title: None,
-                                    subtitle: None,
-                                    options: vec![
+                                request: build_approval_request_payload(
+                                    request_event_id.clone(),
+                                    tool_call.name.clone(),
+                                    approval_preview.clone(),
+                                    vec![
                                         ApprovalOption::ApproveOnce,
                                         ApprovalOption::ApproveSession,
                                         ApprovalOption::Edit,
                                         ApprovalOption::Deny,
                                     ],
-                                    input: Some(tool_call.input.clone()),
-                                },
+                                    Some(tool_call.input.clone()),
+                                    None,
+                                    None,
+                                ),
                             },
                         );
 

--- a/server/src/handlers/common.rs
+++ b/server/src/handlers/common.rs
@@ -457,6 +457,28 @@ pub(crate) fn approval_preview_text(preview: &ToolPreviewPayload) -> Option<Stri
     }
 }
 
+pub(crate) fn build_approval_request_payload(
+    event_id: String,
+    tool: String,
+    preview: ToolPreviewPayload,
+    options: Vec<ApprovalOption>,
+    input: Option<Value>,
+    title: Option<String>,
+    subtitle: Option<String>,
+) -> ApprovalRequestPayload {
+    let preview_text = approval_preview_text(&preview);
+    ApprovalRequestPayload {
+        event_id,
+        tool,
+        preview,
+        preview_text,
+        title,
+        subtitle,
+        options,
+        input,
+    }
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Hash, PartialEq, Eq, TS)]
 #[ts(export, export_to = "../../client/src/types/generated/")]
 pub(super) struct ApprovalRule {
@@ -789,6 +811,27 @@ mod tests {
             affected_lines: None,
         };
         assert_eq!(approval_preview_text(&read_preview), Some("note.txt".to_string()));
+    }
+
+    #[test]
+    fn build_approval_request_payload_populates_preview_text() {
+        let preview = ToolPreviewPayload {
+            kind: "command".to_string(),
+            filepath: None,
+            diff: None,
+            command: Some("ls".to_string()),
+            affected_lines: None,
+        };
+        let payload = build_approval_request_payload(
+            "event-1".to_string(),
+            "tool".to_string(),
+            preview,
+            vec![ApprovalOption::ApproveOnce],
+            None,
+            None,
+            None,
+        );
+        assert_eq!(payload.preview_text, Some("ls".to_string()));
     }
 
 }

--- a/server/src/handlers/pending_edit_ui.rs
+++ b/server/src/handlers/pending_edit_ui.rs
@@ -81,4 +81,24 @@ mod tests {
         assert_eq!(payload.file_path, "notes.txt");
         assert_eq!(payload.id, "edit-1");
     }
+
+    #[test]
+    fn payload_from_output_matches_edit_payload() {
+        let edit = build_edit("notes.txt");
+        let output = serde_json::json!({
+            "type": "pending_edit",
+            "edit": edit.clone(),
+        });
+        let from_output = pending_edit_payload_from_output(&output).expect("payload");
+        let from_edit = pending_edit_payload_from_edit(&edit);
+        assert_eq!(from_output.id, from_edit.id);
+        assert_eq!(from_output.session_id, from_edit.session_id);
+        assert_eq!(from_output.tool_call_id, from_edit.tool_call_id);
+        assert_eq!(from_output.file_path, from_edit.file_path);
+        assert_eq!(from_output.old_text, from_edit.old_text);
+        assert_eq!(from_output.new_text, from_edit.new_text);
+        assert_eq!(from_output.unified_diff, from_edit.unified_diff);
+        assert_eq!(from_output.base_sha256, from_edit.base_sha256);
+        assert_eq!(from_output.expected_sha256, from_edit.expected_sha256);
+    }
 }


### PR DESCRIPTION
## Description

Add parity-focused tests for pending edit payloads and approval requests, and centralize approval payload shaping so previewText is derived consistently for ACP and API-key flows. This keeps the UI contract stable across modes.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `cargo test`
- Not run: `pnpm test`, E2E build/tests

## Screenshots (if applicable)

N/A

## Related Issues

Closes #455
