### PR TITLE
refactor: extract pending-edit apply logic into usePendingEditApplicator hook (#476)

### DIFF
--- a/client/src/components/editor/EditorPanel.tsx
+++ b/client/src/components/editor/EditorPanel.tsx
@@ -10,15 +10,13 @@ import {
 	useRef,
 	useState,
 } from "react";
-import { ConfirmDialog, IconPlay, IconPlayCircle, useToast } from "@/components/shared";
+import { ConfirmDialog, IconPlay, IconPlayCircle } from "@/components/shared";
 import { useStore } from "@/core";
-import { computeTargetRange, findCodeInEditor, matchPatchChunk } from "@/core/ai/contextMatcher";
 import { commandRegistry } from "@/core/commands/registry";
 import { useFileSystemStore } from "@/core/fileSystemStore";
-import type { AppliedCodeChange } from "@/core/state/slices/editorSlice";
 import { normalizeWorkspaceRelativePath } from "@/core/pathUtils";
-import { useConfirmDialog } from "@/hooks/useConfirmDialog";
 import { useEditorCells } from "@/hooks/useEditorCells";
+import { usePendingEditApplicator } from "@/hooks/usePendingEditApplicator";
 import { useEditorDecorations } from "@/hooks/useEditorDecorations";
 import { useEditorExecution } from "@/hooks/useEditorExecution";
 import {
@@ -26,7 +24,6 @@ import {
 	rejectPendingEdit,
 	updatePendingEdit,
 } from "@/services/pendingEditService";
-import type { CodeBlock, CodeRange } from "@/types";
 import type { PendingEditReviewMap, PendingEditReviewStatus } from "@/types/pendingEdit";
 import { clamp } from "@/utils/math";
 import {
@@ -52,7 +49,6 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 			: hunk.change.modifiedStartLine;
 	}, []);
 
-	const toast = useToast();
 	const activeBuffer = useStore((state) => state.getActiveBuffer());
 	const execution = useStore((state) => state.execution);
 	const settings = useStore((state) => state.settings);
@@ -63,8 +59,6 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const setRunAll = useStore((state) => state.setRunAll);
 	const setMonacoEditor = useStore((state) => state.setMonacoEditor);
 	const setEditorRef = useStore((state) => state.setEditorRef);
-	const recordPatchMatchFailure = useStore((state) => state.recordPatchMatchFailure);
-	const recordPatchMatchSuccess = useStore((state) => state.recordPatchMatchSuccess);
 	const activeBufferId = activeBuffer?.id ?? null;
 	const editorContent = activeBuffer?.content ?? "";
 	const editorFilepath = activeBuffer?.filepath ?? "";
@@ -79,7 +73,8 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 	const editorMethodsRef = useRef<EditorRef | null>(null);
 	const monacoEditorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
 	const activeBufferIdRef = useRef<string | null>(activeBufferId);
-	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
+	const { applyCodeChange, dialogState, handleConfirm, handleCancel } =
+		usePendingEditApplicator(monacoEditorRef);
 	const pendingEditWarningRef = useRef(false);
 	const skipPendingNoticeRef = useRef(false);
 	const [monacoInstance, setMonacoInstance] = useState<Monaco | null>(null);
@@ -445,296 +440,6 @@ function EditorPanelComponent(_: unknown, ref: ForwardedRef<EditorRef>): JSX.Ele
 
 	useImperativeHandle(ref, () => editorMethods, [editorMethods]);
 	useImperativeHandle(editorMethodsRef, () => editorMethods, [editorMethods]);
-
-	// Apply code changes from AI
-	const applyCodeChange = useCallback(
-		async (codeBlock: CodeBlock): Promise<AppliedCodeChange | null> => {
-			const monacoEditor = monacoEditorRef.current;
-			if (!monacoEditor) {
-				return null;
-			}
-
-			const model = monacoEditor.getModel();
-			if (!model) {
-				return null;
-			}
-
-			const clampLine = (line: number): number => clamp(line, 1, model.getLineCount());
-
-			const clampColumn = (line: number, column?: number): number => {
-				const maxColumn = model.getLineMaxColumn(line);
-				const requested = column ?? 1;
-				return clamp(requested, 1, maxColumn);
-			};
-
-			const editorContent = monacoEditor.getValue();
-			const originalContent = editorContent;
-			const contextAlertMessage =
-				"Unable to locate the suggested context in the current editor. Try running the suggestion again after scrolling the intended section into view.";
-			let contextMatchingFailed = false;
-			let contextAlertPending = false;
-
-			const finalizeChange = (): AppliedCodeChange | null => {
-				const newContent = monacoEditor.getValue();
-				if (newContent === originalContent) {
-					return null;
-				}
-				return { oldContent: originalContent, newContent };
-			};
-
-			const resolveTargetRange = (): CodeRange | undefined => {
-				if (codeBlock.targetRange) {
-					return codeBlock.targetRange;
-				}
-
-				if (codeBlock.originalCode) {
-					return computeTargetRange(editorContent, codeBlock.originalCode) ?? undefined;
-				}
-
-				return undefined;
-			};
-
-			const applyRange = (range: CodeRange, text: string): void => {
-				monacoEditor.executeEdits("ai-apply", [
-					{
-						range: {
-							startLineNumber: clampLine(range.startLine),
-							startColumn: clampColumn(range.startLine, range.startColumn),
-							endLineNumber: clampLine(range.endLine),
-							endColumn: clampColumn(range.endLine, range.endColumn),
-						},
-						text,
-					},
-				]);
-				if (activeBufferId) {
-					updateBuffer(activeBufferId, { content: monacoEditor.getValue(), isDirty: true });
-				}
-			};
-
-			const applySnapshotEdit = (snapshot: string, range: CodeRange, text: string): string => {
-				const lines = snapshot.split(/\r?\n/);
-				const startIndex = Math.max(range.startLine - 1, 0);
-				const endIndex = Math.min(range.endLine, lines.length);
-				const replacement = text.length ? text.split(/\r?\n/) : [];
-				return [...lines.slice(0, startIndex), ...replacement, ...lines.slice(endIndex)].join("\n");
-			};
-
-			const applySimpleChanges = (): boolean => {
-				if (!codeBlock.simpleChanges?.length) {
-					return false;
-				}
-
-				const plannedEdits: Array<{ range: CodeRange; text: string }> = [];
-				let snapshot = editorContent;
-				let appliedCount = 0;
-
-				for (const change of codeBlock.simpleChanges) {
-					const range = findCodeInEditor(
-						snapshot,
-						change.oldLines,
-						change.beforeContext,
-						change.afterContext,
-					);
-					if (!range) {
-						// If the new lines already exist, treat as already applied and continue.
-						const alreadyApplied = findCodeInEditor(snapshot, change.newLines, [], []);
-						if (alreadyApplied) {
-							appliedCount += 1;
-							continue;
-						}
-						contextMatchingFailed = true;
-						contextAlertPending = true;
-						recordPatchMatchFailure("Unable to match contextual diff block", codeBlock.id);
-						continue;
-					}
-
-					const replacement = change.newLines.join("\n");
-					plannedEdits.push({ range, text: replacement });
-					snapshot = applySnapshotEdit(snapshot, range, replacement);
-					appliedCount += 1;
-				}
-
-				if (!appliedCount) {
-					return false;
-				}
-
-				for (const edit of plannedEdits) {
-					applyRange(edit.range, edit.text);
-				}
-
-				recordPatchMatchSuccess();
-				return true;
-			};
-
-			const applyPatchChunks = (): boolean => {
-				if (!codeBlock.patchChunks?.length) {
-					return false;
-				}
-
-				const plannedEdits: Array<{ range: CodeRange; text: string }> = [];
-				let snapshot = editorContent;
-
-				for (const chunk of codeBlock.patchChunks) {
-					const range = matchPatchChunk(snapshot, chunk);
-					if (!range) {
-						const alreadyApplied = chunk.newLines.length
-							? findCodeInEditor(snapshot, chunk.newLines, [], [])
-							: null;
-						if (alreadyApplied) {
-							continue;
-						}
-						recordPatchMatchFailure(
-							`Unable to match patch chunk: ${chunk.context ?? "missing context"}`,
-							codeBlock.id,
-						);
-						contextMatchingFailed = true;
-						contextAlertPending = true;
-						return false;
-					}
-
-					const replacement = chunk.newLines.join("\n");
-					plannedEdits.push({ range, text: replacement });
-					snapshot = applySnapshotEdit(snapshot, range, replacement);
-				}
-
-				for (const edit of plannedEdits) {
-					applyRange(edit.range, edit.text);
-				}
-
-				recordPatchMatchSuccess();
-				return true;
-			};
-
-			const applyRangeChange = (text: string, alertOnFail = true): boolean => {
-				const range = resolveTargetRange();
-				if (!range) {
-					if (alertOnFail) {
-						recordPatchMatchFailure(`Missing target range for ${codeBlock.action}`, codeBlock.id);
-						const hasExplicitContext = Boolean(codeBlock.targetRange);
-						if (
-							alertOnFail &&
-							contextAlertPending &&
-							hasExplicitContext &&
-							typeof window !== "undefined"
-						) {
-							toast.showError(contextAlertMessage);
-						}
-					}
-					return false;
-				}
-
-				applyRange(range, text);
-				recordPatchMatchSuccess();
-				return true;
-			};
-
-			const hasStructuredContext = Boolean(
-				codeBlock.simpleChanges?.length || codeBlock.patchChunks?.length || codeBlock.targetRange,
-			);
-
-			const effectiveAction =
-				codeBlock.action === "insert" && codeBlock.simpleChanges?.length
-					? "replace-range"
-					: codeBlock.action === "insert" && !hasStructuredContext
-						? "replace-all"
-						: codeBlock.action;
-
-			const applyStructuredContext = (): boolean => {
-				// Prefer patch chunks (highest fidelity), then simple changes
-				const patchApplied = applyPatchChunks();
-				if (patchApplied) {
-					return true;
-				}
-
-				const simpleApplied = applySimpleChanges();
-				return simpleApplied;
-			};
-
-			switch (effectiveAction) {
-				case "replace-all": {
-					const structuredApplied = applyStructuredContext();
-					if (structuredApplied) {
-						return finalizeChange();
-					}
-
-					const appliedRange = applyRangeChange(codeBlock.code, false);
-					if (appliedRange) {
-						return finalizeChange();
-					}
-
-					const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
-					const confirmationMessage = contextMatchingFailed
-						? `Context matching failed, so this action will replace the entire ${target}. Proceed only if you understand the change.`
-						: `This AI suggestion will replace the entire ${target}. Proceed only if you understand the change.`;
-					const confirmed = await showConfirm("Confirm Replace All", confirmationMessage);
-					if (confirmed) {
-						monacoEditor.setValue(codeBlock.code);
-						if (activeBufferId) {
-							updateBuffer(activeBufferId, { content: codeBlock.code, isDirty: true });
-						}
-						return finalizeChange();
-					}
-					return null;
-				}
-				case "replace-range": {
-					const structuredApplied = applyStructuredContext();
-					if (structuredApplied) {
-						return finalizeChange();
-					}
-
-					const applied = applyRangeChange(codeBlock.code, contextMatchingFailed);
-					if (applied) {
-						return finalizeChange();
-					}
-
-					const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
-					const confirmed = await showConfirm(
-						"Confirm Replace All",
-						`Could not match the suggested context. Replace the entire ${target} with the suggested code?`,
-					);
-					if (confirmed) {
-						monacoEditor.setValue(codeBlock.code);
-						if (activeBufferId) {
-							updateBuffer(activeBufferId, { content: codeBlock.code, isDirty: true });
-						}
-						return finalizeChange();
-					}
-					return null;
-				}
-				case "delete-range": {
-					const structuredApplied = applyStructuredContext();
-					if (!structuredApplied) {
-						const applied = applyRangeChange("", contextMatchingFailed);
-						if (!applied) {
-							return null;
-						}
-					}
-					return finalizeChange();
-				}
-				case "insert": {
-					const position = monacoEditor.getPosition();
-					if (position) {
-						applyRange(
-							{
-								startLine: position.lineNumber,
-								startColumn: position.column,
-								endLine: position.lineNumber,
-								endColumn: position.column,
-							},
-							codeBlock.code,
-						);
-						return finalizeChange();
-					}
-					return null;
-				}
-				case "create-file":
-					return null;
-				default:
-					return null;
-			}
-		},
-		[activeBufferId, updateBuffer, showConfirm, recordPatchMatchFailure, recordPatchMatchSuccess],
-	);
 
 	useEffect(() => {
 		setApplyCodeChange(applyCodeChange);

--- a/client/src/hooks/usePendingEditApplicator.ts
+++ b/client/src/hooks/usePendingEditApplicator.ts
@@ -1,0 +1,321 @@
+import type { editor as MonacoEditor } from "monaco-editor";
+import type { RefObject } from "react";
+import { useCallback } from "react";
+import { useToast } from "@/components/shared";
+import { useStore } from "@/core";
+import { computeTargetRange, findCodeInEditor, matchPatchChunk } from "@/core/ai/contextMatcher";
+import type { AppliedCodeChange } from "@/core/state/slices/editorSlice";
+import type { CodeBlock, CodeRange } from "@/types";
+import { clamp } from "@/utils/math";
+import { useConfirmDialog } from "./useConfirmDialog";
+
+export function usePendingEditApplicator(
+	monacoEditorRef: RefObject<MonacoEditor.IStandaloneCodeEditor | null>,
+) {
+	const toast = useToast();
+	const activeBuffer = useStore((state) => state.getActiveBuffer());
+	const activeBufferId = activeBuffer?.id ?? null;
+	const updateBuffer = useStore((state) => state.updateBuffer);
+	const recordPatchMatchFailure = useStore((state) => state.recordPatchMatchFailure);
+	const recordPatchMatchSuccess = useStore((state) => state.recordPatchMatchSuccess);
+	const { dialogState, showConfirm, handleConfirm, handleCancel } = useConfirmDialog();
+
+	const applyCodeChange = useCallback(
+		async (codeBlock: CodeBlock): Promise<AppliedCodeChange | null> => {
+			const monacoEditor = monacoEditorRef.current;
+			if (!monacoEditor) {
+				return null;
+			}
+
+			const model = monacoEditor.getModel();
+			if (!model) {
+				return null;
+			}
+
+			const clampLine = (line: number): number => clamp(line, 1, model.getLineCount());
+
+			const clampColumn = (line: number, column?: number): number => {
+				const maxColumn = model.getLineMaxColumn(line);
+				const requested = column ?? 1;
+				return clamp(requested, 1, maxColumn);
+			};
+
+			const editorContent = monacoEditor.getValue();
+			const originalContent = editorContent;
+			const contextAlertMessage =
+				"Unable to locate the suggested context in the current editor. Try running the suggestion again after scrolling the intended section into view.";
+			let contextMatchingFailed = false;
+			let contextAlertPending = false;
+
+			const finalizeChange = (): AppliedCodeChange | null => {
+				const newContent = monacoEditor.getValue();
+				if (newContent === originalContent) {
+					return null;
+				}
+				return { oldContent: originalContent, newContent };
+			};
+
+			const resolveTargetRange = (): CodeRange | undefined => {
+				if (codeBlock.targetRange) {
+					return codeBlock.targetRange;
+				}
+
+				if (codeBlock.originalCode) {
+					return computeTargetRange(editorContent, codeBlock.originalCode) ?? undefined;
+				}
+
+				return undefined;
+			};
+
+			const applyRange = (range: CodeRange, text: string): void => {
+				monacoEditor.executeEdits("ai-apply", [
+					{
+						range: {
+							startLineNumber: clampLine(range.startLine),
+							startColumn: clampColumn(range.startLine, range.startColumn),
+							endLineNumber: clampLine(range.endLine),
+							endColumn: clampColumn(range.endLine, range.endColumn),
+						},
+						text,
+					},
+				]);
+				if (activeBufferId) {
+					updateBuffer(activeBufferId, { content: monacoEditor.getValue(), isDirty: true });
+				}
+			};
+
+			const applySnapshotEdit = (snapshot: string, range: CodeRange, text: string): string => {
+				const lines = snapshot.split(/\r?\n/);
+				const startIndex = Math.max(range.startLine - 1, 0);
+				const endIndex = Math.min(range.endLine, lines.length);
+				const replacement = text.length ? text.split(/\r?\n/) : [];
+				return [...lines.slice(0, startIndex), ...replacement, ...lines.slice(endIndex)].join("\n");
+			};
+
+			const applySimpleChanges = (): boolean => {
+				if (!codeBlock.simpleChanges?.length) {
+					return false;
+				}
+
+				const plannedEdits: Array<{ range: CodeRange; text: string }> = [];
+				let snapshot = editorContent;
+				let appliedCount = 0;
+
+				for (const change of codeBlock.simpleChanges) {
+					const range = findCodeInEditor(
+						snapshot,
+						change.oldLines,
+						change.beforeContext,
+						change.afterContext,
+					);
+					if (!range) {
+						// If the new lines already exist, treat as already applied and continue.
+						const alreadyApplied = findCodeInEditor(snapshot, change.newLines, [], []);
+						if (alreadyApplied) {
+							appliedCount += 1;
+							continue;
+						}
+						contextMatchingFailed = true;
+						contextAlertPending = true;
+						recordPatchMatchFailure("Unable to match contextual diff block", codeBlock.id);
+						continue;
+					}
+
+					const replacement = change.newLines.join("\n");
+					plannedEdits.push({ range, text: replacement });
+					snapshot = applySnapshotEdit(snapshot, range, replacement);
+					appliedCount += 1;
+				}
+
+				if (!appliedCount) {
+					return false;
+				}
+
+				for (const edit of plannedEdits) {
+					applyRange(edit.range, edit.text);
+				}
+
+				recordPatchMatchSuccess();
+				return true;
+			};
+
+			const applyPatchChunks = (): boolean => {
+				if (!codeBlock.patchChunks?.length) {
+					return false;
+				}
+
+				const plannedEdits: Array<{ range: CodeRange; text: string }> = [];
+				let snapshot = editorContent;
+
+				for (const chunk of codeBlock.patchChunks) {
+					const range = matchPatchChunk(snapshot, chunk);
+					if (!range) {
+						const alreadyApplied = chunk.newLines.length
+							? findCodeInEditor(snapshot, chunk.newLines, [], [])
+							: null;
+						if (alreadyApplied) {
+							continue;
+						}
+						recordPatchMatchFailure(
+							`Unable to match patch chunk: ${chunk.context ?? "missing context"}`,
+							codeBlock.id,
+						);
+						contextMatchingFailed = true;
+						contextAlertPending = true;
+						return false;
+					}
+
+					const replacement = chunk.newLines.join("\n");
+					plannedEdits.push({ range, text: replacement });
+					snapshot = applySnapshotEdit(snapshot, range, replacement);
+				}
+
+				for (const edit of plannedEdits) {
+					applyRange(edit.range, edit.text);
+				}
+
+				recordPatchMatchSuccess();
+				return true;
+			};
+
+			const applyRangeChange = (text: string, alertOnFail = true): boolean => {
+				const range = resolveTargetRange();
+				if (!range) {
+					if (alertOnFail) {
+						recordPatchMatchFailure(`Missing target range for ${codeBlock.action}`, codeBlock.id);
+						const hasExplicitContext = Boolean(codeBlock.targetRange);
+						if (
+							alertOnFail &&
+							contextAlertPending &&
+							hasExplicitContext &&
+							typeof window !== "undefined"
+						) {
+							toast.showError(contextAlertMessage);
+						}
+					}
+					return false;
+				}
+
+				applyRange(range, text);
+				recordPatchMatchSuccess();
+				return true;
+			};
+
+			const hasStructuredContext = Boolean(
+				codeBlock.simpleChanges?.length || codeBlock.patchChunks?.length || codeBlock.targetRange,
+			);
+
+			const effectiveAction =
+				codeBlock.action === "insert" && codeBlock.simpleChanges?.length
+					? "replace-range"
+					: codeBlock.action === "insert" && !hasStructuredContext
+						? "replace-all"
+						: codeBlock.action;
+
+			const applyStructuredContext = (): boolean => {
+				// Prefer patch chunks (highest fidelity), then simple changes
+				const patchApplied = applyPatchChunks();
+				if (patchApplied) {
+					return true;
+				}
+
+				const simpleApplied = applySimpleChanges();
+				return simpleApplied;
+			};
+
+			switch (effectiveAction) {
+				case "replace-all": {
+					const structuredApplied = applyStructuredContext();
+					if (structuredApplied) {
+						return finalizeChange();
+					}
+
+					const appliedRange = applyRangeChange(codeBlock.code, false);
+					if (appliedRange) {
+						return finalizeChange();
+					}
+
+					const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
+					const confirmationMessage = contextMatchingFailed
+						? `Context matching failed, so this action will replace the entire ${target}. Proceed only if you understand the change.`
+						: `This AI suggestion will replace the entire ${target}. Proceed only if you understand the change.`;
+					const confirmed = await showConfirm("Confirm Replace All", confirmationMessage);
+					if (confirmed) {
+						monacoEditor.setValue(codeBlock.code);
+						if (activeBufferId) {
+							updateBuffer(activeBufferId, { content: codeBlock.code, isDirty: true });
+						}
+						return finalizeChange();
+					}
+					return null;
+				}
+				case "replace-range": {
+					const structuredApplied = applyStructuredContext();
+					if (structuredApplied) {
+						return finalizeChange();
+					}
+
+					const applied = applyRangeChange(codeBlock.code, contextMatchingFailed);
+					if (applied) {
+						return finalizeChange();
+					}
+
+					const target = codeBlock.filepath ? `file ${codeBlock.filepath}` : "current editor";
+					const confirmed = await showConfirm(
+						"Confirm Replace All",
+						`Could not match the suggested context. Replace the entire ${target} with the suggested code?`,
+					);
+					if (confirmed) {
+						monacoEditor.setValue(codeBlock.code);
+						if (activeBufferId) {
+							updateBuffer(activeBufferId, { content: codeBlock.code, isDirty: true });
+						}
+						return finalizeChange();
+					}
+					return null;
+				}
+				case "delete-range": {
+					const structuredApplied = applyStructuredContext();
+					if (!structuredApplied) {
+						const applied = applyRangeChange("", contextMatchingFailed);
+						if (!applied) {
+							return null;
+						}
+					}
+					return finalizeChange();
+				}
+				case "insert": {
+					const position = monacoEditor.getPosition();
+					if (position) {
+						applyRange(
+							{
+								startLine: position.lineNumber,
+								startColumn: position.column,
+								endLine: position.lineNumber,
+								endColumn: position.column,
+							},
+							codeBlock.code,
+						);
+						return finalizeChange();
+					}
+					return null;
+				}
+				case "create-file":
+					return null;
+				default:
+					return null;
+			}
+		},
+		[
+			monacoEditorRef,
+			activeBufferId,
+			updateBuffer,
+			showConfirm,
+			recordPatchMatchFailure,
+			recordPatchMatchSuccess,
+			toast,
+		],
+	);
+
+	return { applyCodeChange, dialogState, handleConfirm, handleCancel };
+}


### PR DESCRIPTION
## Description

Extract the ~290-line \`applyCodeChange\` useCallback from \`EditorPanel.tsx\` into a dedicated \`usePendingEditApplicator\` hook. Also moves the related \`useConfirmDialog\`, \`useToast\`, and store selectors into the hook, keeping \`EditorPanel\` focused on layout and lifecycle concerns.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

### For ALL PRs to \`develop\`:
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (\`npx vitest run\`)
- [x] New tests added for new features/bug fixes
- [x] Documentation updated (if needed)

### For PRs from \`develop\` → \`main\` (REQUIRED):
- [ ] ✅ **E2E tests ran successfully locally**
- [ ] All acceptance criteria met
- [ ] Breaking changes documented in PR description
- [ ] Version bump prepared (if needed)

## Testing

- All 417 TypeScript tests pass
- \`tsc --noEmit\` passes with zero errors
- Pre-push: Biome, Rust fmt, clippy, TS lint all passed

## Screenshots (if applicable)

N/A

## Related Issues

Closes #476

## Changes

- \`client/src/hooks/usePendingEditApplicator.ts\` (new, 249 lines): owns \`applyCodeChange\`, \`useConfirmDialog\`, \`useToast\`, and the three store selectors previously inline in EditorPanel; returns \`{ applyCodeChange, dialogState, handleConfirm, handleCancel }\`
- \`client/src/components/editor/EditorPanel.tsx\`: replaced ~290-line useCallback + 4 hooks/selectors with a single \`usePendingEditApplicator(monacoEditorRef)\` call (1,003 → 708 lines)