### PR TITLE
fix: sync ACP workspace after Open Folder

### DIFF
--- a/client/src/core/commands/modules/file.ts
+++ b/client/src/core/commands/modules/file.ts
@@ -105,6 +105,7 @@ export function setupFileCommands() {
 						showError(response.message);
 						return;
 					}
+					useStore.getState().setAgentSessionId(null);
 					useFileSystemStore
 						.getState()
 						.resetAndLoadRoot()

--- a/client/src/services/AgentClient.ts
+++ b/client/src/services/AgentClient.ts
@@ -9,6 +9,7 @@ import type { AIMode } from "@/types/generated/AIMode";
 
 export class AgentClientService {
 	private apiTransport = new ApiTransport();
+	private lastWorkspaceRoot: string | null = null;
 
 	constructor() {
 		this.setupListeners();
@@ -69,11 +70,23 @@ export class AgentClientService {
 	): Promise<() => void> {
 		const state = useStore.getState();
 		const requestId = createRequestId();
-		const agentSessionId = state.ai.agentSessionId || createRequestId();
+		const workspaceRoot = options.context.workspaceRoot;
+		const workspaceChanged =
+			Boolean(workspaceRoot) &&
+			Boolean(this.lastWorkspaceRoot) &&
+			workspaceRoot !== this.lastWorkspaceRoot;
 
-		if (!state.ai.agentSessionId) {
-			state.setAgentSessionId(agentSessionId);
+		if (workspaceChanged) {
+			state.setAgentSessionId(null);
 		}
+
+		const latestState = useStore.getState();
+		const agentSessionId = latestState.ai.agentSessionId || createRequestId();
+
+		if (!latestState.ai.agentSessionId) {
+			latestState.setAgentSessionId(agentSessionId);
+		}
+		this.lastWorkspaceRoot = workspaceRoot || this.lastWorkspaceRoot;
 
 		const request: AITransportRequest = {
 			id: requestId,

--- a/client/src/services/__tests__/AgentClient.test.ts
+++ b/client/src/services/__tests__/AgentClient.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useStore } from "@/core";
+import type { AITransportRequest } from "@/services/agent/transport/AITransport";
+import { AgentClientService } from "../AgentClient";
+
+const sentRequests: AITransportRequest[] = [];
+
+vi.mock("@/services/agent/transport/ApiTransport", () => {
+	class MockApiTransport {
+		onEvent() {
+			return () => {};
+		}
+
+		send(request: AITransportRequest) {
+			sentRequests.push(request);
+			return () => {};
+		}
+
+		async cancel(): Promise<void> {}
+	}
+
+	return { ApiTransport: MockApiTransport };
+});
+
+describe("AgentClientService", () => {
+	beforeEach(() => {
+		sentRequests.length = 0;
+		useStore.setState((state) => ({
+			ai: {
+				...state.ai,
+				agentSessionId: null,
+				activeRequestId: null,
+				isLoading: false,
+				messages: [],
+			},
+		}));
+	});
+
+	it("rotates ACP session id when workspace root changes", async () => {
+		const client = new AgentClientService();
+		const contextA = {
+			editorFilepath: "",
+			editorContent: "",
+			workspaceRoot: "/workspace-a",
+		};
+		const contextB = {
+			editorFilepath: "",
+			editorContent: "",
+			workspaceRoot: "/workspace-b",
+		};
+
+		await client.sendMessage("first", { mode: "agent", context: contextA });
+		const firstSessionId = sentRequests[0]?.agentSessionId;
+		expect(firstSessionId).toBeTruthy();
+		expect(useStore.getState().ai.agentSessionId).toBe(firstSessionId);
+
+		await client.sendMessage("second", { mode: "agent", context: contextA });
+		expect(sentRequests[1]?.agentSessionId).toBe(firstSessionId);
+
+		await client.sendMessage("third", { mode: "agent", context: contextB });
+		const switchedSessionId = sentRequests[2]?.agentSessionId;
+		expect(switchedSessionId).toBeTruthy();
+		expect(switchedSessionId).not.toBe(firstSessionId);
+		expect(useStore.getState().ai.agentSessionId).toBe(switchedSessionId);
+	});
+});


### PR DESCRIPTION
## Description

This PR fixes ACP workspace drift after `File > Open Folder` by resetting and rotating ACP conversation sessions when the active workspace changes.
It ensures ACP prompts run with a session created for the currently active workspace, preventing stale-directory context from previous folders.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [x] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `make lint`
- `make test-client`
- `pnpm --filter client test -- src/services/__tests__/AgentClient.test.ts`

## Screenshots (if applicable)

N/A

## Related Issues

Closes #440
