### PR TITLE
refactor: split ai_handler.rs into context_builder and approval_rules (#473)

### DIFF
--- a/server/src/handlers/acp_handler.rs
+++ b/server/src/handlers/acp_handler.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use super::ai_handler::build_context_prompt;
+use super::context_builder::build_context_prompt;
 use reprod_core::ai::extract_code_blocks;
 
 use super::common::{

--- a/server/src/handlers/ai_handler.rs
+++ b/server/src/handlers/ai_handler.rs
@@ -19,90 +19,13 @@ use tokio::time::{timeout, Duration};
 use super::common::{
     build_approval_request_payload, build_streaming_payload, error_response, now_millis,
     tool_log_from_call, with_system_prompts, AIMode, AgentEventPayload, AgentEventStatus, AppState,
-    ApprovalDecisionPayload, ApprovalOption, ApprovalRule, ArtifactDetailsPayload, ArtifactKind,
+    ApprovalDecisionPayload, ApprovalOption, ArtifactDetailsPayload, ArtifactKind,
     PendingEditPayload, PlanStepKind, PlanStepPayload, PlanStepStatus, ToolLogStatus,
     ToolPreviewPayload, WSResponse,
 };
+use super::approval_rules::{build_approval_rule, normalize_relative_path, tool_requires_approval};
+use super::context_builder::build_context_prompt;
 use super::tool_handler::execute_ai_tool_call;
-
-pub(super) async fn build_context_prompt(
-    runtime: &Arc<ProjectRuntime>,
-    context: reprod_core::acp::types::AcpContextRequest,
-) -> Result<String, anyhow::Error> {
-    let mut parts = Vec::new();
-
-    // 1. Console Context
-    if let Some(limit) = context.console_history_limit {
-        if limit > 0 {
-            let runs = runtime
-                .execution_repo
-                .latest_runs(limit)
-                .await
-                .unwrap_or_default();
-
-            if !runs.is_empty() {
-                let mut console_text =
-                    String::from("Recent console output (newest first, truncated):\n");
-                for run in runs {
-                    let status = format!("{:?}", run.status).to_lowercase();
-                    let duration = run.duration_ms.unwrap_or(0);
-                    console_text.push_str(&format!(
-                        "- [{}] {} in {}ms\n",
-                        run.created_at_ms, status, duration
-                    ));
-                    if !run.result.output.is_empty() {
-                        let trimmed = run
-                            .result
-                            .output
-                            .lines()
-                            .take(20)
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        let truncated = if trimmed.len() > 800 {
-                            &trimmed[..800]
-                        } else {
-                            &trimmed
-                        };
-                        console_text.push_str(&format!("stdout: {}\n", truncated));
-                    }
-                    if let Some(err) = &run.result.error {
-                        let trimmed = err.lines().take(20).collect::<Vec<_>>().join("\n");
-                        let truncated = if trimmed.len() > 800 {
-                            &trimmed[..800]
-                        } else {
-                            &trimmed
-                        };
-                        console_text.push_str(&format!("stderr: {}\n", truncated));
-                    }
-                    console_text.push('\n');
-                }
-                parts.push(console_text);
-            }
-        }
-    }
-
-    // 2. File Context
-    if let Some(path) = context.active_buffer_path {
-        if !path.is_empty() {
-            match runtime.edit_service.read_text_file(&path).await {
-                Ok(result) => {
-                    parts.push(format!(
-                        "Current file ({}):\n\n```r\n{}\n```\n",
-                        path, result.text
-                    ));
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to read context file {}: {}", path, e);
-                }
-            }
-        }
-    }
-
-    // 3. User Input
-    parts.push(context.user_input);
-
-    Ok(parts.join("\n"))
-}
 
 type ResponseSender = Option<UnboundedSender<WSResponse>>;
 
@@ -150,10 +73,6 @@ impl EventStream {
             },
         );
     }
-}
-
-fn tool_requires_approval(name: &str) -> bool {
-    matches!(name, "apply_pending_edit")
 }
 
 fn push_cancel_response(
@@ -326,41 +245,6 @@ fn mark_plan_finished(
         return true;
     }
     false
-}
-
-fn normalize_relative_path(path: &str) -> Option<String> {
-    use std::path::Component;
-    let mut parts = Vec::new();
-    let path = std::path::Path::new(path);
-    for component in path.components() {
-        match component {
-            Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
-            Component::CurDir => {}
-            _ => return None,
-        }
-    }
-    if parts.is_empty() {
-        return None;
-    }
-    Some(parts.join("/"))
-}
-
-fn approval_prefix_from_path(path: &str) -> Option<String> {
-    let normalized = normalize_relative_path(path)?;
-    if let Some((parent, _)) = normalized.rsplit_once('/') {
-        if !parent.is_empty() {
-            return Some(parent.to_string());
-        }
-    }
-    Some(normalized)
-}
-
-fn build_approval_rule(tool: &str, path: Option<&str>) -> Option<ApprovalRule> {
-    let path_prefix = path.and_then(approval_prefix_from_path);
-    Some(ApprovalRule {
-        tool: tool.to_string(),
-        path_prefix,
-    })
 }
 
 fn build_diff(path: &str, old_text: &str, new_text: &str) -> String {

--- a/server/src/handlers/approval_rules.rs
+++ b/server/src/handlers/approval_rules.rs
@@ -1,0 +1,40 @@
+use super::common::ApprovalRule;
+
+pub(super) fn tool_requires_approval(name: &str) -> bool {
+    matches!(name, "apply_pending_edit")
+}
+
+pub(super) fn normalize_relative_path(path: &str) -> Option<String> {
+    use std::path::Component;
+    let mut parts = Vec::new();
+    let path = std::path::Path::new(path);
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    if parts.is_empty() {
+        return None;
+    }
+    Some(parts.join("/"))
+}
+
+fn approval_prefix_from_path(path: &str) -> Option<String> {
+    let normalized = normalize_relative_path(path)?;
+    if let Some((parent, _)) = normalized.rsplit_once('/') {
+        if !parent.is_empty() {
+            return Some(parent.to_string());
+        }
+    }
+    Some(normalized)
+}
+
+pub(super) fn build_approval_rule(tool: &str, path: Option<&str>) -> Option<ApprovalRule> {
+    let path_prefix = path.and_then(approval_prefix_from_path);
+    Some(ApprovalRule {
+        tool: tool.to_string(),
+        path_prefix,
+    })
+}

--- a/server/src/handlers/context_builder.rs
+++ b/server/src/handlers/context_builder.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+
+use crate::projects::ProjectRuntime;
+
+pub(super) async fn build_context_prompt(
+    runtime: &Arc<ProjectRuntime>,
+    context: reprod_core::acp::types::AcpContextRequest,
+) -> Result<String, anyhow::Error> {
+    let mut parts = Vec::new();
+
+    // 1. Console Context
+    if let Some(limit) = context.console_history_limit {
+        if limit > 0 {
+            let runs = runtime
+                .execution_repo
+                .latest_runs(limit)
+                .await
+                .unwrap_or_default();
+
+            if !runs.is_empty() {
+                let mut console_text =
+                    String::from("Recent console output (newest first, truncated):\n");
+                for run in runs {
+                    let status = format!("{:?}", run.status).to_lowercase();
+                    let duration = run.duration_ms.unwrap_or(0);
+                    console_text.push_str(&format!(
+                        "- [{}] {} in {}ms\n",
+                        run.created_at_ms, status, duration
+                    ));
+                    if !run.result.output.is_empty() {
+                        let trimmed = run
+                            .result
+                            .output
+                            .lines()
+                            .take(20)
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        let truncated = if trimmed.len() > 800 {
+                            &trimmed[..800]
+                        } else {
+                            &trimmed
+                        };
+                        console_text.push_str(&format!("stdout: {}\n", truncated));
+                    }
+                    if let Some(err) = &run.result.error {
+                        let trimmed = err.lines().take(20).collect::<Vec<_>>().join("\n");
+                        let truncated = if trimmed.len() > 800 {
+                            &trimmed[..800]
+                        } else {
+                            &trimmed
+                        };
+                        console_text.push_str(&format!("stderr: {}\n", truncated));
+                    }
+                    console_text.push('\n');
+                }
+                parts.push(console_text);
+            }
+        }
+    }
+
+    // 2. File Context
+    if let Some(path) = context.active_buffer_path {
+        if !path.is_empty() {
+            match runtime.edit_service.read_text_file(&path).await {
+                Ok(result) => {
+                    parts.push(format!(
+                        "Current file ({}):\n\n```r\n{}\n```\n",
+                        path, result.text
+                    ));
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to read context file {}: {}", path, e);
+                }
+            }
+        }
+    }
+
+    // 3. User Input
+    parts.push(context.user_input);
+
+    Ok(parts.join("\n"))
+}

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -23,7 +23,9 @@ use uuid::Uuid;
 
 mod acp_handler;
 mod ai_handler;
+mod approval_rules;
 pub(crate) mod common;
+mod context_builder;
 mod environment_handler;
 mod export_handler;
 mod pending_edit_ui;


### PR DESCRIPTION
## Description

Split the 1,279-line `ai_handler.rs` into focused, smaller modules to improve LLM-readability and maintainability. Extracted two cohesive groups of functions into their own files.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

### For ALL PRs to `develop`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (`pnpm test`)
- [x] New tests added for new features/bug fixes
- [x] Documentation updated (if needed)

### For PRs from `develop` → `main` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
  ```bash
  pnpm tauri build --debug
  pnpm --filter @reprod/e2e test
  ```
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- `cargo check` passes with zero errors
- `cargo build` succeeds cleanly
- Pre-push: Biome, Rust fmt, clippy, TS lint all passed

## Screenshots (if applicable)

N/A

## Related Issues

Closes #473

## Changes

- `server/src/handlers/context_builder.rs` (new, 82 lines): `build_context_prompt`
- `server/src/handlers/approval_rules.rs` (new, 40 lines): `tool_requires_approval`, `normalize_relative_path`, `approval_prefix_from_path`, `build_approval_rule`
- `server/src/handlers/ai_handler.rs`: removed extracted functions, added imports (1,279 → 1,163 lines)
- `server/src/handlers/acp_handler.rs`: updated import path for `build_context_prompt`
- `server/src/handlers/mod.rs`: registered two new submodules