### PR TITLE
Change frontend default port to 5176

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 import { defineConfig } from "vite";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const defaultPort = 5173;
+const defaultPort = 5176;
 const envPortRaw = process.env.REPROD_E2E_WEB_PORT ?? process.env.VITE_PORT;
 const envPort = envPortRaw ? Number.parseInt(envPortRaw, 10) : Number.NaN;
 const serverPort = Number.isFinite(envPort) && envPort > 0 ? envPort : defaultPort;

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -5,7 +5,7 @@
 	"identifier": "com.reprod.app",
 	"build": {
 		"beforeDevCommand": "pnpm --dir .. --filter client dev",
-		"devUrl": "http://localhost:5173",
+		"devUrl": "http://localhost:5176",
 		"beforeBuildCommand": "pnpm --dir .. --filter ./client build",
 		"frontendDist": "../client/dist"
 	},


### PR DESCRIPTION
## Summary
- Update Vite dev server default port from 5173 to 5176 in `client/vite.config.ts`
- Environment variable overrides (`VITE_PORT`, `REPROD_E2E_WEB_PORT`) still take precedence when set

## Test plan
- [x] Run `npm run dev` in `client/` and confirm it starts on port 5176
- [x] Verify `VITE_PORT=3000 npm run dev` still overrides to port 3000