### PR TITLE
feat: add Makefile command shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,95 @@
+SHELL := /bin/bash
+
+.PHONY: help install dev dev-client dev-desktop build build-client test test-core test-client lint biome-check format format-check rust-fmt rust-fmt-check clippy check check-build pre-push
+
+help:
+	@echo "Re-prod Make targets"
+	@echo ""
+	@echo "Setup"
+	@echo "  make install           Install workspace dependencies"
+	@echo ""
+	@echo "Development"
+	@echo "  make dev               Run Axum backend + Vite client"
+	@echo "  make dev-client        Run frontend only"
+	@echo "  make dev-desktop       Launch Tauri desktop app"
+	@echo ""
+	@echo "Build"
+	@echo "  make build             Build all packages"
+	@echo "  make build-client      Build client only"
+	@echo "  make check-build       Run build checks (client + Rust)"
+	@echo ""
+	@echo "Testing"
+	@echo "  make test              Run Rust + client tests"
+	@echo "  make test-core         Run all Rust tests"
+	@echo "  make test-client       Run client tests"
+	@echo ""
+	@echo "Quality"
+	@echo "  make lint              Run TypeScript lint"
+	@echo "  make biome-check       Run Biome checks"
+	@echo "  make format            Apply Biome formatting"
+	@echo "  make format-check      Check Biome formatting"
+	@echo "  make rust-fmt          Apply Rust formatting"
+	@echo "  make rust-fmt-check    Check Rust formatting"
+	@echo "  make clippy            Run Rust clippy"
+	@echo "  make check             Run standard local checks"
+	@echo "  make pre-push          Run .husky pre-push checks"
+
+install:
+	pnpm install
+
+dev:
+	pnpm dev
+
+dev-client:
+	pnpm --filter client dev
+
+dev-desktop:
+	cd desktop && cargo tauri dev
+
+build:
+	pnpm build
+
+build-client:
+	pnpm --filter client build
+
+check-build:
+	pnpm --filter client run build
+	cargo build
+
+test: test-core test-client
+
+test-core:
+	cargo test
+
+test-client:
+	pnpm --filter client test
+
+lint:
+	pnpm -r lint
+
+biome-check:
+	pnpm biome:check
+
+format:
+	pnpm format
+
+format-check:
+	pnpm format:check
+
+rust-fmt:
+	cargo fmt
+
+rust-fmt-check:
+	cargo fmt --check
+
+clippy:
+	cargo clippy
+
+check:
+	pnpm -r lint
+	pnpm biome:check
+	cargo fmt --check
+	cargo clippy
+
+pre-push:
+	./.husky/pre-push


### PR DESCRIPTION
## Description

This PR adds a root `Makefile` to simplify common contributor workflows by wrapping the existing documented commands from `README.md` and `CONTRIBUTING.md`.
The targets are intentionally thin wrappers so behavior remains unchanged while improving discoverability and day-to-day ergonomics.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [ ] Tests pass locally (`pnpm test`)
- [ ] New tests added for new features/bug fixes
- [ ] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- Ran `make help` to validate target discovery output.
- Ran `make -n check` to verify the check pipeline maps to expected commands.
- Pre-push hook checks passed during `git push`:
  - `pnpm format`
  - `cargo fmt --check`
  - `cargo clippy`
  - `pnpm run lint`

## Screenshots (if applicable)

N/A

## Related Issues

Closes #462
